### PR TITLE
LPS-21064

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -468,7 +468,7 @@ else if (dlFileEntryType != null) {
 			document.<portlet:namespace />fm.<portlet:namespace />workflowAction.value = "<%= WorkflowConstants.ACTION_SAVE_DRAFT %>";
 		}
 
-		document.<portlet:namespace />fm.<portlet:namespace /><%= Constants.CMD %>.value = "<%= (fileEntry == null) ? Constants.ADD : Constants.UPDATE %>";
+		document.<portlet:namespace />fm.<portlet:namespace /><%= Constants.CMD %>.value = "<%= (fileEntry == null || cmd.equals(Constants.ADD)) ? Constants.ADD : Constants.UPDATE %>";
 		submitForm(document.<portlet:namespace />fm);
 	}
 


### PR DESCRIPTION
fileEntry is not null after request fails with error message which force cmd to have "update" where it should be still "add". 
