### PR TITLE
LPS-21064

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
@@ -82,24 +82,13 @@ public class ActionUtil {
 	public static void getFileEntry(HttpServletRequest request)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		long fileEntryId = ParamUtil.getLong(request, "fileEntryId");
-
-		long groupId = themeDisplay.getScopeGroupId();
-		long folderId = ParamUtil.getLong(request, "folderId");
-		String title = ParamUtil.getString(request, "title");
 
 		FileEntry fileEntry = null;
 
 		try {
 			if (fileEntryId > 0) {
 				fileEntry = DLAppServiceUtil.getFileEntry(fileEntryId);
-			}
-			else if (Validator.isNotNull(title)) {
-				fileEntry = DLAppServiceUtil.getFileEntry(
-					groupId, folderId, title);
 			}
 
 			request.setAttribute(


### PR DESCRIPTION
Commits in LPS-13160 caused regression bug: LPS-21064.
documentlibrary.action.ActionUtil.getFileEntry method is searching with title even when fileEntryId = 0.
When there is any error in EditFileEntryAction.process action, fileEntry in the request is still set to the data from previous render stage which causes the future actions to fail. 

Is it necessary to search document with title even though fileEntryId = 0?
