### PR TITLE
LPS-21160

### DIFF
--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -605,6 +605,17 @@ function OnUploadCompleted( errorNumber, fileUrl, fileName, customMsg )]]></repl
 					<replacevalue><![CDATA[<body bottommargin="0" topmargin="0">]]></replacevalue>
 				</replace>
 
+				<replace file="docroot/html/js/editor/fckeditor/editor/filemanager/browser/liferay/frmfolders.html">
+					<replacetoken><![CDATA[var sLink = '<a href="#" onclick="OpenFolder(\'' + folderPath + '\');return false;">' ;]]></replacetoken>
+					<replacevalue><![CDATA[var sLink = '<a href="#" onclick="OpenFolder(\'' + folderPath.replace( /&#039;/g, '\\\'') + '\');return false;">' ;]]></replacevalue>
+				</replace>
+
+				<replace file="docroot/html/js/editor/fckeditor/editor/filemanager/browser/liferay/frmresourceslist.html">
+					<replacetoken><![CDATA[path = path.replace( /'/g, '\\\'') ;]]></replacetoken>
+					<replacevalue><![CDATA[path = path.replace( /'/g, '\\\'') ;
+	path = path.replace( /&#039;/g, '\\\'') ;]]></replacevalue>
+				</replace>
+
 				<replaceregexp file="docroot/html/js/editor/fckeditor/editor/filemanager/browser/liferay/frmresourceslist.html"
 					match="(\t*)// Get the optional [^;]*?;\r?(\n).*?sFileSize \) \) ;"
 					replace="\1var sFileDesc = oNode.attributes.getNamedItem('desc').value ;\2\1var sFileUrl = oNode.attributes.getNamedItem('url').value ;\2\2\1oHtml.Append( oListManager.GetFileRowHtml( sFileDesc, sFileUrl, sFileSize ) ) ;"


### PR DESCRIPTION
Please send pull request to nate.

Here's the explanation of why this issue is caused:

folderPath variable in both frmresourceslist.html and frmfolders.html is escaped when the community/organization contains apostrophe.
(ex. If Community name is Test's test then folderPath is Test&#039;s test)

However when it actually gets displayed in html, ckeditor unescapes it and html markup looks like following:

onclick="OpenFolder('/10502 - Test's test/');return false;" href="#">10502 - Test's test

Which will break and we need to escape by adding \ in front of apostrophe.
