### PR TITLE
LPS-23495 Make URL absolute

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -26,6 +26,7 @@ if (Validator.isNotNull(cssClass)) {
 if (Validator.isNotNull(src) && themeDisplay.isThemeImagesFastLoad() && !auiImage) {
 	SpriteImage spriteImage = null;
 	String spriteFileName = null;
+	String spriteFileURL = null;
 
 	String imageFileName = StringUtil.replace(src, "common/../", "");
 
@@ -43,7 +44,13 @@ if (Validator.isNotNull(src) && themeDisplay.isThemeImagesFastLoad() && !auiImag
 				spriteFileName = StringUtil.replace(spriteFileName, ".png", ".gif");
 			}
 
-			spriteFileName = themeDisplay.getPathThemeImages().concat(spriteFileName);
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(PortalUtil.getPortalURL(request));
+			sb.append(themeDisplay.getPathThemeImages());
+			sb.append(spriteFileName);
+
+			spriteFileURL = sb.toString();
 		}
 	}
 
@@ -74,7 +81,7 @@ if (Validator.isNotNull(src) && themeDisplay.isThemeImagesFastLoad() && !auiImag
 					spriteFileName = StringUtil.replace(spriteFileName, ".png", ".gif");
 				}
 
-				spriteFileName = portlet.getStaticResourcePath().concat(spriteFileName);
+				spriteFileURL = portlet.getStaticResourcePath().concat(spriteFileName);
 			}
 		}
 	}
@@ -86,7 +93,7 @@ if (Validator.isNotNull(src) && themeDisplay.isThemeImagesFastLoad() && !auiImag
 
 		sb.append(details);
 		sb.append(" style=\"background-image: url('");
-		sb.append(spriteFileName);
+		sb.append(spriteFileURL);
 		sb.append("'); background-position: 50% -");
 		sb.append(spriteImage.getOffset());
 		sb.append("px; background-repeat: no-repeat; height: ");


### PR DESCRIPTION
There is an issue with ssl, ajax, and sprite images (background image url) causing mixed content warnings for some browsers (ie8).

ref: http://stackoverflow.com/questions/1548551/ssl-and-mixed-content-due-to-css-background-images

The solution was to turn the relative URLs which the browsers mishandle in those situations, into absolute URLs.
