### PR TITLE
LPS-25818 No longer decoded: ea391e2

### DIFF
--- a/portal-web/docroot/html/portlet/journal/edit_template_xsl.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_template_xsl.jsp
@@ -130,7 +130,7 @@ else if (langType.equals("xml") || langType.equals("xsl") || langType.equals("xs
 		var content = getEditorContent(editorType);
 
 		if (editorContentOutputElement) {
-			editorContentOutputElement.val(encodeURIComponent(content));
+			editorContentOutputElement.val(content);
 
 			var dialog = Liferay.Util.getWindow();
 


### PR DESCRIPTION
I don't know if the initial implementation (LPS-25642) is correct but because of it.. it tries to SAXReaderUtil.read(xsd) where xsd is encoded which throws an xsd exception.
