### PR TITLE
LPS-26484 Maximum failures on account lockout doesn't work properly

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5114,7 +5114,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 					int failedLoginAttempts = user.getFailedLoginAttempts();
 					int maxFailures = passwordPolicy.getMaxFailure();
 
-					if ((failedLoginAttempts >= maxFailures) &&
+					if (((failedLoginAttempts + 1) >= maxFailures) &&
 						(maxFailures != 0)) {
 
 						if (authType.equals(CompanyConstants.AUTH_TYPE_EA)) {


### PR DESCRIPTION
failedLoginAttempts is counted from 0, 1, 2, 3... and maxFailures is counted from 1,2,3,4..

I'm adding (failedLoginAttempts + 1) to for-loop because it make sense that failedLoginAttempts to be counted from 0 but in comparision with maxFailures we should add +1.

It's also not a good idea to change default value to defaultUser.setFailedLoginAttempts(1);.
