### PR TITLE
LPS-27105 Rows in collapsed panels are being removed by visible check, c...

### DIFF
--- a/portal-web/docroot/html/js/liferay/auto_fields.js
+++ b/portal-web/docroot/html/js/liferay/auto_fields.js
@@ -235,7 +235,7 @@ AUI.add(
 					serialize: function(filter) {
 						var instance = this;
 
-						var visibleRows = instance._contentBox.all('.lfr-form-row:visible');
+						var visibleRows = instance._contentBox.all('.lfr-form-row').each(instance._clearHiddenRows, instance);
 
 						var serializedData = [];
 


### PR DESCRIPTION
...learHiddenRows instead

Reviewed by Jon Mak. On a related side note, contentBox in save is never used after clearing hidden rows. If it is used (passed in to serialize), it could be incorrect because the entire form is passed/instead of just the contentBox containing the auto fields.

In summary, it looks like the form isn't and shouldn't be used. The save function as a result would just call serialize and sets fieldIndexes with it's values.

``` javascript
save: function(form) {
    var instance = this;

    var contentBox = form || instance._contentBox;

    contentBox.all('.lfr-form-row').each(instance._clearHiddenRows, instance);

    var fieldOrder = instance.serialize();

    instance._fieldIndexes.val(fieldOrder);
},
```
