### PR TITLE
LPS-27484 Organizations - When assigning organizational roles, name defaults to "Liferay"

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/ActionUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.MembershipRequest;
 import com.liferay.portal.model.PortletPreferencesIds;
 import com.liferay.portal.model.Team;
+import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.MembershipRequestLocalServiceUtil;
 import com.liferay.portal.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.service.TeamLocalServiceUtil;
@@ -127,11 +128,17 @@ public class ActionUtil
 			WebKeys.THEME_DISPLAY);
 
 		String cmd = ParamUtil.getString(request, Constants.CMD);
+		long groupId = ParamUtil.getLong(request, "groupId");
 
 		Group group = null;
 
 		if (!cmd.equals(Constants.ADD)) {
-			group = themeDisplay.getScopeGroup();
+			if (groupId > 0) {
+				group = GroupLocalServiceUtil.getGroup(groupId);
+			}
+			else {
+				group = themeDisplay.getScopeGroup();
+			}
 		}
 
 		request.setAttribute(WebKeys.GROUP, group);


### PR DESCRIPTION
Groups no longer get scoped when they shouldn't.
