### PR TITLE
LPS-27453 Shorten doesn't account for suffix, renders it useless

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -1924,8 +1924,8 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns a string representing the original string shortened to 20
-	 * characters, with suffix "..." appended to it.
+	 * Returns a string representing the original string appended with suffix "..."
+	 * and then shortened to 20 characters.
 	 *
 	 * <p>
 	 * The suffix is only added if the original string exceeds 20 characters. If
@@ -1939,7 +1939,7 @@ public class StringUtil {
 	 *
 	 * <pre>
 	 * <code>
-	 * shorten("12345678901234567890xyz") returns "12345678901234567890..."
+	 * shorten("12345678901234567890xyz") returns "12345678901234567..."
 	 * shorten("1 345678901234567890xyz") returns "1..."
 	 * shorten(" 2345678901234567890xyz") returns "..."
 	 * shorten("12345678901234567890") returns "12345678901234567890"
@@ -1956,8 +1956,8 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns a string representing the original string shortened to the
-	 * specified length, with suffix "..." appended to it.
+	 * Returns a string representing the original string appended with suffix
+	 * "..." and then shortened to the specified length.
 	 *
 	 * <p>
 	 * The suffix is only added if the original string exceeds the specified
@@ -1972,11 +1972,11 @@ public class StringUtil {
 	 *
 	 * <pre>
 	 * <code>
-	 * shorten("123456", 5) returns "12345..."
-	 * shorten("1 3456", 5) returns "1..."
-	 * shorten(" 23456", 5) returns "..."
-	 * shorten("12345", 5) returns "12345"
-	 * shorten(" 1234", 5) returns " 1234"
+	 * shorten("123456789", 8) returns "12345..."
+	 * shorten("1 3456789", 8) returns "1..."
+	 * shorten(" 23456789", 8) returns "..."
+	 * shorten("12345678", 8) returns "12345678"
+	 * shorten(" 1234567", 8) returns " 1234567"
 	 * </code>
 	 * </pre>
 	 *
@@ -1990,8 +1990,8 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns a string representing the original string shortened to the
-	 * specified length, with the specified suffix appended to it.
+	 * Returns a string representing the original string appended with the
+	 * specified suffix and then shortened to the specified length.
 	 *
 	 * <p>
 	 * The suffix is only added if the original string exceeds the specified
@@ -2006,11 +2006,11 @@ public class StringUtil {
 	 *
 	 * <pre>
 	 * <code>
-	 * shorten("123456", 5, "... etc.") returns "12345... etc."
-	 * shorten("1 3456", 5, "... etc.") returns "1... etc."
-	 * shorten(" 23456", 5, "... etc.") returns "... etc."
-	 * shorten("12345", 5, "... etc.") returns "12345"
-	 * shorten(" 1234", 5, "... etc.") returns " 1234"
+	 * shorten("12345678901234", 13, "... etc.") returns "12345... etc."
+	 * shorten("1 345678901234", 13, "... etc.") returns "1... etc."
+	 * shorten(" 2345678901234", 13, "... etc.") returns "... etc."
+	 * shorten("1234567890123", 13, "... etc.") returns "1234567890123"
+	 * shorten(" 123456789012", 13, "... etc.") returns " 123456789012"
 	 * </code>
 	 * </pre>
 	 *
@@ -2026,15 +2026,21 @@ public class StringUtil {
 		}
 
 		if (s.length() > length) {
-			for (int j = length; j >= 0; j--) {
+			int curLength = length;
+
+			for (int j = (curLength - suffix.length()); j >= 0; j--) {
 				if (Character.isWhitespace(s.charAt(j))) {
-					length = j;
+					curLength = j;
 
 					break;
 				}
 			}
 
-			String temp = s.substring(0, length);
+			if ((curLength + suffix.length()) > length) {
+				curLength = curLength - suffix.length();
+			}
+
+			String temp = s.substring(0, curLength);
 
 			s = temp.concat(suffix);
 		}
@@ -2043,8 +2049,8 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns a string representing the original string shortened to 20
-	 * characters, with the specified suffix appended to it.
+	 * Returns a string representing the original string appended with the
+	 * specified suffix and then shortened to 20 characters.
 	 *
 	 * <p>
 	 * The suffix is only added if the original string exceeds 20 characters. If
@@ -2058,7 +2064,7 @@ public class StringUtil {
 	 *
 	 * <pre>
 	 * <code>
-	 * shorten("12345678901234567890xyz", "... etc.") returns "12345678901234567890... etc."
+	 * shorten("12345678901234567890xyz", "... etc.") returns "123456789012... etc."
 	 * shorten("1 345678901234567890xyz", "... etc.") returns "1... etc."
 	 * shorten(" 2345678901234567890xyz", "... etc.") returns "... etc."
 	 * shorten("12345678901234567890", "... etc.") returns "12345678901234567890"

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -186,6 +186,50 @@ public class StringUtilTest extends TestCase {
 		assertEquals(expected, actual);
 	}
 
+	public void testShortenString() {
+		String original = "Hello World HELLO WORLD Hello World";
+		String expected = "Hello World HELLO...";
+
+		String actual = StringUtil.shorten(original);
+
+		assertEquals(expected, actual);
+
+		original = "Hi Hello";
+		expected = "Hi Hello";
+
+		actual = StringUtil.shorten(original, 8);
+
+		assertEquals(expected, actual);
+
+		original = "Hello World";
+		expected = "Hello...";
+
+		actual = StringUtil.shorten(original, 8);
+
+		assertEquals(expected, actual);
+
+		original = "Hi Hello World";
+		expected = "Hi...";
+
+		actual = StringUtil.shorten(original, 8);
+
+		assertEquals(expected, actual);
+
+		original = " Hello World";
+		expected = "...";
+
+		actual = StringUtil.shorten(original, 8);
+
+		assertEquals(expected, actual);
+
+		original = "HelloWorldHelloWorldHelloWorldHelloWorldHelloWorldHello";
+		expected = "HelloWorldHe... etc.";
+
+		actual = StringUtil.shorten(original, 20, "... etc.");
+
+		assertEquals(expected, actual);
+	}
+
 	public void testSplitLines() {
 		String singleLine = "abcdefg";
 


### PR DESCRIPTION
We use StringUtil.Shorten in some of our database methods.

If a column's field has a limit of 40 and we StringUtil.shorten("...", 40), theoretically it could be more than 40 characters after including "...". My fix was to account for the suffix when we shorten.
