### PR TITLE
LPS-28153

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceVirtualLayoutsAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceVirtualLayoutsAdvice.java
@@ -152,7 +152,7 @@ public class LayoutLocalServiceVirtualLayoutsAdvice
 
 				List<Layout> layouts = (List<Layout>)methodInvocation.proceed();
 
-				if (!PropsValues.
+				if (PropsValues.
 						USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
 
 					return layouts;


### PR DESCRIPTION
Refer to Liferay admin user guide, set property "user.groups.copy.layouts.to.user.personal.site" to false will enable virtual layout dynamic copy and disable actual user group layout copy, reverse if set property "user.groups.copy.layouts.to.user.personal.site" to true will enable actual user group layout copy and disable virtual layout dynamic copy.
so previous fix totally impact this function, I rollback it.
