### PR TITLE
LPS-28722

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -376,6 +376,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		long[] userGroupIds = ArrayUtil.toArray(
 			userGroupIdSet.toArray(new Long[userGroupIdSet.size()]));
 
+		if (PropsValues.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
+			for (long userGroupId : userGroupIds) {
+				userGroupLocalService.copyUserGroupLayouts(userGroupId, userId);
+			}
+		}
+
 		userPersistence.addUserGroups(userId, userGroupIds);
 	}
 
@@ -567,6 +573,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 */
 	public void addUserGroupUsers(long userGroupId, long[] userIds)
 		throws PortalException, SystemException {
+
+		if (PropsValues.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
+			userGroupLocalService.copyUserGroupLayouts(userGroupId, userIds);
+		}
 
 		userGroupPersistence.addUsers(userGroupId, userIds);
 
@@ -836,6 +846,13 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		// User groups
 
 		if (userGroupIds != null) {
+			if (PropsValues.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
+				for (long userGroupId : userGroupIds) {
+					userGroupLocalService.copyUserGroupLayouts(
+						userGroupId, new long[] {userId});
+				}
+			}
+
 			userPersistence.setUserGroups(userId, userGroupIds);
 		}
 
@@ -3466,6 +3483,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	public void setUserGroupUsers(long userGroupId, long[] userIds)
 		throws PortalException, SystemException {
 
+		if (PropsValues.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
+			userGroupLocalService.copyUserGroupLayouts(userGroupId, userIds);
+		}
+
 		userGroupPersistence.setUsers(userGroupId, userIds);
 
 		Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
@@ -4840,6 +4861,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		// User groups
 
 		if (userGroupIds != null) {
+			if (PropsValues.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE) {
+				userGroupLocalService.copyUserGroupLayouts(
+					userGroupIds, userId);
+			}
+
 			userPersistence.setUserGroups(userId, userGroupIds);
 		}
 


### PR DESCRIPTION
the previous fix impact actual user group layout copy function, so I rollback it. The correct behavior should be like following
set property "user.groups.copy.layouts.to.user.personal.site=true" will enable actual user group layout copy and disable dynamic virtual layout copy

set property "user.groups.copy.layouts.to.user.personal.site=false" will enable dynamic virtual layout copy and disable actual user group layout copy
