### PR TITLE
LPS-30083 Search results return message board article with markups

### DIFF
--- a/portal-web/docroot/html/portlet/search/init.jsp
+++ b/portal-web/docroot/html/portlet/search/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ include file="/html/portlet/init.jsp" %>
 
-<%@ page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
+<%@ page import="com.liferay.portal.kernel.parsers.bbcode.BBCodeTranslatorUtil" %><%@
+page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
 page import="com.liferay.portal.kernel.search.Document" %><%@
 page import="com.liferay.portal.kernel.search.FacetedSearcher" %><%@
 page import="com.liferay.portal.kernel.search.Hits" %><%@

--- a/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
+++ b/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
@@ -103,7 +103,7 @@ if (indexer != null) {
 }
 else if (assetRenderer != null) {
 	entryTitle = assetRenderer.getTitle(locale);
-	entrySummary = assetRenderer.getSummary(locale);
+	entrySummary = HtmlUtil.extractText(BBCodeTranslatorUtil. getHTML(assetRenderer.getSummary(locale)));
 }
 
 if ((assetRendererFactory == null) && viewInContext) {


### PR DESCRIPTION
LPS-28728 fixed this issue by coincidence. It is better to fix in this manner. The summary gets stripped so that search results won't contain any makeups. 
