### PR TITLE
LPS-31090 Permission check for getLastFileVersion

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
@@ -42,6 +42,9 @@ public class DLFileVersionServiceImpl extends DLFileVersionServiceBaseImpl {
 	public DLFileVersion getLatestFileVersion(long fileEntryId)
 		throws PortalException, SystemException {
 
+		DLFileEntryPermission.check(
+			getPermissionChecker(), fileEntryId, ActionKeys.VIEW);
+
 		return dlFileVersionLocalService.getLatestFileVersion(
 			getGuestOrUserId(), fileEntryId);
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
@@ -83,7 +83,7 @@ public class DLFileEntryPermission {
 		}
 
 		DLFileVersion latestDLFileVersion = dlFileEntry.getLatestFileVersion(
-			false);
+			true);
 
 		if (latestDLFileVersion.isPending()) {
 			hasPermission = WorkflowPermissionUtil.hasPermission(


### PR DESCRIPTION
The DLFileEntryPermission change was necessary as the permission would call this API and it would lead to a stackoverflow. The permission check should not call an API which needs permission check.
