### PR TITLE
LPS-31080

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -99,6 +99,7 @@ import com.liferay.util.ContentUtil;
 import com.liferay.util.servlet.EncryptedServletRequest;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 import java.util.List;
 import java.util.Locale;
@@ -111,7 +112,6 @@ import javax.portlet.PortletException;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -1098,9 +1098,9 @@ public class MainServlet extends ActionServlet {
 
 		html = StringUtil.replace(html, "[$MESSAGE$]", message);
 
-		ServletOutputStream servletOutputStream = response.getOutputStream();
+		PrintWriter writer = response.getWriter();
 
-		servletOutputStream.print(html);
+		writer.print(html);
 	}
 
 	protected boolean processMaintenanceRequest(


### PR DESCRIPTION
The root cause is Tomcat 6 use org.apache.catalina.connector.CoyoteOutputSteam class and this class does not override the println method of ServletOutputStream class,

Here is the code snippet of println method of ServletOutputStream class

public void print(String s) throws IOException {
if (s==null) s="null";
int len = s.length();
for (int i = 0; i < len; i++) {
char c = s.charAt ;

//
// XXX NOTE: This is clearly incorrect for many strings,
// but is the only consistent approach within the current
// servlet framework. It must suffice until servlet output
// streams properly encode their output.
//
if ((c & 0xff00) != 0) {    // high order byte must be zero String errMsg = lStrings.getString("err.not_iso8859_1"); Object[] errArgs = new Object[1]; errArgs[0] = new Character(c); errMsg = MessageFormat.format(errMsg, errArgs); throw new CharConversionException(errMsg); }
write (c);
}
}

The code c & 0xff00) != 0 restrict char c must be a ASCII otherwise will throw CharConversionException, so if char c is chinese character it will throwCharConversionException

Use writer method of PrintWriter class to avoid this issue.
