### PR TITLE
LPS-31227 Applying a theme with a setting without value throws exception

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
@@ -657,8 +657,8 @@ public class ThemeLocalServiceImpl extends ThemeLocalServiceBaseImpl {
 					String key = settingElement.attributeValue("key");
 					String[] options = StringUtil.split(
 						settingElement.attributeValue("options"));
-					String type = settingElement.attributeValue("type");
-					String value = settingElement.attributeValue("value");
+					String type = settingElement.attributeValue("type", "text");
+					String value = settingElement.attributeValue("value", "");
 					String script = settingElement.getTextTrim();
 
 					theme.addSetting(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -766,7 +766,9 @@ public class EditLayoutsAction extends PortletAction {
 				value = ParamUtil.getString(actionRequest, property);
 			}
 
-			if (!value.equals(layoutSet.getThemeSetting(key, device))) {
+			if ((value != null) &&
+				!value.equals(layoutSet.getThemeSetting(key, device))) {
+
 				typeSettingsProperties.setProperty(
 					ThemeSettingImpl.namespaceProperty(device, key), value);
 			}


### PR DESCRIPTION
Fixing the problem at two different places. Each one would be enough, however it's better if we are null-safe. If the settings page would be saved, it would always be an empty string (as the ParamUtil will get that value) so having a null value there is very exceptional.
