### PR TITLE
LPS-31256 Use https port when https is forced

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3115,9 +3115,12 @@ public class PortalImpl implements Portal {
 	public String getPortalURL(
 		String serverName, int serverPort, boolean secure) {
 
+		boolean https =
+			secure || Http.HTTPS.equals(PropsValues.WEB_SERVER_PROTOCOL);
+
 		StringBundler sb = new StringBundler();
 
-		if (secure || Http.HTTPS.equals(PropsValues.WEB_SERVER_PROTOCOL)) {
+		if (https) {
 			sb.append(Http.HTTPS_WITH_SLASH);
 		}
 		else {
@@ -3131,7 +3134,7 @@ public class PortalImpl implements Portal {
 			sb.append(PropsValues.WEB_SERVER_HOST);
 		}
 
-		if (!secure) {
+		if (!https) {
 			if (PropsValues.WEB_SERVER_HTTP_PORT == -1) {
 				if ((serverPort != Http.HTTP_PORT) &&
 					(serverPort != Http.HTTPS_PORT)) {
@@ -3148,7 +3151,7 @@ public class PortalImpl implements Portal {
 			}
 		}
 
-		if (secure) {
+		if (https) {
 			if (PropsValues.WEB_SERVER_HTTPS_PORT == -1) {
 				if ((serverPort != Http.HTTP_PORT) &&
 					(serverPort != Http.HTTPS_PORT)) {


### PR DESCRIPTION
Sorry, I couldn't resist on fixing this one. :)

It's a pretty strange that we have this issue in so deeply in the core. I was not sure about reusing the secure boolean variable, however I was afraid of changing it inside the method.
