### PR TITLE
LPS-31307 Making MapUtil.toString null-safe

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/MapUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/MapUtil.java
@@ -217,7 +217,7 @@ public class MapUtil {
 	public static String toString(
 		Map<?, ?> map, String hideIncludesRegex, String hideExcludesRegex) {
 
-		if (map.isEmpty()) {
+		if ((map == null) || map.isEmpty()) {
 			return StringPool.OPEN_CURLY_BRACE + StringPool.CLOSE_CURLY_BRACE;
 		}
 


### PR DESCRIPTION
Hugo, I'm not big fan of this solution, I would prefer returning a "null" string, however this is how we are handling it on the ArrayUtil and ListUtil.
