### PR TITLE
LPS-31714 In cluster environment, MB message count does not increment correctly

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -620,17 +620,31 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 		// Category
 
 		if ((oldCategory != null) && (categoryId != oldCategoryId)) {
-			oldCategory.setThreadCount(oldCategory.getThreadCount() - 1);
-			oldCategory.setMessageCount(
-				oldCategory.getMessageCount() - thread.getMessageCount());
+			int messageCount =
+				mbMessageLocalService.getCategoryMessagesCount(
+					groupId, oldCategoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setMessageCount(messageCount);
+
+			int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+				groupId, oldCategoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setThreadCount(threadCount);
 
 			mbCategoryPersistence.update(oldCategory);
 		}
 
 		if ((category != null) && (categoryId != oldCategoryId)) {
-			category.setThreadCount(category.getThreadCount() + 1);
-			category.setMessageCount(
-				category.getMessageCount() + thread.getMessageCount());
+			int messageCount =
+				mbMessageLocalService.getCategoryMessagesCount(
+					groupId, categoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setMessageCount(messageCount);
+
+			int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+				groupId, categoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setThreadCount(threadCount);
 
 			mbCategoryPersistence.update(category);
 		}
@@ -881,16 +895,18 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 				MBCategory category = mbCategoryPersistence.findByPrimaryKey(
 					thread.getCategoryId());
 
-				if (status == WorkflowConstants.STATUS_IN_TRASH) {
-					category.setThreadCount(category.getThreadCount() - 1);
-					category.setMessageCount(
-						category.getMessageCount() - thread.getMessageCount());
-				}
-				else {
-					category.setThreadCount(category.getThreadCount() + 1);
-					category.setMessageCount(
-						category.getMessageCount() + thread.getMessageCount());
-				}
+				int messageCount =
+					mbMessageLocalService.getCategoryMessagesCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(messageCount);
+
+				int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+					category.getGroupId(), category.getCategoryId(),
+					WorkflowConstants.STATUS_APPROVED);
+
+				category.setThreadCount(threadCount);
 
 				mbCategoryPersistence.update(category);
 			}


### PR DESCRIPTION
This fix leads to the inaccuracy of messageCount for MBCategory when recycle bin enabled. LPS-32160 is trying to fix the problem related to it. Code need to be merged in the future. Make a pull request here because recycle bin is not implemented on 6.1.x and we want to make a patch for one of customers asap.
