### PR TITLE
LPS-31714 In cluster environment, MB message count does not increment correctly

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -545,8 +545,19 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 				MBCategory category = mbCategoryPersistence.findByPrimaryKey(
 					message.getCategoryId());
 
-				category.setThreadCount(category.getThreadCount() - 1);
-				category.setMessageCount(category.getMessageCount() - 1);
+				int messageCount =
+					mbMessageLocalService.getCategoryMessagesCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(messageCount - 1);
+
+				int threadCount =
+					mbThreadLocalService.getCategoryThreadsCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setThreadCount(threadCount);
 
 				mbCategoryPersistence.update(category);
 			}
@@ -655,7 +666,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 				MBCategory category = mbCategoryPersistence.findByPrimaryKey(
 					message.getCategoryId());
 
-				category.setMessageCount(category.getMessageCount() - 1);
+				int messageCount = mbMessageLocalService.getThreadMessagesCount(
+					thread.getThreadId(), WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(messageCount - 1);
 
 				mbCategoryPersistence.update(category);
 			}
@@ -2152,12 +2166,20 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			if ((category != null) &&
 				(thread.getRootMessageId() == message.getMessageId())) {
 
-				category.setThreadCount(category.getThreadCount() + 1);
+				int categoryThreadCount =
+					mbThreadLocalService.getCategoryThreadsCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setThreadCount(categoryThreadCount + 1);
 
 				mbCategoryPersistence.update(category);
 			}
 
-			thread.setMessageCount(thread.getMessageCount() + 1);
+			int messageCount = mbMessageLocalService.getThreadMessagesCount(
+				thread.getThreadId(), WorkflowConstants.STATUS_APPROVED);
+
+			thread.setMessageCount(messageCount);
 
 			if (message.isAnonymous()) {
 				thread.setLastPostByUserId(0);
@@ -2171,7 +2193,12 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			// Category
 
 			if (category != null) {
-				category.setMessageCount(category.getMessageCount() + 1);
+				int categoryMessageCount =
+					mbMessageLocalService.getCategoryMessagesCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(categoryMessageCount);
 				category.setLastPostDate(modifiedDate);
 
 				mbCategoryPersistence.update(category);
@@ -2185,17 +2212,30 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			if ((category != null) &&
 				(thread.getRootMessageId() == message.getMessageId())) {
 
-				category.setThreadCount(category.getThreadCount() - 1);
+				int categoryThreadCount =
+					mbThreadLocalService.getCategoryThreadsCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setThreadCount(categoryThreadCount - 1);
 
 				mbCategoryPersistence.update(category);
 			}
 
-			thread.setMessageCount(thread.getMessageCount() - 1);
+			int messageCount = mbMessageLocalService.getThreadMessagesCount(
+				thread.getThreadId(), WorkflowConstants.STATUS_APPROVED);
+
+			thread.setMessageCount(messageCount - 1);
 
 			// Category
 
 			if (category != null) {
-				category.setMessageCount(category.getMessageCount() - 1);
+				int categoryMessageCount =
+					mbMessageLocalService.getCategoryMessagesCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(categoryMessageCount - 1);
 
 				mbCategoryPersistence.update(category);
 			}

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -193,9 +193,19 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			MBCategory category = mbCategoryPersistence.findByPrimaryKey(
 				thread.getCategoryId());
 
-			category.setThreadCount(category.getThreadCount() - 1);
-			category.setMessageCount(
-				category.getMessageCount() - thread.getMessageCount());
+			int threadCount =
+				mbThreadLocalService.getCategoryThreadsCount(
+					category.getGroupId(), category.getCategoryId(),
+					WorkflowConstants.STATUS_APPROVED);
+
+			category.setThreadCount(threadCount - 1);
+
+			int categoryMessageCount =
+				mbMessageLocalService.getCategoryMessagesCount(
+					category.getGroupId(), category.getCategoryId(),
+					WorkflowConstants.STATUS_APPROVED);
+
+			category.setMessageCount(categoryMessageCount);
 
 			mbCategoryPersistence.update(category);
 		}
@@ -620,17 +630,31 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 		// Category
 
 		if ((oldCategory != null) && (categoryId != oldCategoryId)) {
-			oldCategory.setThreadCount(oldCategory.getThreadCount() - 1);
-			oldCategory.setMessageCount(
-				oldCategory.getMessageCount() - thread.getMessageCount());
+			int messageCount =
+				mbMessageLocalService.getCategoryMessagesCount(
+					groupId, oldCategoryId, WorkflowConstants.STATUS_APPROVED);
+
+			oldCategory.setMessageCount(messageCount);
+
+			int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+				groupId, oldCategoryId, WorkflowConstants.STATUS_APPROVED);
+
+			oldCategory.setThreadCount(threadCount);
 
 			mbCategoryPersistence.update(oldCategory);
 		}
 
 		if ((category != null) && (categoryId != oldCategoryId)) {
-			category.setThreadCount(category.getThreadCount() + 1);
-			category.setMessageCount(
-				category.getMessageCount() + thread.getMessageCount());
+			int messageCount =
+				mbMessageLocalService.getCategoryMessagesCount(
+					groupId, categoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setMessageCount(messageCount);
+
+			int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+				groupId, categoryId, WorkflowConstants.STATUS_APPROVED);
+
+			category.setThreadCount(threadCount);
 
 			mbCategoryPersistence.update(category);
 		}
@@ -784,20 +808,24 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		// Update children
 
-		int messagesMoved = 1;
-
-		messagesMoved += moveChildrenMessages(
-			message, category, oldThread.getThreadId());
+		moveChildrenMessages(message, category, oldThread.getThreadId());
 
 		// Update new thread
 
-		thread.setMessageCount(messagesMoved);
+		int threadMessageCount = mbMessageLocalService.getThreadMessagesCount(
+			thread.getThreadId(), WorkflowConstants.STATUS_APPROVED);
+
+		thread.setMessageCount(threadMessageCount);
 
 		mbThreadPersistence.update(thread);
 
 		// Update old thread
 
-		oldThread.setMessageCount(oldThread.getMessageCount() - messagesMoved);
+		int oldThreadMessageCount =
+			mbMessageLocalService.getThreadMessagesCount(
+				oldThread.getThreadId(), WorkflowConstants.STATUS_APPROVED);
+
+		oldThread.setMessageCount(oldThreadMessageCount);
 
 		mbThreadPersistence.update(oldThread);
 
@@ -808,7 +836,11 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			(message.getCategoryId() !=
 				MBCategoryConstants.DISCUSSION_CATEGORY_ID)) {
 
-			category.setThreadCount(category.getThreadCount() + 1);
+			int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+				category.getGroupId(), category.getCategoryId(),
+				WorkflowConstants.STATUS_APPROVED);
+
+			category.setThreadCount(threadCount);
 
 			mbCategoryPersistence.update(category);
 		}
@@ -881,16 +913,18 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 				MBCategory category = mbCategoryPersistence.findByPrimaryKey(
 					thread.getCategoryId());
 
-				if (status == WorkflowConstants.STATUS_IN_TRASH) {
-					category.setThreadCount(category.getThreadCount() - 1);
-					category.setMessageCount(
-						category.getMessageCount() - thread.getMessageCount());
-				}
-				else {
-					category.setThreadCount(category.getThreadCount() + 1);
-					category.setMessageCount(
-						category.getMessageCount() + thread.getMessageCount());
-				}
+				int messageCount =
+					mbMessageLocalService.getCategoryMessagesCount(
+						category.getGroupId(), category.getCategoryId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				category.setMessageCount(messageCount);
+
+				int threadCount = mbThreadLocalService.getCategoryThreadsCount(
+					category.getGroupId(), category.getCategoryId(),
+					WorkflowConstants.STATUS_APPROVED);
+
+				category.setThreadCount(threadCount);
 
 				mbCategoryPersistence.update(category);
 			}


### PR DESCRIPTION
This fix leads to the inaccuracy of messageCount for MBCategory when recycle bin enabled. LPS-32160 is trying to fix the problem related to it. Code need to be merged in the future. Make a pull request here because recycle bin is not implemented on 6.1.x and we want to make a patch for one of customers asap.
