### PR TITLE
LPS-34508 Won't reset the elcontent when publish a web content without an image uploaded in the structure

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5409,6 +5409,12 @@ public class JournalArticleLocalServiceImpl
 				continue;
 			}
 
+			if (dynamicContent.getText().isEmpty()) {
+				imageLocalService.deleteImage(imageId);
+
+				continue;
+			}
+
 			byte[] bytes = images.get(elInstanceId + "_" + elName + elLanguage);
 
 			if ((bytes != null) && (bytes.length > 0)) {


### PR DESCRIPTION
Also we need to remove the existing image in case dirty data was stored in the data folder.
