### PR TITLE
LPS-37191 Involve workflow for change parent on wiki page

### DIFF
--- a/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutConstants;
 import com.liferay.portal.model.ResourceConstants;
@@ -435,7 +436,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			nodeId, title, false);
 
 		for (WikiPage oldPage : oldPages) {
-			oldPage.setParentTitle(originalParentTitle);
+			if (!WorkflowThreadLocal.isEnabled()) {
+				oldPage.setParentTitle(originalParentTitle);
+			}
 
 			wikiPagePersistence.update(oldPage);
 		}

--- a/portal-web/docroot/html/portlet/wiki/move_page.jsp
+++ b/portal-web/docroot/html/portlet/wiki/move_page.jsp
@@ -144,7 +144,16 @@ String newTitle = ParamUtil.get(request, "newTitle", StringPool.BLANK);
 				%>
 
 				<aui:button-row>
-					<aui:button disabled="<%= !newParentAvailable %>" type="submit" value="change-parent" />
+
+					<%
+					String saveButtonLabel = "change-parent";
+
+					if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(themeDisplay.getCompanyId(), scopeGroupId, WikiPage.class.getName())) {
+						saveButtonLabel = "submit-for-publication";
+					}
+					%>
+
+					<aui:button disabled="<%= !newParentAvailable %>" type="submit" value="<%= saveButtonLabel %>" />
 
 					<aui:button href="<%= redirect %>" type="cancel" />
 				</aui:button-row>
@@ -158,6 +167,12 @@ String newTitle = ParamUtil.get(request, "newTitle", StringPool.BLANK);
 		document.<portlet:namespace />fm.<portlet:namespace /><%= Constants.CMD %>.value = "changeParent";
 
 		submitForm(document.<portlet:namespace />fm);
+	}
+
+	function <portlet:namespace />publishPage() {
+		document.<portlet:namespace />fm.<portlet:namespace />workflowAction.value = "<%= WorkflowConstants.ACTION_PUBLISH %>";
+
+		<portlet:namespace />changeParent();
 	}
 
 	function <portlet:namespace />renamePage() {


### PR DESCRIPTION
Hi Hugo,

The changes in WikiPageLocalServiceImpl class in because I involve the workflow for change parent and after updatePage() in changeParent() we have the following:

for (WikiPage oldPage : oldPages) {
     oldPage.setParentTitle(originalParentTitle);

```
 wikiPagePersistence.update(oldPage);
```

  } 

As the oldPages will fetch all the pages which head is 0 so it is also include the changed parent page as the status is not approved. You know that change parent will find the originalParentTitle and before change parent it is blank. So that is why I add that check to escape to reset the originalParentTitle. I thing above code should apply to the pages which version is lower than page.

Thanks,
-Eric
