### PR TITLE
LPS-41940 Downloading a file with a long title will cause text to overflow in the Recent Downloads portlet

### DIFF
--- a/portal-web/docroot/html/css/portal/generic_portlet.css
+++ b/portal-web/docroot/html/css/portal/generic_portlet.css
@@ -45,6 +45,7 @@
 
 	tr td, tr th {
 		padding: 0 5px;
+		word-break: break-all;
 
 		&:first-child, &.first-child {
 			padding-left: 0;


### PR DESCRIPTION
Hey Hugo,

I'm not sure if this is the right place for this fix so just let me know if it needs to made somewhere else.

Thanks.
