### PR TITLE
LPS-42846  After moving a document between folders with Amazon s3 DL Store the document cannot be downloaded

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/S3Store.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/S3Store.java
@@ -328,7 +328,8 @@ public class S3Store extends BaseStore {
 
 				x = oldKey.indexOf(CharPool.SLASH, x + 1);
 
-				String newKey = newPrefix + oldKey.substring(x + 1);
+				String newKey =
+					newPrefix + CharPool.SLASH + oldKey.substring(x + 1);
 
 				S3Object newS3Object = new S3Object(_s3Bucket, newKey);
 
@@ -383,7 +384,8 @@ public class S3Store extends BaseStore {
 				x = oldKey.indexOf(CharPool.SLASH, x + 1);
 				x = oldKey.indexOf(CharPool.SLASH, x + 1);
 
-				String newKey = newPrefix + oldKey.substring(x + 1);
+				String newKey =
+					newPrefix + CharPool.SLASH + oldKey.substring(x + 1);
 
 				S3Object newS3Object = new S3Object(_s3Bucket, newKey);
 


### PR DESCRIPTION
Hey Hugo,

The issue is that a trailing slash was removed from the getKey method which in turn breaks this functionality. The document is stored with a key of "1/10815/301/1.0" but Liferay tries to search for "1/10815301/1.0" instead. This fix adds the slash back in but still preserves the fix from LPS-31081.

Also, on line 385, there is a duplicate "x = oldKey.indexOf(CharPool.SLASH, x + 1);". I wasn't sure if that was there on purpose so I just left it in but wanted to get your thoughts on it.

Thanks.
