### PR TITLE
LPS-43181 Simplify the fix

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -75,6 +75,8 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.comparator.LayoutComparator;
 import com.liferay.portal.util.comparator.LayoutPriorityComparator;
+import com.liferay.portlet.documentlibrary.FileNameException;
+import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
 import com.liferay.portlet.dynamicdatalists.RecordSetDuplicateRecordSetKeyException;
 import com.liferay.portlet.dynamicdatamapping.StructureDuplicateStructureKeyException;
 import com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance;
@@ -888,6 +890,10 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate, String fileName)
 		throws PortalException, SystemException {
+
+		if (!DLStoreUtil.isValidName(fileName)) {
+			throw new FileNameException(fileName);
+		}
 
 		Map<String, Serializable> taskContextMap =
 			BackgroundTaskContextMapFactory.buildTaskContextMap(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/ExportLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/ExportLayoutsAction.java
@@ -30,6 +30,7 @@ import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.struts.PortletAction;
+import com.liferay.portlet.documentlibrary.FileNameException;
 import com.liferay.portlet.sites.action.ActionUtil;
 
 import java.util.List;
@@ -90,14 +91,19 @@ public class ExportLayoutsAction extends PortletAction {
 			}
 		}
 		catch (Exception e) {
-			_log.error(e, e);
+			if (e instanceof FileNameException) {
+				SessionErrors.add(actionRequest, e.getClass());
+			}
+			else {
+				_log.error(e, e);
 
-			SessionErrors.add(actionRequest, e.getClass());
+				SessionErrors.add(actionRequest, e.getClass());
 
-			String pagesRedirect = ParamUtil.getString(
-				actionRequest, "pagesRedirect");
+				String pagesRedirect = ParamUtil.getString(
+					actionRequest, "pagesRedirect");
 
-			sendRedirect(actionRequest, actionResponse, pagesRedirect);
+				sendRedirect(actionRequest, actionResponse, pagesRedirect);
+			}
 		}
 	}
 

--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
@@ -102,6 +102,8 @@ portletURL.setParameter("rootNodeName", rootNodeName);
 				<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.EXPORT %>" />
 				<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 
+				<liferay-ui:error exception="<%= FileNameException.class %>" message="please-enter-a-file-with-a-valid-file-name" />
+
 				<div class="export-dialog-tree">
 					<aui:input cssClass="file-selector" label="export-the-selected-data-to-the-given-lar-file-name" name="exportFileName" required="<%= true %>" showRequiredLabel="<%= false %>" size="50" value='<%= HtmlUtil.escape(StringUtil.replace(rootNodeName, " ", "_")) + "-" + Time.getShortTimestamp() + ".lar" %>' />
 

--- a/portal-web/docroot/html/portlet/layouts_admin/init.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/init.jsp
@@ -64,6 +64,7 @@ page import="com.liferay.portal.security.auth.AuthException" %><%@
 page import="com.liferay.portal.security.auth.RemoteAuthException" %><%@
 page import="com.liferay.portal.theme.NavItem" %><%@
 page import="com.liferay.portlet.backgroundtask.util.comparator.BackgroundTaskComparatorFactoryUtil" %><%@
+page import="com.liferay.portlet.documentlibrary.FileNameException" %><%@
 page import="com.liferay.portlet.dynamicdatalists.RecordSetDuplicateRecordSetKeyException" %><%@
 page import="com.liferay.portlet.dynamicdatamapping.StructureDuplicateStructureKeyException" %><%@
 page import="com.liferay.portlet.layoutsadmin.util.LayoutsTreeUtil" %><%@


### PR DESCRIPTION
Validate the file name before the background process start, then we do not need to adjust the log level to hide the stacktrace.
