### PR TITLE
LPS-43111 Locked thread can be deleted when it is moved into a category

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/message_action.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/message_action.jsp
@@ -146,7 +146,7 @@ MBThread thread = message.getThread();
 		</c:choose>
 	</c:if>
 
-	<c:if test="<%= MBCategoryPermission.contains(permissionChecker, message.getGroupId(), message.getCategoryId(), ActionKeys.MOVE_THREAD) %>">
+	<c:if test="<%= MBCategoryPermission.contains(permissionChecker, message.getGroupId(), message.getCategoryId(), ActionKeys.MOVE_THREAD) && !thread.isLocked() %>">
 		<portlet:renderURL var="moveThreadURL">
 			<portlet:param name="struts_action" value="/message_boards/move_thread" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />


### PR DESCRIPTION
Hey Hugo,

I'm just doing what Sergio said https://github.com/sergiogonzalez/liferay-portal/pull/1169#issuecomment-33048537 and checking if the thread is locked, and if so then don't allow the user to move it.

Thanks.
