### PR TITLE
LPS-44343

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -369,7 +369,7 @@ AUI.add(
 						var tabHtml = Lang.sub(
 							tabTPL,
 							{
-								pageTitle: Lang.String.escapeHTML(data.title),
+								pageTitle: data.title,
 								url: data.url
 							}
 						);

--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -231,7 +231,7 @@ else {
 					data: {
 						layoutId: <%= addedLayout.getLayoutId() %>,
 						parentLayoutId: <%= addedLayout.getParentLayoutId() %>,
-						title: A.Lang.String.escapeHTML('<%= navItem.getName() %>'),
+						title: '<%= navItem.getName() %>',
 						url: '<%= navItem.getURL() %>'
 					}
 				}


### PR DESCRIPTION
remove duplicate escape calling since navitem name is escaped already in method navItem.getName()
