### PR TITLE
LPS-44328 The apostrophe in a user's name appears as HTML numeric charac...

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
@@ -122,7 +122,7 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 		>
 
 			<%
-			buffer.append(HtmlUtil.escape(user2.getFullName()));
+			buffer.append(user2.getFullName());
 
 			List<String> names = new ArrayList<String>();
 


### PR DESCRIPTION
...ter reference (&#039;) in the Site Memberships page.

The name field had been escaped two times. 

The first time is in user2.getFullName(). When executes the method user2.getFullName(), the AutoEscapeBeanHandler.invoke method will be invoked. When the program executes the below code in this method
### 

if (method.getAnnotation(AutoEscape.class) != null) { 
    result = HtmlUtil.escape((String)result);
}
//Due to User.getFullName() uses the annotation "@com.liferay.portal.kernel.bean.AutoEscape()", so the program will execute the if block so that the first time escape occurs.
### 

The second time is in HtmlUtil.escape().

So the fix removes the second time escape.
