### PR TITLE
LPS-44383 Friendly URL comparison should not be case sensitive

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
@@ -295,7 +296,8 @@ public class FriendlyURLServlet extends HttpServlet {
 
 				Locale locale = PortalUtil.getLocale(request);
 
-				if (!layoutFriendlyURLCompositeFriendlyURL.equals(
+				if (!StringUtil.equalsIgnoreCase(
+						layoutFriendlyURLCompositeFriendlyURL,
 						layout.getFriendlyURL(locale))) {
 
 					Locale originalLocale = setAlternativeLayoutFriendlyURL(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3501,6 +3501,8 @@ public class PortalImpl implements Portal {
 
 		String requestURI = request.getRequestURI();
 
+		requestURI = StringUtil.toLowerCase(requestURI);
+
 		if (Validator.isNotNull(contextPath) &&
 			requestURI.contains(contextPath)) {
 
@@ -3511,6 +3513,8 @@ public class PortalImpl implements Portal {
 			requestURI, StringPool.DOUBLE_SLASH, StringPool.SLASH);
 
 		String path = request.getPathInfo();
+
+		path = StringUtil.toLowerCase(path);
 
 		int x = path.indexOf(CharPool.SLASH, 1);
 


### PR DESCRIPTION
The fix should address two parts of the issue:
1. In FriendlyURLServlet.getRedirect() we have the following check:

if (!layoutFriendlyURLCompositeFriendlyURL.equals(layout.getFriendlyURL(locale))) {...}
The friendly url from database will be always lower case so lower case layoutFriendlyURLCompositeFriendlyURL makes more sense.
1. In PortalImpl.getLocalizedFriendlyURL() we have the following check:

if (requestURI.contains(layoutFriendlyURL)) {...}
Here layoutFriendlyURL can be from path and database
a) When it is from path it should have the same case as requestURI as they are from the same request. 
b) When it is from database it will be lower case.

So that make more sense if we lower case all the urls here.

Thanks.
