### PR TITLE
LPS-44849 Allow setting null to "To" email address as some mail engine does not accept emty address like AWS SES

### DIFF
--- a/util-java/src/com/liferay/util/mail/MailEngine.java
+++ b/util-java/src/com/liferay/util/mail/MailEngine.java
@@ -252,15 +252,15 @@ public class MailEngine {
 
 			message.setFrom(from);
 
-			if (to != null) {
+			if ((to != null) && (to.length > 0)) {
 				message.setRecipients(Message.RecipientType.TO, to);
 			}
 
-			if (cc != null) {
+			if ((cc != null) && (cc.length > 0)) {
 				message.setRecipients(Message.RecipientType.CC, cc);
 			}
 
-			if (bcc != null) {
+			if ((bcc != null) && (bcc.length > 0)) {
 				message.setRecipients(Message.RecipientType.BCC, bcc);
 			}
 


### PR DESCRIPTION
Also apply to CC and BCC.
