### PR TITLE
LPS-44686 add new error code for AssetCategoryException

### DIFF
--- a/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
+++ b/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
@@ -247,6 +247,9 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 				else if (causeString.contains("SystemException")) {
 					returnValue = "209";
 				}
+				else if (causeString.contains("AssetCategoryException")) {
+					returnValue = "210";
+				}
 				else {
 					throw fcke;
 				}

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseConstants.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseConstants.java
@@ -19,7 +19,7 @@ package com.liferay.portal.kernel.servlet;
  */
 public interface ServletResponseConstants {
 
-	public static final int SC_AUDIO_PREVIEW_DISABLED_EXCEPTION = 211;
+	public static final int SC_AUDIO_PREVIEW_DISABLED_EXCEPTION = 212;
 
 	public static final int SC_DUPLICATE_FILE_EXCEPTION = 490;
 
@@ -31,6 +31,6 @@ public interface ServletResponseConstants {
 
 	public static final int SC_FILE_SIZE_EXCEPTION = 493;
 
-	public static final int SC_VIDEO_PREVIEW_DISABLED_EXCEPTION = 210;
+	public static final int SC_VIDEO_PREVIEW_DISABLED_EXCEPTION = 211;
 
 }

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -748,9 +748,12 @@
 								alert( 'An internal server error occured.' );
 								break ;
 							case 210:
-								alert( 'You cannot upload a video file if video preview generation is disabled.' );
+								alert( 'You cannot upload a file if category is required.' );
 								break ;
 							case 211:
+								alert( 'You cannot upload a video file if video preview generation is disabled.' );
+								break ;
+							case 212:
 								alert( 'You cannot upload an audio file if audio preview generation is disabled.' );
 								break ;
 							default :


### PR DESCRIPTION
Hey Hugo,
I did not refact the class BaseCommandReceiver to use Constants for error code due to following concern.
1. You can see some of them use one error code express two type exception, so If I combine the type exception looks like not standard
1. potential problem, same type exception with different error code. (e.g FileExtensionException, FileSizeException)
