### PR TITLE
LPS-45758 When impersonate we should assume userSetupComplete is true

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/view.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/view.jsp
@@ -173,6 +173,10 @@ String toggleControlsState = GetterUtil.getString(SessionClicks.get(request, "li
 	<%
 	boolean userSetupComplete = user.isSetupComplete();
 
+	if (themeDisplay.isImpersonated()) {
+		userSetupComplete = true;
+	}
+
 	boolean portalMessageUseAnimation = GetterUtil.getBoolean(PortalMessages.get(request, PortalMessages.KEY_ANIMATION), true);
 	%>
 


### PR DESCRIPTION
This issue only happened when impersonted a user before the real user login to the portal, that means when impersonated it did not finish all the necessary setup then user.isSetupComplete() will return false which make the corresponding parts can not be displayed in dockbar. So add the check to set userSetupComplete to true when impersonate a user.
