### PR TITLE
LPS-45921

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -555,7 +555,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 				if (group.isStagingGroup() &&
 					!ResourceBlockLocalServiceUtil.isSupported(name)) {
-					
+
 					if (primKey.equals(String.valueOf(groupId))) {
 						primKey = String.valueOf(group.getLiveGroupId());
 					}


### PR DESCRIPTION
Note from George on LPS:

"After a discussion with Ray and Minhchau, we have determined that the best course of action for now is to prevent switching the groupId for a ResourceBlock for layout-scoped pages for staging. There will be further discussions to determine how Liferay should move forward with ResourceBlocks, but this fix will resolve the current issue."

Thanks.
