### PR TITLE
LPS-45934 Post-Upgrade Activities portlet doesn't show (wiki,message.blog,bookmark,calendar) links

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSocial.java
@@ -503,8 +503,11 @@ public class UpgradeSocial extends UpgradeProcess {
 			con = DataAccess.getUpgradeOptimizedConnection();
 
 			ps = con.prepareStatement(
-				"select groupId, companyId, userId, modifiedDate, " +
-					"resourcePrimKey, version from WikiPage");
+				"select groupId, companyId, userId, modifiedDate, title, " +
+					"resourcePrimKey, version from WikiPage " +
+						"where status = ?");
+
+			ps.setInt(1, WorkflowConstants.STATUS_APPROVED);
 
 			rs = ps.executeQuery();
 
@@ -513,6 +516,7 @@ public class UpgradeSocial extends UpgradeProcess {
 				long companyId = rs.getLong("companyId");
 				long userId = rs.getLong("userId");
 				Timestamp modifiedDate = rs.getTimestamp("modifiedDate");
+				String title = rs.getString("title");
 				long resourcePrimKey = rs.getLong("resourcePrimKey");
 				double version = rs.getDouble("version");
 
@@ -529,6 +533,7 @@ public class UpgradeSocial extends UpgradeProcess {
 				JSONObject extraDataJSONObject =
 					JSONFactoryUtil.createJSONObject();
 
+				extraDataJSONObject.put("title", title);
 				extraDataJSONObject.put("version", version);
 
 				addActivity(


### PR DESCRIPTION
Hi Hugo,

The fix logic is similiar with https://github.com/hhuijser/liferay-portal/pull/1802. And the root issue is also the same explanation as https://github.com/hhuijser/liferay-portal/pull/1802.

I want to explain some reasons regarding every entrys fix:
1. For Blog,  Bookmarks and CalEvent, I choose firstly to delete them and then insert them. This method will miss some socialactivitys data of them. For example, when I edit one blog, the program will insert one new  data in SocialActivity. In the Activity portlet, we can see the same blog two activitys as the followings:
### 

Test wrote a new blog entry, blog hello.
Test updated a blog entry, blog hello.  
### 

Due to the two displayed data comes from SocialActivity table and we only save one data in blogsentry table (because blog doesn't versions), so we can't completely restore these activitys. That is to say, after upgrading 6.1.10 to 6.2, all blogs will be inserted as new created blog(or activitys, type = BlogsActivityKeys.ADD_ENTRY).

The fix lack is that when the customer used  6.1.20 version,  the customer had correctly record regarding activitys  (the issue was fixed on LPS-28482), But after upgrading 6.1.20 to 6.2, as my explanation, the fix  will only add blog as "ADD_ENTRY" in SocialActivity table.

In fact, when I click "Test wrote a new blog entry, blog hello.", the latest blog will be displayed because we  only save the latest blog. So I think the fiix method should be ok or acceptable.  Bookmarks and CalEvent  also have the same issue as the blog.

2.For MBmessage, the fix logic is different from other asset entrys. Please refer to MBMessageLocalServiceImpl.updateMessage() method. It inlcuded the logic in receiverUserId and mirrorActivity. It also includes all asset entry's comment data.

For I used the sql program from 400 to 407 lines, it can make sure the program can get all messages from MB portlet and all entry's comment data.

When update SocialActivity table, using  "extraData like ..." can make sure that the program will update the detailed comment data. For example, when I comment two records for the same blog. In SocialActivity table, it will also two related activitys as the followings:
//
the first data: classPK: 10701, extraData: {"messageId":10901}
the second data: classPK: 10701, extraData: {"messageId":10110}
//

3.For web content, 6.1 didn't add journal activity, the feature was added in LPS-31951.

Please help check the fix whether be ok.

Thanks,
Hai
