### PR TITLE
LPS-45877 Adding "comma and space" as delimiter between email addresses

### DIFF
--- a/util-java/src/com/liferay/util/mail/InternetAddressUtil.java
+++ b/util-java/src/com/liferay/util/mail/InternetAddressUtil.java
@@ -107,7 +107,7 @@ public class InternetAddressUtil {
 
 		for (int i = 0; i < (addresses.length - 1); i++) {
 			sb.append(toString(addresses[i]));
-			sb.append(StringPool.COMMA);
+			sb.append(StringPool.COMMA_AND_SPACE);
 		}
 
 		sb.append(toString(addresses[addresses.length - 1]));


### PR DESCRIPTION
Hi Hugo,

The PR extends from https://github.com/hhuijser/liferay-plugins/pull/184.

I find InternetAddressUtil.toString(Address[] addresses) method is used for generating emailAddress format when update or add message in mail_message table. Please refer to IMAPAccessor.storeEnvelopes() and IMAPMailbox.saveDraft() in mail portlet. 

The current "comma" delimiter between email addresses was generated in this method InternetAddressUtil.toString(Address[] addresses). 

I also check the InternetAddressUtil.java log and find we used "StringPool.COMMA+StringPool.NBSP" as delimiter before applying LPS-30185 fix. For the current fix, if we use "space" instead of "StringPool.NBSP" and the LPS-30185 won't occur.

Could you please help check this fix?

Thanks,
Hai 
