### PR TITLE
LPS-46580 duplicated title occured when upgraded from 5.2.7 to 6.1 GA2 d...

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_0/UpgradeDocumentLibrary.java
@@ -154,6 +154,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 		upgradeTable.setCreateSQL(DLFileEntryTable.TABLE_SQL_CREATE);
 		upgradeTable.setIndexesSQL(DLFileEntryTable.TABLE_SQL_ADD_INDEXES);
+		upgradeTable.setAllowUniqueIndexes(true);
 
 		upgradeTable.updateTable();
 


### PR DESCRIPTION
...irectly

Due to we have different validateFile method when save a document between 5.2 and 6.1, so that we can insert same name in IGImage table of 5.2.7 database. In 6.1 version, we will transfer IGImage's data into DLFileEntry. And when upgrading from 5.2.7 to 6.1.20, we updated the unique index for non-unique on DLFileEntry (groupId, folderId, title) in the process of upgrade. So our existed code regarding handling with the title duplicated issue in the process of upgrading don't take effect(The below code don't take effect). 
## 

v6_1_0\UpgradeImageGallery.updateIGImageEntries() method:

try {
    addDLFileEntry(uuid, imageId, groupId, companyId, userId, userName,...);
}
catch (Exception e) { 
//catch block wasn't be executed when inserted same value(groupId, folderId, title) on DLFileEntry

```
title = title.concat(StringPool.SPACE).concat(String.valueOf(imageId));

addDLFileEntry(uuid, imageId, groupId, companyId, userId, userName,..);
```

}
## 

Updated the unique index for non-unique occured in BaseUpgradeTableImpl.updateTable(). The code "!isAllowUniqueIndexes()" was added by LPS-14456.

As Brian's commit "Default allowUniqueIndexes to false, but still allow it to be called in the future for "special' cases", so the fix sets allowUniqueIndexes=true to solve the issue. That is to say, when execute v6_1_0\UpgradeImageGallery.updateIGImageEntries() method, we can use catch block to handle with the duplicated document.

Please help review the fix.

Thanks,
Hai

PS:
On 5.2, we used name + extension to validate whether the image document is duplicated. Please refer to the method.
### 

in IGImageLocalServiceImpl.validate(long folderId, String nameWithExtension) {

String name = FileUtil.stripExtension(nameWithExtension);

List<IGImage> images = igImagePersistence.findByF_N(folderId, name);

for (IGImage image : images) {
if (imageType.equals(image.getImageType()))
{ throw new DuplicateImageNameException(); }

}
}
### 

On 6.1, we used title field to validate whether the document is duplicated.
### 

in DLFileEntryLocalServiceImpl.validateFile (long groupId, long folderId,
long fileEntryId, String title,String extension) {
DLFileEntry dlFileEntry = dlFileEntryPersistence.fetchByG_F_T(
groupId, folderId, title);

if ((dlFileEntry != null) &&
(dlFileEntry.getFileEntryId() != fileEntryId))
{ throw new DuplicateFileException(title); }

}
### 
