### PR TITLE
LPS-46850

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
+++ b/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
@@ -113,7 +113,7 @@
 	organizationParams.put("groupOrganization", new Long(curGroup.getGroupId()));
 	organizationParams.put("organizationsGroups", new Long(curGroup.getGroupId()));
 
-	int organizationsCount = OrganizationLocalServiceUtil.searchCount(company.getCompanyId(), OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, searchTerms.getKeywords(), null, null, null, organizationParams);
+	int organizationsCount = OrganizationLocalServiceUtil.searchCount(company.getCompanyId(), OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, null, null, null, null, organizationParams);
 	%>
 
 	<c:if test="<%= organizationsCount > 0 %>">


### PR DESCRIPTION
The "searchTerms.getKeywords()" is used to filter the Site's name and description, not the organizations that are members and both the users and userGroups columns do not filter by the keywords.
