### PR TITLE
LPS-47034 WebDAV service returns HTTP error 409 instead of error code 41...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/webdav/DLWebDAVStorageImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/webdav/DLWebDAVStorageImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portlet.asset.service.AssetLinkLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.DuplicateFileException;
 import com.liferay.portlet.documentlibrary.DuplicateFolderNameException;
+import com.liferay.portlet.documentlibrary.FileSizeException;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
@@ -738,6 +739,9 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			}
 
 			return HttpServletResponse.SC_CREATED;
+		}
+		catch (FileSizeException pe) {
+			return HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE;
 		}
 		catch (PrincipalException pe) {
 			return HttpServletResponse.SC_FORBIDDEN;


### PR DESCRIPTION
...3 for the FileSizeException

The issue occurs when uploading file's size is greater than the property "dl.file.max.size" setting's value by using webdav, the program will threw the FileSizeException and returned http Status-Code:"409".

Status-Code:"413" should be related with the FileSizeException closely. Please refer to the below link
http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14
#### 

413 Request Entity Too Large

The server is refusing to process a request because the request entity is larger than the server is willing or able to process. The server MAY close the connection to prevent the client from continuing the request.

If the condition is temporary, the server SHOULD include a Retry- After header field to indicate that it is temporary and after what time the client MAY try again. 
#### 

By returning Status-Code:"413", it can express the meaning of "FileSizeException".

Please help reviewing the fix.

Thanks,
Hai
