### PR TITLE
LPS-47694 User search facet throws exception for deleted users

### DIFF
--- a/portal-web/docroot/html/portlet/search/facets/users.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/users.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/html/portlet/search/facets/init.jsp" %>
 
 <%
+Hits hits = (Hits)request.getAttribute("search.jsp-hits");
+
 if (termCollectors.isEmpty()) {
 	return;
 }
@@ -42,7 +44,24 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 
 			long curUserId = GetterUtil.getLong(termCollector.getTerm());
 
-			User curUser = UserLocalServiceUtil.getUser(curUserId);
+			User curUser = UserLocalServiceUtil.fetchUser(curUserId);
+
+			String curUserName = null;
+
+			if (curUser != null) {
+				curUserName = curUser.getFullName();
+			}
+			else {
+				for (Document document : hits.toList()) {
+					long assetEntryUserId = GetterUtil.getLong(document.get("userId"));
+
+					if (assetEntryUserId == curUserId) {
+						curUserName = document.get("userName");
+
+						break;
+					}
+				}
+			}
 		%>
 
 			<c:if test="<%= userId == curUserId %>">
@@ -50,7 +69,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 					Liferay.Search.tokenList.add(
 						{
 							clearFields: '<%= renderResponse.getNamespace() + HtmlUtil.escapeJS(facet.getFieldId()) %>',
-							text: '<%= HtmlUtil.escapeJS(curUser.getFullName()) %>'
+							text: '<%= HtmlUtil.escapeJS(curUserName) %>'
 						}
 					);
 				</aui:script>
@@ -64,7 +83,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 
 			<li class="facet-value <%= (userId == curUserId) ? "active" : StringPool.BLANK %>">
 				<a data-value="<%= curUserId %>" href="javascript:;">
-					<%= HtmlUtil.escape(curUser.getFullName()) %>
+					<%= HtmlUtil.escape(curUserName) %>
 
 					<c:if test="<%= showAssetCount %>">
 						<span class="badge badge-info frequency"><%= termCollector.getFrequency() %></span>

--- a/portal-web/docroot/html/portlet/search/main_search.jspf
+++ b/portal-web/docroot/html/portlet/search/main_search.jspf
@@ -65,6 +65,7 @@ Hits hits = indexer.search(searchContext);
 String[] queryTerms = hits.getQueryTerms();
 
 request.setAttribute("search.jsp-highlightEnabled", queryConfig.isHighlightEnabled());
+request.setAttribute("search.jsp-hits", hits);
 request.setAttribute("search.jsp-queryTerms", queryTerms);
 
 boolean showMenu = advancedConfiguration || displayScopeFacet || displayAssetTypeFacet || displayAssetTagsFacet || displayAssetCategoriesFacet || displayFolderFacet || displayUserFacet || displayModifiedRangeFacet;


### PR DESCRIPTION
Hey Hugo,

Really not sure about this one due to:
1. Performance
2. Allowing users to search by a deleted user

It kind of makes sense to allow 2 since if you click on the asset itself, it'll show the deleted user's name, but it still seems strange to me. Let me know your thoughts.

Thanks.
