### PR TITLE
LPS-43773

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -80,6 +80,7 @@ import com.liferay.portlet.documentlibrary.InvalidFileVersionException;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryMetadataException;
 import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
+import com.liferay.portlet.documentlibrary.action.EditFileEntryAction;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryMetadata;
@@ -159,6 +160,12 @@ public class DLFileEntryLocalServiceImpl
 			else {
 				title = sourceFileName;
 			}
+		}
+
+		int pos = sourceFileName.indexOf(EditFileEntryAction.TEMP_RANDOM_SUFFIX);
+
+		if (pos != -1) {
+			sourceFileName = sourceFileName.substring(0, pos);
 		}
 
 		// File entry


### PR DESCRIPTION
Hey Hugo,

This should be it. The sourceFileName and the extension are used to confirm that the filename/extension pass the validation checks. The extension comes from the sourceFileName so we only need to strip out the random suffix once. I left the title alone because we need that to contain the random suffix or else uploading multiple files with the same name will be broken again. Let me know if you have any questions.

Thanks.
