### PR TITLE
LPS-47973 Assets name should not be capitalized in the sentence

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/notifications/BaseModelUserNotificationHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/notifications/BaseModelUserNotificationHandler.java
@@ -87,7 +87,8 @@ public abstract class BaseModelUserNotificationHandler
 				HtmlUtil.escape(
 					StringUtil.shorten(jsonObject.getString("entryTitle")),
 					50),
-				getTitle(jsonObject, assetRenderer, serviceContext)
+				StringUtil.toLowerCase(
+					getTitle(jsonObject, assetRenderer, serviceContext))
 			});
 	}
 
@@ -132,7 +133,7 @@ public abstract class BaseModelUserNotificationHandler
 
 		return serviceContext.translate(
 			message, HtmlUtil.escape(assetRenderer.getUserName()),
-			StringUtil.toLowerCase(HtmlUtil.escape(typeName)));
+			HtmlUtil.escape(typeName));
 	}
 
 }


### PR DESCRIPTION
I made this change as the initial lowercase is too early. In the translate method if the type name matches the language key it will be capitalized again.
