### PR TITLE
LPS-48720 Anyone can't filter web content by own site's structure

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/action/ViewAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/ViewAction.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.journal.action;
 
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.struts.PortletAction;
 import com.liferay.portlet.journal.NoSuchFolderException;
@@ -45,7 +46,13 @@ public class ViewAction extends PortletAction {
 		throws Exception {
 
 		try {
-			ActionUtil.getArticle(renderRequest);
+			String strutsAction = ParamUtil.getString(
+				renderRequest, "struts_action");
+
+			if (strutsAction.equals("/journal/select_version")) {
+				ActionUtil.getArticle(renderRequest);
+			}
+
 			ActionUtil.getFolder(renderRequest);
 		}
 		catch (Exception e) {


### PR DESCRIPTION
Here is the description from Hai

The issue was caused by when click "Browse by Structure"->"Test structure", it will invoke ActionUtil.getArticle(renderRequest); in com.liferay.portlet.journal.action.ViewAction render().

In com.liferay.portlet.journal.action.ActionUtil.getArticle(HttpServletRequest request), the below code will throw exception:
// 215 line
article = JournalArticleServiceUtil.getArticle(ddmStructure.getGroupId(), DDMStructure.class.getName(), ddmStructure.getStructureId());

The purpose of ActionUtil.getArticle(renderRequest) setAttribute "WebKeys.JOURNAL_ARTICLE" and "WebKeys.JOURNAL_RECENT_ARTICLES". However, for the feature "Browse by Structure", ActionUtil.getArticle(renderRequest) is not necessary. The code was added in "LPS-46224 Uses "Compare to" to compare versions like in wiki". So it should match "struts_action=/journal/select_version".

Thanks,
Hai
