### PR TITLE
LPS-50327 Omin-admin can be modified by admins of other instances.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.model.User;
-import com.liferay.portal.security.auth.CompanyThreadLocal;
 import com.liferay.portal.service.RoleLocalServiceUtil;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalInstances;
@@ -57,12 +56,6 @@ public class OmniadminUtil {
 	}
 
 	public static boolean isOmniadmin(User user) {
-		if (CompanyThreadLocal.getCompanyId() !=
-				PortalInstances.getDefaultCompanyId()) {
-
-			return false;
-		}
-
 		long userId = user.getUserId();
 
 		if (userId <= 0) {


### PR DESCRIPTION
Hi Hugo

I sent this directly to you as you know its context.

According to the comments of Sam and Zsolt, see https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/2903588, "we should check the user's company ID and not the requests company ID when deciding if the user is omni admin,"

Thx for review.
