### PR TITLE
LPS-48609 DDMStructure Readonly attribute

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/alloy/text.ftl
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/alloy/text.ftl
@@ -1,11 +1,19 @@
 <#include "../init.ftl">
 
 <@aui["field-wrapper"] data=data>
-	<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName type="text" value=fieldValue>
-		<#if required>
-			<@aui.validator name="required" />
-		</#if>
-	</@aui.input>
+	<#if fieldStructure.readOnly?? && (fieldStructure.readOnly == "true")>
+		<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName readonly="readonly" type="text" value=fieldValue>
+			<#if required>
+				<@aui.validator name="required" />
+			</#if>
+		</@aui.input>
+	<#else>
+		<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName type="text" value=fieldValue>
+			<#if required>
+				<@aui.validator name="required" />
+			</#if>
+		</@aui.input>
+	</#if>
 
 	${fieldStructure.children}
 </@>

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/alloy/textarea.ftl
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/alloy/textarea.ftl
@@ -1,11 +1,19 @@
 <#include "../init.ftl">
 
 <@aui["field-wrapper"] data=data>
-	<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName type="textarea" value=fieldValue>
-		<#if required>
-			<@aui.validator name="required" />
-		</#if>
-	</@aui.input>
+	<#if fieldStructure.readOnly?? && (fieldStructure.readOnly == "true")>
+		<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName readonly="readonly" type="textarea" value=fieldValue>
+			<#if required>
+				<@aui.validator name="required" />
+			</#if>
+		</@aui.input>
+	<#else>
+		<@aui.input cssClass=cssClass dir=requestedLanguageDir helpMessage=escape(fieldStructure.tip) label=escape(label) name=namespacedFieldName type="textarea" value=fieldValue>
+			<#if required>
+				<@aui.validator name="required" />
+			</#if>
+		</@aui.input>
+	</#if>
 
 	${fieldStructure.children}
 </@>


### PR DESCRIPTION
The issue root is that we didn't define readOnly attribute in <input type="text"> and <textarea> label.

Refer to the below link:
input text: http://www.w3schools.com/jsref/dom_obj_text.asp
textarea: http://www.w3schools.com/tags/tag_textarea.asp

We should add the readOnly attribute in the two tags. For other tags, for example, <select> tag, it doesn't have this attribute (http://www.w3schools.com/tags/tag_select.asp).

For the readOnly attribute, we can't directly define it in tag. Because readOnly still be read-only (even though we set readOnly=false, the filed also is read-only) if the field have readOnly attribute.

Please help check it.

Thanks,
Hai
