### PR TITLE
LPS-51142 Web Content Configuration setting are all on the same line

### DIFF
--- a/portal-web/docroot/html/portlet/journal_content/configuration.jsp
+++ b/portal-web/docroot/html/portlet/journal_content/configuration.jsp
@@ -123,21 +123,19 @@ String ddmTemplateKey = journalContentDisplayContext.getDDMTemplateKey();
 			/>
 		</aui:field-wrapper>
 
-		<aui:field-wrapper>
-			<aui:input name="preferences--enablePrint--" type="checkbox" value="<%= journalContentDisplayContext.isEnablePrint() %>" />
+		<aui:input name="preferences--enablePrint--" type="checkbox" value="<%= journalContentDisplayContext.isEnablePrint() %>" />
 
-			<aui:input name="preferences--enableRelatedAssets--" type="checkbox" value="<%= journalContentDisplayContext.isEnableRelatedAssets() %>" />
+		<aui:input name="preferences--enableRelatedAssets--" type="checkbox" value="<%= journalContentDisplayContext.isEnableRelatedAssets() %>" />
 
-			<aui:input name="preferences--enableRatings--" type="checkbox" value="<%= journalContentDisplayContext.isEnableRatings() %>" />
+		<aui:input name="preferences--enableRatings--" type="checkbox" value="<%= journalContentDisplayContext.isEnableRatings() %>" />
 
-			<c:if test="<%= PropsValues.JOURNAL_ARTICLE_COMMENTS_ENABLED %>">
-				<aui:input name="preferences--enableComments--" type="checkbox" value="<%= journalContentDisplayContext.isEnableComments() %>" />
+		<c:if test="<%= PropsValues.JOURNAL_ARTICLE_COMMENTS_ENABLED %>">
+			<aui:input name="preferences--enableComments--" type="checkbox" value="<%= journalContentDisplayContext.isEnableComments() %>" />
 
-				<aui:input name="preferences--enableCommentRatings--" type="checkbox" value="<%= journalContentDisplayContext.isEnableCommentRatings() %>" />
-			</c:if>
+			<aui:input name="preferences--enableCommentRatings--" type="checkbox" value="<%= journalContentDisplayContext.isEnableCommentRatings() %>" />
+		</c:if>
 
-			<aui:input name="preferences--enableViewCountIncrement--" type="checkbox" value="<%= journalContentDisplayContext.isEnableViewCountIncrement() %>" />
-		</aui:field-wrapper>
+		<aui:input name="preferences--enableViewCountIncrement--" type="checkbox" value="<%= journalContentDisplayContext.isEnableViewCountIncrement() %>" />
 	</aui:fieldset>
 
 	<aui:button-row>


### PR DESCRIPTION
Hey Hugo.

A fix for https://issues.liferay.com/browse/LPS-51142.

The aui:field-wrapper will apply css display:inline-block which makes all the input in one line.

Just remove the aui:field-wrapper to make it following the configuration.jsp in other portlet.

Let me know if you have any concerns.

John.
