### PR TITLE
LPS-51686 doAsGroupId and referPlid do not require namespace. Appending namespace will make them unavailable in themeDisplay.

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -104,10 +104,10 @@ private String _getURL(long groupId, long plid, PortletURL addPortletURL, String
 
 	String addPortletURLString = addPortletURL.toString();
 
-	String namespace = PortalUtil.getPortletNamespace(portletId);
+	addPortletURLString = HttpUtil.addParameter(addPortletURLString, "doAsGroupId", groupId);
+	addPortletURLString = HttpUtil.addParameter(addPortletURLString, "refererPlid", plid);
 
-	addPortletURLString = HttpUtil.addParameter(addPortletURLString, namespace + "doAsGroupId", groupId);
-	addPortletURLString = HttpUtil.addParameter(addPortletURLString, namespace + "refererPlid", plid);
+	String namespace = PortalUtil.getPortletNamespace(portletId);
 
 	if (defaultAssetPublisher) {
 		addPortletURLString = HttpUtil.addParameter(addPortletURLString, namespace + "layoutUuid", layout.getUuid());


### PR DESCRIPTION
Hey Hugo 

LPS-51583 makes a regression bug: LPS-51686.

doAsGroupId and referPlid do not require namespace.

Appending namespace will make them unavailable in themeDisplay.

Please refer to initThemeDisplay() in ServicePreAction.java.  themeDisplay set them without namespace.

Sorry for regression bug.

Let me know if you have any concerns

John.
