### PR TITLE
XMLSourceProcessor

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/XMLSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/XMLSourceProcessor.java
@@ -89,9 +89,7 @@ public class XMLSourceProcessor extends BaseSourceProcessor {
 	protected void checkPoshiCharactersBeforeDefinition(
 		String fileName, String content) {
 
-		Matcher matcher = _poshiCharactersBeforeDefinitionTag.matcher(content);
-
-		if (matcher.find()) {
+		if (!content.startsWith("<definition")) {
 			processErrorMessage(
 				fileName,
 				"Characters found before definition element: " + fileName);


### PR DESCRIPTION
@lesliewong92
I'm trying to speed up the source formatter and I came across this in XMLSourceProcessor. Is there some reason we use a regex when it seems like String.startsWith() works? At least, nothing changes when I run ant format-source. My change reduces the runtime of XMLSourceProcessor by about 20%, so it'd be nice if this is valid.
