### PR TITLE
LPS-52399 Display 404 error page to users requesting a non existing file entry.

### DIFF
--- a/modules/portal/portal-servlet-jsp-compiler/src/com/liferay/portal/servlet/jsp/compiler/compiler/JspCompiler.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/com/liferay/portal/servlet/jsp/compiler/compiler/JspCompiler.java
@@ -348,7 +348,7 @@ public class JspCompiler extends Jsr199JavaCompiler {
 			int pos = file.indexOf("!/");
 
 			if (pos != -1) {
-				file.substring(0, pos);
+				file = file.substring(0, pos);
 			}
 
 			return new URI(file);

--- a/pmd-rulesets/java/standard-rules.xml
+++ b/pmd-rulesets/java/standard-rules.xml
@@ -41,7 +41,7 @@ Boolean.valueOf(false);
 		since="0.4"
 	>
 		<description>
-			[Origin rule set file rulesets/java/basic.xml] Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
+			[Origin rule set file rulesets/java/basic.xml] Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
 		</description>
 		<priority>3</priority>
 		<example><![CDATA[
@@ -76,6 +76,40 @@ public class Foo {
 
 	public int hashCode() {
 		return 0;
+	}
+
+}]]>
+		</example>
+	</rule>
+	<rule
+		class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOperationOnImmutableRule"
+		externalInfoUrl="http://pmd.sourceforge.net/snapshot/pmd-java/rules/java/unnecessary.html#UselessOperationOnImmutable"
+		message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
+		name="UselessOperationOnImmutable"
+		since="3.5">
+		<description>
+			[Origin rule set file rulesets/java/unnecessary.xml] An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself since the result of the operation is a new object. Therefore, ignoring the operation result is an error.
+		</description>
+		<priority>3</priority>
+		<example><![CDATA[
+import java.math.*;
+
+class Test {
+
+	void method1() {
+		BigDecimal bd = new BigDecimal(10);
+
+		// This will trigger the rule
+
+		bd.add(new BigDecimal(5));
+	}
+
+	void method2() {
+		BigDecimal bd = new BigDecimal(10);
+
+		// This won't trigger the rule
+
+		bd = bd.add(new BigDecimal(5));
 	}
 
 }]]>

--- a/pmd-rulesets/java/standard-rules.xml
+++ b/pmd-rulesets/java/standard-rules.xml
@@ -20,16 +20,17 @@
 			[Origin rule set file rulesets/java/basic.xml] Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf() instead.
 		</description>
 		<priority>2</priority>
-		<example><![CDATA[
+		<example>
+			<![CDATA[
 
-// Unnecessary creation, just reference Boolean.TRUE
+// Poor, unnecessary creation, just reference Boolean.TRUE
 
 new Boolean("true");
 
-// Unnecessary creation, just reference Boolean.FALSE
+// Poor, unnecessary creation, just reference Boolean.FALSE
 
 Boolean.valueOf(false);
-	]]>
+			]]>
 		</example>
 	</rule>
 	<rule
@@ -41,10 +42,11 @@ Boolean.valueOf(false);
 		since="0.4"
 	>
 		<description>
-			[Origin rule set file rulesets/java/basic.xml] Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
+			[Origin rule set file rulesets/java/basic.xml] Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither. Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
 		</description>
 		<priority>3</priority>
-		<example><![CDATA[
+		<example>
+			<![CDATA[
 
 // Poor, missing a hashcode() method
 
@@ -78,7 +80,8 @@ public class Foo {
 		return 0;
 	}
 
-}]]>
+}
+			]]>
 		</example>
 	</rule>
 	<rule
@@ -91,28 +94,19 @@ public class Foo {
 			[Origin rule set file rulesets/java/unnecessary.xml] An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself since the result of the operation is a new object. Therefore, ignoring the operation result is an error.
 		</description>
 		<priority>3</priority>
-		<example><![CDATA[
-import java.math.*;
+		<example>
+			<![CDATA[
 
-class Test {
+BigDecimal bigDecimal = new BigDecimal(10);
 
-	void method1() {
-		BigDecimal bd = new BigDecimal(10);
+// Poor, useless operation
 
-		// This will trigger the rule
+bigDecimal.add(new BigDecimal(5));
 
-		bd.add(new BigDecimal(5));
-	}
+// Perfect, useful operation
 
-	void method2() {
-		BigDecimal bd = new BigDecimal(10);
-
-		// This won't trigger the rule
-
-		bd = bd.add(new BigDecimal(5));
-	}
-
-}]]>
+bigDecimal = bigDecimal.add(new BigDecimal(5));
+			]]>
 		</example>
 	</rule>
 </ruleset>

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -197,6 +197,7 @@ import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
 import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.calendar.model.CalEvent;
 import com.liferay.portlet.documentlibrary.ImageSizeException;
+import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.expando.ValueDataException;
@@ -6832,6 +6833,12 @@ public class PortalImpl implements Portal {
 					PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND)) {
 
 			redirect = PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND;
+		}
+		else if ((e instanceof NoSuchFileEntryException) &&
+				 Validator.isNotNull(
+					PropsValues.DL_FILE_ENTRY_NOT_FOUND)) {
+
+			redirect = PropsValues.DL_FILE_ENTRY_NOT_FOUND;
 		}
 		else if (PropsValues.LAYOUT_SHOW_HTTP_STATUS) {
 			redirect = PATH_MAIN + "/portal/status";

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -596,6 +596,8 @@ public class PropsValues {
 
 	public static boolean DL_FILE_ENTRY_TYPE_IG_IMAGE_AUTO_CREATE_ON_UPGRADE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_TYPE_IG_IMAGE_AUTO_CREATE_ON_UPGRADE));
 
+	public static final String DL_FILE_ENTRY_NOT_FOUND = GetterUtil.getString(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_NOT_FOUND));
+
 	public static final int DL_FILE_ENTRY_VERSION_POLICY = GetterUtil.getInteger(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_VERSION_POLICY));
 
 	public static final String[] DL_FILE_EXTENSIONS = PropsUtil.getArray(PropsKeys.DL_FILE_EXTENSIONS);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -10163,6 +10163,15 @@
     dl.file.entry.type.ig.image.auto.create.on.upgrade=true
 
     #
+    # Redirect to this resource if the user requested a file entry that
+    # does not exist. Leave it blank to display nothing.
+    #
+    # A similar configuration for pages is managed with the property
+    # "layout.friendly.url.page.not.found".
+    #
+    #dl.file.entry.not.found=/html/portal/404.html
+
+    #
     # Set this to true if document library should be published to live by
     # default.
     #

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -679,6 +679,8 @@ public interface PropsKeys {
 
 	public static final String DL_FILE_ENTRY_LOCK_POLICY = "dl.file.entry.lock.policy";
 
+	public static final String DL_FILE_ENTRY_NOT_FOUND = "dl.file.entry.not.found";
+
 	public static final String DL_FILE_ENTRY_OPEN_IN_MS_OFFICE_MANUAL_CHECK_IN_REQUIRED = "dl.file.entry.open.in.ms.office.manual.check.in.required";
 
 	public static final String DL_FILE_ENTRY_PREVIEW_AUDIO = "dl.file.entry.preview.audio.";
@@ -746,8 +748,6 @@ public interface PropsKeys {
 	public static final String DL_FILE_ENTRY_THUMBNAIL_VIDEO_FRAME_PERCENTAGE = "dl.file.entry.thumbnail.video.frame.percentage";
 
 	public static final String DL_FILE_ENTRY_TYPE_IG_IMAGE_AUTO_CREATE_ON_UPGRADE = "dl.file.entry.type.ig.image.auto.create.on.upgrade";
-
-	public static final String DL_FILE_ENTRY_NOT_FOUND = "dl.file.entry.not.found";
 
 	public static final String DL_FILE_ENTRY_VERSION_POLICY = "dl.file.entry.version.policy";
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -747,6 +747,8 @@ public interface PropsKeys {
 
 	public static final String DL_FILE_ENTRY_TYPE_IG_IMAGE_AUTO_CREATE_ON_UPGRADE = "dl.file.entry.type.ig.image.auto.create.on.upgrade";
 
+	public static final String DL_FILE_ENTRY_NOT_FOUND = "dl.file.entry.not.found";
+
 	public static final String DL_FILE_ENTRY_VERSION_POLICY = "dl.file.entry.version.policy";
 
 	public static final String DL_FILE_EXTENSIONS = "dl.file.extensions";


### PR DESCRIPTION
Hey Hugo 

The attached is a fix for [LPS-52399](https://issues.liferay.com/browse/LPS-52399).

In [LPS-44899](https://issues.liferay.com/browse/LPS-44899), we added a new property to allow the end user to specify a 404 error page for non-existing site.

Similarly, one of our customer wants a 404 error page for non-existing file entry.

I am not sure if this feature should be added, so just pass it to engineer team to let them decide.

Thanks
John.
