### PR TITLE
LPS-52423  - While upgrading portal from 6.1.2 to 6.2, clicking on old calendar permissions throwing NullPointerException.

### DIFF
--- a/portal-impl/src/resource-actions/default.xml
+++ b/portal-impl/src/resource-actions/default.xml
@@ -7,7 +7,7 @@
 	<resource file="resource-actions/asset.xml" />
 	<resource file="resource-actions/blogs.xml" />
 	<resource file="resource-actions/breadcrumb.xml" />
-	<resource file="resource-actions/calendar.xml" />
+	<!--<resource file="resource-actions/calendar.xml" />-->
 	<resource file="resource-actions/cms.xml" />
 	<resource file="resource-actions/documentlibrary.xml" />
 	<resource file="resource-actions/dynamicdatalists.xml" />


### PR DESCRIPTION
Hi Hugo,

According to LPS-52423 #6,

I have confirmed that we should not remove the "calendar.xml" in the folder of "custom-sql", because it will the verifying process will check the customer SQL,but we can remove the "calendar.xml"  in the folder of "resource-actions". 

I have tested the LPP issue and the issue caused by previous commit.

David.