### PR TITLE
LPS-53717 & LPS-53718 

### DIFF
--- a/portal-web/docroot/html/taglib/ui/breadcrumb/breadcrumb.jspf
+++ b/portal-web/docroot/html/taglib/ui/breadcrumb/breadcrumb.jspf
@@ -49,7 +49,7 @@ for (int i = 0; i < breadcrumbEntries.size(); i++) {
 %>
 
 	<li class="<%= cssClass %>">
-		<aui:a data="<%= breadcrumbEntry.getData() %>" href="<%= HtmlUtil.escape(breadcrumbEntry.getURL()) %>" label="<%= HtmlUtil.escape(breadcrumbEntry.getTitle()) %>" />
+		<aui:a data="<%= breadcrumbEntry.getData() %>" href="<%= breadcrumbEntry.getURL() %>" label="<%= HtmlUtil.escape(breadcrumbEntry.getTitle()) %>" />
 	</li>
 
 <%

--- a/portal-web/docroot/html/taglib/ui/breadcrumb/breadcrumb.jspf
+++ b/portal-web/docroot/html/taglib/ui/breadcrumb/breadcrumb.jspf
@@ -41,10 +41,9 @@ for (int i = 0; i < breadcrumbEntries.size(); i++) {
 		}
 		else if (i == (breadcrumbEntries.size() - 1)) {
 			cssClass = "active last" + breadcrumbTruncateClass;
-
-			if (breadcrumbTruncate) {
-				cssClass += " current-parent";
-			}
+		}
+		else if (i == (breadcrumbEntries.size() - 2)) {
+			cssClass = "current-parent" + breadcrumbTruncateClass;
 		}
 	}
 %>


### PR DESCRIPTION
Hey Hugo.

Happy Chinese new year :)

When I was trying to fix LPS-53626, see https://github.com/daledotshan/liferay-portal/pull/206, I was being blocked by these two LPS as I cannot tested my fix for LPS-53626.

So I have to fix them at first.

In brief, they are caused by LPS-53579, see the change https://github.com/brianchandotcom/liferay-portal/compare/c3e038e69e...7e39cb9951#diff-5c3b4c5636c94bbb4d29ac85873e1998.

I changed the logic a little bit even though LPS-53579 didn't follow the original logic strictly.

We need have at least three nodes in breadcrumb in order to allow users to go backwards in breadcrumb no matter if the breadcrumb truncated.

The first node is always the Home, the last node is current selected folder and the second last node is its parent.

Please help reviewing 

Thanks
John.