### PR TITLE
LPS-54140 Image in Blog portlet gets overflowed.

### DIFF
--- a/portal-web/docroot/html/portlet/blogs/css/common_main.css
+++ b/portal-web/docroot/html/portlet/blogs/css/common_main.css
@@ -7,6 +7,7 @@
 
 	.entry-body {
 		font-size: 18px;
+		overflow: auto;
 
 		h1 {
 			font-size: 22px;


### PR DESCRIPTION
Hey Hugo 

This is a fix for LPS-54140.

It also affects branch 6.2.x, but it should be solved by back porting one commit in LPS-51699.

See https://github.com/liferay/liferay-portal-ee/compare/fix-pack-base-6210-sp10...fix-pack-fix-4708215.

So this fix is just for the regression bug in trunk. (Because the trunk use different aui css.)

Please help reviewing

Thanks
John.
