### PR TITLE
Remove unneeded fully qualified class names

### DIFF
--- a/portal-impl/src/com/liferay/portal/scripting/ruby/RubyExecutor.java
+++ b/portal-impl/src/com/liferay/portal/scripting/ruby/RubyExecutor.java
@@ -140,6 +140,10 @@ public class RubyExecutor extends BaseScriptingExecutor {
 		_scriptingContainer.setCurrentDirectory(_basePath);
 	}
 
+	public void destroy() {
+		_scriptingContainer.terminate();
+	}
+
 	@Override
 	public Map<String, Object> eval(
 			Set<String> allowedClasses, Map<String, Object> inputObjects,

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1884,6 +1884,38 @@ public class ServiceBuilder {
 		}
 	}
 
+	private void _checkForUnnecessaryFullyQualifiedClassNames(
+		String filePath, String content) throws IOException {
+
+		JavaClass finalJavaClass = _getJavaClass(filePath);
+
+		if (_containsUnnecessaryFullyQualifiedClassNames(finalJavaClass)) {
+			content = _removeUnnecessaryFullyQualifiedClassNames(
+				finalJavaClass, content);
+
+			writeFile(new File(filePath), content, _author);
+		}
+	}
+
+	private boolean _containsUnnecessaryFullyQualifiedClassNames(
+		JavaClass javaClass) throws IOException {
+
+		JavaSource javaSource = javaClass.getSource();
+		String[] javaImports = javaSource.getImports();
+
+		for (String importToExclude : javaImports) {
+			String content = javaSource.toString();
+			int pos = content.indexOf(importToExclude);
+			int secondPos = content.indexOf(importToExclude, pos + 1);
+
+			if (secondPos != -1) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private void _createActionableDynamicQuery(Entity entity) throws Exception {
 		if (_osgiModule) {
 			return;
@@ -2084,10 +2116,14 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File modelFile = new File(
-			_serviceOutputPath + "/model/" + entity.getName() + ".java");
+		String modelFilePath = _serviceOutputPath + "/model/" +
+			entity.getName() + ".java";
+
+		File modelFile = new File(modelFilePath);
 
 		writeFile(modelFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(modelFilePath, content);
 	}
 
 	private void _createExtendedModelBaseImpl(Entity entity) throws Exception {
@@ -2516,10 +2552,14 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File modelFile = new File(
-			_serviceOutputPath + "/model/" + entity.getName() + "Wrapper.java");
+		String modelFilePath = _serviceOutputPath + "/model/" +
+			entity.getName() + "Wrapper.java";
+
+		File modelFile = new File(modelFilePath);
 
 		writeFile(modelFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(modelFilePath, content);
 	}
 
 	private void _createPersistence(Entity entity) throws Exception {
@@ -2538,11 +2578,14 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_serviceOutputPath + "/service/persistence/" + entity.getName() +
-				"Persistence.java");
+		String ejbFilePath = _serviceOutputPath + "/service/persistence/" +
+			entity.getName() + "Persistence.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createPersistenceImpl(Entity entity) throws Exception {
@@ -2622,11 +2665,14 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_serviceOutputPath + "/service/persistence/" + entity.getName() +
-				"Util.java");
+		String ejbFilePath = _serviceOutputPath + "/service/persistence/" +
+			entity.getName() + "Util.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createPool(Entity entity) {
@@ -2835,11 +2881,15 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_serviceOutputPath + "/service/" + entity.getName() +
-				_getSessionTypeName(sessionType) + "Service.java");
+		String ejbFilePath = _serviceOutputPath + "/service/" +
+			entity.getName() + _getSessionTypeName(sessionType) +
+			"Service.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createServiceBaseImpl(Entity entity, int sessionType)
@@ -3141,11 +3191,14 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_outputPath + "/service/http/" + entity.getName() +
-				"ServiceSoap.java");
+		String ejbFilePath = _outputPath + "/service/http/" + entity.getName() +
+			"ServiceSoap.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createServiceUtil(Entity entity, int sessionType)
@@ -3169,11 +3222,15 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_serviceOutputPath + "/service/" + entity.getName() +
-				_getSessionTypeName(sessionType) + "ServiceUtil.java");
+		String ejbFilePath = _serviceOutputPath + "/service/" +
+			entity.getName() + _getSessionTypeName(sessionType) +
+			"ServiceUtil.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createServiceWrapper(Entity entity, int sessionType)
@@ -3197,11 +3254,15 @@ public class ServiceBuilder {
 
 		// Write file
 
-		File ejbFile = new File(
-			_serviceOutputPath + "/service/" + entity.getName() +
-				_getSessionTypeName(sessionType) + "ServiceWrapper.java");
+		String ejbFilePath = _serviceOutputPath + "/service/" +
+			entity.getName() + _getSessionTypeName(sessionType) +
+			"ServiceWrapper.java";
+
+		File ejbFile = new File(ejbFilePath);
 
 		writeFile(ejbFile, content, _author);
+
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
 	}
 
 	private void _createSpringXml() throws Exception {
@@ -5139,6 +5200,34 @@ public class ServiceBuilder {
 		FileUtil.delete(
 			_serviceOutputPath + "/service/" + entity.getName() +
 				_getSessionTypeName(sessionType) + "ServiceWrapper.java");
+	}
+
+	private String _removeUnnecessaryFullyQualifiedClassNames(
+		JavaClass javaClass, String content) {
+
+		JavaSource javaSource = javaClass.getSource();
+		String[] javaImports = javaSource.getImports();
+
+		for (String importToExclude : javaImports) {
+			int fromIndex = 0;
+			int pos = content.indexOf(importToExclude, fromIndex);
+
+			for (; pos > -1; pos = content.indexOf(importToExclude, fromIndex)) {
+				int endPos = pos + importToExclude.length();
+				String charAfter = content.substring(endPos, endPos + 1);
+
+				if (content.length() > endPos && !charAfter.matches("[a-zA-Z;]")) {
+					String className = importToExclude.substring(
+						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
+
+					content = StringUtil.replace(
+						content, importToExclude, className, pos);
+				}
+					fromIndex = pos + importToExclude.length();
+			}
+		}
+
+		return content;
 	}
 
 	private void _resolveEntity(Entity entity) throws Exception {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -520,11 +520,7 @@ public class ServiceBuilder {
 		if (!file.exists() || !FileUtil.isSameContent(file, content)) {
 			FileUtil.write(file, content);
 
-			if (_outputMessagePrinted == false) {
-				System.out.println("Writing " + file);
-
-				_outputMessagePrinted = true;
-			}
+			System.out.println("Writing " + file);
 		}
 	}
 
@@ -1899,8 +1895,6 @@ public class ServiceBuilder {
 
 			writeFile(new File(filePath), content, _author);
 		}
-
-		_outputMessagePrinted = false;
 	}
 
 	private boolean _containsUnnecessaryFullyQualifiedClassNames(
@@ -5281,7 +5275,6 @@ public class ServiceBuilder {
 	private static Pattern _getterPattern = Pattern.compile(
 		"public .* get.*" + Pattern.quote("(") + "|public boolean is.*" +
 			Pattern.quote("("));
-	private static boolean _outputMessagePrinted = false;
 	private static Pattern _setterPattern = Pattern.compile(
 		"public void set.*" + Pattern.quote("("));
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1885,7 +1885,8 @@ public class ServiceBuilder {
 	}
 
 	private void _checkForUnnecessaryFullyQualifiedClassNames(
-		String filePath, String content) throws IOException {
+			String filePath, String content)
+		throws IOException {
 
 		JavaClass finalJavaClass = _getJavaClass(filePath);
 
@@ -1898,7 +1899,8 @@ public class ServiceBuilder {
 	}
 
 	private boolean _containsUnnecessaryFullyQualifiedClassNames(
-		JavaClass javaClass) throws IOException {
+			JavaClass javaClass)
+		throws IOException {
 
 		JavaSource javaSource = javaClass.getSource();
 		String[] javaImports = javaSource.getImports();
@@ -2116,8 +2118,8 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String modelFilePath = _serviceOutputPath + "/model/" +
-			entity.getName() + ".java";
+		String modelFilePath =
+			_serviceOutputPath + "/model/" + entity.getName() + ".java";
 
 		File modelFile = new File(modelFilePath);
 
@@ -2552,8 +2554,8 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String modelFilePath = _serviceOutputPath + "/model/" +
-			entity.getName() + "Wrapper.java";
+		String modelFilePath =
+			_serviceOutputPath + "/model/" + entity.getName() + "Wrapper.java";
 
 		File modelFile = new File(modelFilePath);
 
@@ -2578,8 +2580,9 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _serviceOutputPath + "/service/persistence/" +
-			entity.getName() + "Persistence.java";
+		String ejbFilePath =
+			_serviceOutputPath + "/service/persistence/" + entity.getName() +
+			"Persistence.java";
 
 		File ejbFile = new File(ejbFilePath);
 
@@ -2665,8 +2668,9 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _serviceOutputPath + "/service/persistence/" +
-			entity.getName() + "Util.java";
+		String ejbFilePath =
+			_serviceOutputPath + "/service/persistence/" + entity.getName() +
+			"Util.java";
 
 		File ejbFile = new File(ejbFilePath);
 
@@ -2881,9 +2885,9 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _serviceOutputPath + "/service/" +
-			entity.getName() + _getSessionTypeName(sessionType) +
-			"Service.java";
+		String ejbFilePath =
+			_serviceOutputPath + "/service/" + entity.getName() +
+			_getSessionTypeName(sessionType) + "Service.java";
 
 		File ejbFile = new File(ejbFilePath);
 
@@ -3191,7 +3195,8 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _outputPath + "/service/http/" + entity.getName() +
+		String ejbFilePath =
+			_outputPath + "/service/http/" + entity.getName() +
 			"ServiceSoap.java";
 
 		File ejbFile = new File(ejbFilePath);
@@ -3222,9 +3227,9 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _serviceOutputPath + "/service/" +
-			entity.getName() + _getSessionTypeName(sessionType) +
-			"ServiceUtil.java";
+		String ejbFilePath =
+			_serviceOutputPath + "/service/" + entity.getName() +
+			_getSessionTypeName(sessionType) + "ServiceUtil.java";
 
 		File ejbFile = new File(ejbFilePath);
 
@@ -3254,9 +3259,9 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath = _serviceOutputPath + "/service/" +
-			entity.getName() + _getSessionTypeName(sessionType) +
-			"ServiceWrapper.java";
+		String ejbFilePath =
+			_serviceOutputPath + "/service/" + entity.getName() +
+			_getSessionTypeName(sessionType) + "ServiceWrapper.java";
 
 		File ejbFile = new File(ejbFilePath);
 
@@ -5216,14 +5221,17 @@ public class ServiceBuilder {
 				int endPos = pos + importToExclude.length();
 				String charAfter = content.substring(endPos, endPos + 1);
 
-				if (content.length() > endPos && !charAfter.matches("[a-zA-Z;]")) {
+				if ((content.length() > endPos) &&
+					!charAfter.matches("[a-zA-Z;]")) {
+
 					String className = importToExclude.substring(
 						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
 
 					content = StringUtil.replaceFirst(
 						content, importToExclude, className, pos);
 				}
-					fromIndex = pos + importToExclude.length();
+
+				fromIndex = pos + importToExclude.length();
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -522,6 +522,8 @@ public class ServiceBuilder {
 
 			if (_outputMessagePrinted == false) {
 				System.out.println("Writing " + file);
+
+				_outputMessagePrinted = true;
 			}
 		}
 	}
@@ -1890,8 +1892,6 @@ public class ServiceBuilder {
 		String filePath, String content) throws IOException {
 
 		JavaClass finalJavaClass = _getJavaClass(filePath);
-		
-		_outputMessagePrinted = true;
 
 		if (_containsUnnecessaryFullyQualifiedClassNames(finalJavaClass)) {
 			content = _removeUnnecessaryFullyQualifiedClassNames(
@@ -5226,7 +5226,7 @@ public class ServiceBuilder {
 					String className = importToExclude.substring(
 						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
 
-					content = StringUtil.replace(
+					content = StringUtil.replaceFirst(
 						content, importToExclude, className, pos);
 				}
 					fromIndex = pos + importToExclude.length();

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1885,16 +1885,16 @@ public class ServiceBuilder {
 	}
 
 	private void _checkForUnnecessaryFullyQualifiedClassNames(
-			String filePath, String content)
+			File file, String content)
 		throws IOException {
 
-		JavaClass finalJavaClass = _getJavaClass(filePath);
+		JavaClass finalJavaClass = _getJavaClass(file.getPath());
 
 		if (_containsUnnecessaryFullyQualifiedClassNames(finalJavaClass)) {
 			content = _removeUnnecessaryFullyQualifiedClassNames(
 				finalJavaClass, content);
 
-			writeFile(new File(filePath), content, _author);
+			writeFile(file, content, _author);
 		}
 	}
 
@@ -2118,14 +2118,12 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String modelFilePath =
-			_serviceOutputPath + "/model/" + entity.getName() + ".java";
-
-		File modelFile = new File(modelFilePath);
+		File modelFile = new File(
+			_serviceOutputPath + "/model/" + entity.getName() + ".java");
 
 		writeFile(modelFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(modelFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(modelFile, content);
 	}
 
 	private void _createExtendedModelBaseImpl(Entity entity) throws Exception {
@@ -2554,14 +2552,12 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String modelFilePath =
-			_serviceOutputPath + "/model/" + entity.getName() + "Wrapper.java";
-
-		File modelFile = new File(modelFilePath);
+		File modelFile = new File(
+			_serviceOutputPath + "/model/" + entity.getName() + "Wrapper.java");
 
 		writeFile(modelFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(modelFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(modelFile, content);
 	}
 
 	private void _createPersistence(Entity entity) throws Exception {
@@ -2580,15 +2576,13 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
+		File ejbFile = new File(
 			_serviceOutputPath + "/service/persistence/" + entity.getName() +
-			"Persistence.java";
-
-		File ejbFile = new File(ejbFilePath);
+				"Persistence.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createPersistenceImpl(Entity entity) throws Exception {
@@ -2668,15 +2662,13 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
+		File ejbFile = new File(
 			_serviceOutputPath + "/service/persistence/" + entity.getName() +
-			"Util.java";
-
-		File ejbFile = new File(ejbFilePath);
+				"Util.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createPool(Entity entity) {
@@ -2889,11 +2881,13 @@ public class ServiceBuilder {
 			_serviceOutputPath + "/service/" + entity.getName() +
 			_getSessionTypeName(sessionType) + "Service.java";
 
-		File ejbFile = new File(ejbFilePath);
+		File ejbFile = new File(
+			_serviceOutputPath + "/service/" + entity.getName() +
+				_getSessionTypeName(sessionType) + "Service.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceBaseImpl(Entity entity, int sessionType)
@@ -3195,15 +3189,13 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
+		File ejbFile = new File(
 			_outputPath + "/service/http/" + entity.getName() +
-			"ServiceSoap.java";
-
-		File ejbFile = new File(ejbFilePath);
+				"ServiceSoap.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceUtil(Entity entity, int sessionType)
@@ -3227,15 +3219,13 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
+		File ejbFile = new File(
 			_serviceOutputPath + "/service/" + entity.getName() +
-			_getSessionTypeName(sessionType) + "ServiceUtil.java";
-
-		File ejbFile = new File(ejbFilePath);
+				_getSessionTypeName(sessionType) + "ServiceUtil.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceWrapper(Entity entity, int sessionType)
@@ -3259,15 +3249,13 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
+		File ejbFile = new File(
 			_serviceOutputPath + "/service/" + entity.getName() +
-			_getSessionTypeName(sessionType) + "ServiceWrapper.java";
-
-		File ejbFile = new File(ejbFilePath);
+				_getSessionTypeName(sessionType) + "ServiceWrapper.java");
 
 		writeFile(ejbFile, content, _author);
 
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFilePath, content);
+		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createSpringXml() throws Exception {
@@ -4266,14 +4254,9 @@ public class ServiceBuilder {
 	}
 
 	private JavaClass _getJavaClass(String fileName) throws IOException {
-		int pos = fileName.indexOf(_implDir + "/");
+		fileName = StringUtil.replace(fileName, "\\", "/");
 
-		if (pos != -1) {
-			pos += _implDir.length();
-		}
-		else {
-			pos = fileName.indexOf(_apiDir + "/") + _apiDir.length();
-		}
+		int pos = fileName.lastIndexOf("/src/") + 4;
 
 		String srcFile = fileName.substring(pos + 1);
 		String className = StringUtil.replace(

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -2877,10 +2877,6 @@ public class ServiceBuilder {
 
 		// Write file
 
-		String ejbFilePath =
-			_serviceOutputPath + "/service/" + entity.getName() +
-			_getSessionTypeName(sessionType) + "Service.java";
-
 		File ejbFile = new File(
 			_serviceOutputPath + "/service/" + entity.getName() +
 				_getSessionTypeName(sessionType) + "Service.java");

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -520,7 +520,9 @@ public class ServiceBuilder {
 		if (!file.exists() || !FileUtil.isSameContent(file, content)) {
 			FileUtil.write(file, content);
 
-			System.out.println("Writing " + file);
+			if (_outputMessagePrinted == false) {
+				System.out.println("Writing " + file);
+			}
 		}
 	}
 
@@ -1888,6 +1890,8 @@ public class ServiceBuilder {
 		String filePath, String content) throws IOException {
 
 		JavaClass finalJavaClass = _getJavaClass(filePath);
+		
+		_outputMessagePrinted = true;
 
 		if (_containsUnnecessaryFullyQualifiedClassNames(finalJavaClass)) {
 			content = _removeUnnecessaryFullyQualifiedClassNames(
@@ -1895,6 +1899,8 @@ public class ServiceBuilder {
 
 			writeFile(new File(filePath), content, _author);
 		}
+
+		_outputMessagePrinted = false;
 	}
 
 	private boolean _containsUnnecessaryFullyQualifiedClassNames(
@@ -5275,6 +5281,7 @@ public class ServiceBuilder {
 	private static Pattern _getterPattern = Pattern.compile(
 		"public .* get.*" + Pattern.quote("(") + "|public boolean is.*" +
 			Pattern.quote("("));
+	private static boolean _outputMessagePrinted = false;
 	private static Pattern _setterPattern = Pattern.compile(
 		"public void set.*" + Pattern.quote("("));
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -408,6 +408,9 @@ public class ServiceBuilder {
 		content = JavaSourceProcessor.stripJavaImports(
 			content, packagePath, className);
 
+		content = JavaSourceProcessor._stripFullyQualifiedClassNames(
+			content, file);
+
 		File tempFile = new File("ServiceBuilder.temp");
 
 		FileUtil.write(tempFile, content);
@@ -1884,40 +1887,6 @@ public class ServiceBuilder {
 		}
 	}
 
-	private void _checkForUnnecessaryFullyQualifiedClassNames(
-			File file, String content)
-		throws IOException {
-
-		JavaClass finalJavaClass = _getJavaClass(file.getPath());
-
-		if (_containsUnnecessaryFullyQualifiedClassNames(finalJavaClass)) {
-			content = _removeUnnecessaryFullyQualifiedClassNames(
-				finalJavaClass, content);
-
-			writeFile(file, content, _author);
-		}
-	}
-
-	private boolean _containsUnnecessaryFullyQualifiedClassNames(
-			JavaClass javaClass)
-		throws IOException {
-
-		JavaSource javaSource = javaClass.getSource();
-		String[] javaImports = javaSource.getImports();
-
-		for (String importToExclude : javaImports) {
-			String content = javaSource.toString();
-			int pos = content.indexOf(importToExclude);
-			int secondPos = content.indexOf(importToExclude, pos + 1);
-
-			if (secondPos != -1) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	private void _createActionableDynamicQuery(Entity entity) throws Exception {
 		if (_osgiModule) {
 			return;
@@ -2122,8 +2091,6 @@ public class ServiceBuilder {
 			_serviceOutputPath + "/model/" + entity.getName() + ".java");
 
 		writeFile(modelFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(modelFile, content);
 	}
 
 	private void _createExtendedModelBaseImpl(Entity entity) throws Exception {
@@ -2556,8 +2523,6 @@ public class ServiceBuilder {
 			_serviceOutputPath + "/model/" + entity.getName() + "Wrapper.java");
 
 		writeFile(modelFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(modelFile, content);
 	}
 
 	private void _createPersistence(Entity entity) throws Exception {
@@ -2581,8 +2546,6 @@ public class ServiceBuilder {
 				"Persistence.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createPersistenceImpl(Entity entity) throws Exception {
@@ -2667,8 +2630,6 @@ public class ServiceBuilder {
 				"Util.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createPool(Entity entity) {
@@ -2882,8 +2843,6 @@ public class ServiceBuilder {
 				_getSessionTypeName(sessionType) + "Service.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceBaseImpl(Entity entity, int sessionType)
@@ -3190,8 +3149,6 @@ public class ServiceBuilder {
 				"ServiceSoap.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceUtil(Entity entity, int sessionType)
@@ -3220,8 +3177,6 @@ public class ServiceBuilder {
 				_getSessionTypeName(sessionType) + "ServiceUtil.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createServiceWrapper(Entity entity, int sessionType)
@@ -3250,8 +3205,6 @@ public class ServiceBuilder {
 				_getSessionTypeName(sessionType) + "ServiceWrapper.java");
 
 		writeFile(ejbFile, content, _author);
-
-		_checkForUnnecessaryFullyQualifiedClassNames(ejbFile, content);
 	}
 
 	private void _createSpringXml() throws Exception {
@@ -5183,37 +5136,6 @@ public class ServiceBuilder {
 		FileUtil.delete(
 			_serviceOutputPath + "/service/" + entity.getName() +
 				_getSessionTypeName(sessionType) + "ServiceWrapper.java");
-	}
-
-	private String _removeUnnecessaryFullyQualifiedClassNames(
-		JavaClass javaClass, String content) {
-
-		JavaSource javaSource = javaClass.getSource();
-		String[] javaImports = javaSource.getImports();
-
-		for (String importToExclude : javaImports) {
-			int fromIndex = 0;
-			int pos = content.indexOf(importToExclude, fromIndex);
-
-			for (; pos > -1; pos = content.indexOf(importToExclude, fromIndex)) {
-				int endPos = pos + importToExclude.length();
-				String charAfter = content.substring(endPos, endPos + 1);
-
-				if ((content.length() > endPos) &&
-					!charAfter.matches("[a-zA-Z;]")) {
-
-					String className = importToExclude.substring(
-						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
-
-					content = StringUtil.replaceFirst(
-						content, importToExclude, className, pos);
-				}
-
-				fromIndex = pos + importToExclude.length();
-			}
-		}
-
-		return content;
 	}
 
 	private void _resolveEntity(Entity entity) throws Exception {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4252,9 +4252,8 @@ public class ServiceBuilder {
 	private JavaClass _getJavaClass(String fileName) throws IOException {
 		fileName = StringUtil.replace(fileName, "\\", "/");
 
-		int pos = fileName.lastIndexOf("/src/") + 4;
+		String srcFile = fileName.substring(fileName.lastIndexOf("/src/") + 5);
 
-		String srcFile = fileName.substring(pos + 1);
 		String className = StringUtil.replace(
 			srcFile.substring(0, srcFile.length() - 5), "/", ".");
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4202,15 +4202,15 @@ public class ServiceBuilder {
 		return dimensions;
 	}
 
-	private JavaClass _getJavaClass(String fileName) throws IOException {
-		fileName = StringUtil.replace(fileName, "\\", "/");
+	private JavaClass _getJavaClass(String filePath) throws IOException {
+		filePath = StringUtil.replace(filePath, "\\", "/");
 
-		String srcFile = fileName.substring(fileName.lastIndexOf("/src/") + 5);
+		filePath = filePath.substring(filePath.lastIndexOf("/src/") + 5);
 
-		String className = StringUtil.replace(
-			srcFile.substring(0, srcFile.length() - 5), "/", ".");
+		String fullyQualifiedClassName = StringUtil.replace(
+			filePath.substring(0, filePath.length() - 5), "/", ".");
 
-		JavaClass javaClass = _javaClasses.get(className);
+		JavaClass javaClass = _javaClasses.get(fullyQualifiedClassName);
 
 		if (javaClass == null) {
 			ClassLibrary classLibrary = new ClassLibrary();
@@ -4219,7 +4219,7 @@ public class ServiceBuilder {
 
 			JavaDocBuilder builder = new JavaDocBuilder(classLibrary);
 
-			File file = new File(fileName);
+			File file = new File(filePath);
 
 			if (!file.exists()) {
 				return null;
@@ -4227,9 +4227,9 @@ public class ServiceBuilder {
 
 			builder.addSource(file);
 
-			javaClass = builder.getClassByName(className);
+			javaClass = builder.getClassByName(fullyQualifiedClassName);
 
-			_javaClasses.put(className, javaClass);
+			_javaClasses.put(fullyQualifiedClassName, javaClass);
 		}
 
 		return javaClass;

--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaSource;
 
 import java.io.File;
@@ -40,8 +41,60 @@ import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
+ * @author Cody Hoag
+ * @author James Hinkey
  */
 public class JavaSourceProcessor extends BaseSourceProcessor {
+
+	public static String _stripFullyQualifiedClassNames(
+			String content, File file)
+		throws IOException {
+
+		Matcher matcher = _importsPattern.matcher(content);
+
+		if (!matcher.find()) {
+			return content;
+		}
+
+		String filePath = StringUtil.replace(file.getCanonicalPath(), "\\", "/");
+
+		filePath = filePath.substring(filePath.lastIndexOf("/src/") + 5);
+
+		String fullyQualifiedClassName = StringUtil.replace(
+			filePath.substring(0, filePath.length() - 5), "/", ".");
+
+		JavaDocBuilder javadocBuilder = new JavaDocBuilder();
+		javadocBuilder.addSource(new UnsyncStringReader(content));
+
+		JavaClass javaClass = javadocBuilder.getClassByName(fullyQualifiedClassName);
+		JavaSource javaSource = javaClass.getSource();
+		String[] imports = javaSource.getImports();
+
+		for (String importToExclude : imports) {
+			int fromIndex = 0;
+			int pos = content.indexOf(importToExclude, fromIndex);
+
+			for (; pos > -1; pos = content.indexOf(importToExclude, fromIndex))
+			{
+				int endPos = pos + importToExclude.length();
+				String charAfter = content.substring(endPos, endPos + 1);
+
+				if ((content.length() > endPos) &&
+					!charAfter.matches("[a-zA-Z;]")) {
+
+					String importClassName = importToExclude.substring(
+						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
+
+					content = StringUtil.replaceFirst(
+						content, importToExclude, importClassName, pos);
+				}
+
+				fromIndex = pos + importToExclude.length();
+			}
+		}
+
+		return content;
+	}
 
 	public static String stripJavaImports(
 			String content, String packageDir, String className)

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2839,6 +2839,7 @@ public class PortalImpl implements Portal {
 
 		actualParams.put(
 			namespace + "type", new String[] {assetRendererFactory.getType()});
+
 		actualParams.put(
 			namespace + "urlTitle",
 			new String[] {journalArticle.getUrlTitle()});

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -194,6 +194,8 @@ import com.liferay.portlet.RenderResponseImpl;
 import com.liferay.portlet.StateAwareResponseImpl;
 import com.liferay.portlet.UserAttributes;
 import com.liferay.portlet.admin.util.OmniadminUtil;
+import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
+import com.liferay.portlet.asset.model.AssetRendererFactory;
 import com.liferay.portlet.asset.model.AssetTag;
 import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
 import com.liferay.portlet.blogs.model.BlogsEntry;
@@ -205,7 +207,6 @@ import com.liferay.portlet.expando.ValueDataException;
 import com.liferay.portlet.expando.model.ExpandoBridge;
 import com.liferay.portlet.expando.model.ExpandoColumnConstants;
 import com.liferay.portlet.journal.NoSuchFeedException;
-import com.liferay.portlet.journal.asset.JournalArticleAssetRendererFactory;
 import com.liferay.portlet.journal.model.JournalArticle;
 import com.liferay.portlet.journal.model.JournalArticleConstants;
 import com.liferay.portlet.journal.model.JournalFolder;
@@ -2831,9 +2832,13 @@ public class PortalImpl implements Portal {
 
 		actualParams.put(
 			namespace + "mvcPath", new String[] {"/view_content.jsp"});
+
+		AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				JournalArticle.class.getName());
+
 		actualParams.put(
-			namespace + "type",
-			new String[] {JournalArticleAssetRendererFactory.TYPE});
+			namespace + "type", new String[] {assetRendererFactory.getType()});
 		actualParams.put(
 			namespace + "urlTitle",
 			new String[] {journalArticle.getUrlTitle()});

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6249,7 +6249,7 @@ public class JournalArticleLocalServiceImpl
 		for (Node imageNode : imageNodes) {
 			Element imageEl = (Element)imageNode;
 
-			String instanceId = imageEl.attributeValue("instance-id");
+			String elInstanceId = imageEl.attributeValue("instance-id");
 			String elName = imageEl.attributeValue("name");
 			String elIndex = imageEl.attributeValue("index");
 
@@ -6272,7 +6272,7 @@ public class JournalArticleLocalServiceImpl
 
 				imageId = journalArticleImageLocalService.getArticleImageId(
 					newArticle.getGroupId(), newArticle.getArticleId(),
-					newArticle.getVersion(), instanceId, name, languageId);
+					newArticle.getVersion(), elInstanceId, name, languageId);
 
 				imageLocalService.updateImage(imageId, oldImage.getTextObj());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6253,7 +6253,7 @@ public class JournalArticleLocalServiceImpl
 			String elName = imageEl.attributeValue("name");
 			String elIndex = imageEl.attributeValue("index");
 
-			String name = elName + "_" + elIndex;
+			String name = elName + StringPool.UNDERLINE + elIndex;
 
 			List<Element> dynamicContentEls = imageEl.elements(
 				"dynamic-content");
@@ -6346,7 +6346,7 @@ public class JournalArticleLocalServiceImpl
 				String elIndex = element.attributeValue(
 					"index", StringPool.BLANK);
 
-				String name = elName + "_" + elIndex;
+				String name = elName + StringPool.UNDERLINE + elIndex;
 
 				formatImage(
 					groupId, articleId, version, incrementVersion, element,

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6250,7 +6250,10 @@ public class JournalArticleLocalServiceImpl
 			Element imageEl = (Element)imageNode;
 
 			String instanceId = imageEl.attributeValue("instance-id");
-			String name = imageEl.attributeValue("name");
+			String elName = imageEl.attributeValue("name");
+			String elIndex = imageEl.attributeValue("index");
+
+			String name = elName + "_" + elIndex;
 
 			List<Element> dynamicContentEls = imageEl.elements(
 				"dynamic-content");

--- a/portal-impl/src/com/liferay/portlet/journal/trash/JournalArticleTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/trash/JournalArticleTrashHandler.java
@@ -24,9 +24,10 @@ import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
+import com.liferay.portlet.asset.model.AssetRendererFactory;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil;
-import com.liferay.portlet.journal.asset.JournalArticleAssetRenderer;
 import com.liferay.portlet.journal.model.JournalArticle;
 import com.liferay.portlet.journal.model.JournalArticleResource;
 import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
@@ -146,10 +147,15 @@ public class JournalArticleTrashHandler extends JournalBaseTrashHandler {
 
 	@Override
 	public TrashRenderer getTrashRenderer(long classPK) throws PortalException {
+		AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				JournalArticle.class.getName());
+
 		JournalArticle article =
 			JournalArticleLocalServiceUtil.getLatestArticle(classPK);
 
-		return new JournalArticleAssetRenderer(article);
+		return (TrashRenderer)assetRendererFactory.getAssetRenderer(
+			article.getId());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/trash/JournalFolderTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/trash/JournalFolderTrashHandler.java
@@ -22,8 +22,9 @@ import com.liferay.portal.model.ContainerModel;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
+import com.liferay.portlet.asset.model.AssetRendererFactory;
 import com.liferay.portlet.journal.InvalidDDMStructureException;
-import com.liferay.portlet.journal.asset.JournalFolderAssetRenderer;
 import com.liferay.portlet.journal.model.JournalFolder;
 import com.liferay.portlet.journal.model.JournalFolderConstants;
 import com.liferay.portlet.journal.service.JournalFolderLocalServiceUtil;
@@ -134,9 +135,11 @@ public class JournalFolderTrashHandler extends JournalBaseTrashHandler {
 
 	@Override
 	public TrashRenderer getTrashRenderer(long classPK) throws PortalException {
-		JournalFolder folder = JournalFolderLocalServiceUtil.getFolder(classPK);
+		AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				JournalFolder.class.getName());
 
-		return new JournalFolderAssetRenderer(folder);
+		return (TrashRenderer)assetRendererFactory.getAssetRenderer(classPK);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationFactory.java
@@ -161,10 +161,19 @@ public class ExportImportConfigurationFactory {
 			PortletDataHandlerKeys.LOGO,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION,
+			new String[] {Boolean.TRUE.toString()});
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION_ALL,
+			new String[] {Boolean.TRUE.toString()});
+		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_DATA,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.TRUE.toString()});
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
 			ExportImportDateUtil.RANGE,


### PR DESCRIPTION
Hi Hugo,

These commits improve the ServiceBuilder so that it strips out all unnecessary fully qualified class names.

It also cleans up the ServiceBuilder._getJavaClass method introducing clearer param/variable names and adding more robust handling of path separators.

cc/ @codyhoag