### PR TITLE
Strip unneeded fully qualified class names

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4248,16 +4248,9 @@ public class ServiceBuilder {
 	}
 
 	private JavaClass _getJavaClass(String fileName) throws IOException {
-		int pos = fileName.indexOf(_implDir + "/");
+		fileName = StringUtil.replace(fileName, "\\", "/");
 
-		if (pos != -1) {
-			pos += _implDir.length();
-		}
-		else {
-			pos = fileName.indexOf(_apiDir + "/") + _apiDir.length();
-		}
-
-		String srcFile = fileName.substring(pos + 1);
+		String srcFile = fileName.substring(fileName.lastIndexOf("/src/") + 5);
 		String className = StringUtil.replace(
 			srcFile.substring(0, srcFile.length() - 5), "/", ".");
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -408,7 +408,7 @@ public class ServiceBuilder {
 		content = JavaSourceProcessor.stripJavaImports(
 			content, packagePath, className);
 
-		content = JavaSourceProcessor._stripFullyQualifiedClassNames(
+		content = JavaSourceProcessor.stripFullyQualifiedClassNames(
 			content, file);
 
 		File tempFile = new File("ServiceBuilder.temp");
@@ -4202,15 +4202,15 @@ public class ServiceBuilder {
 		return dimensions;
 	}
 
-	private JavaClass _getJavaClass(String fileName) throws IOException {
-		fileName = StringUtil.replace(fileName, "\\", "/");
+	private JavaClass _getJavaClass(String filePath) throws IOException {
+		filePath = StringUtil.replace(filePath, "\\", "/");
 
-		String srcFile = fileName.substring(fileName.lastIndexOf("/src/") + 5);
+		String srcFile = filePath.substring(filePath.lastIndexOf("/src/") + 5);
 
-		String className = StringUtil.replace(
+		String fullyQualifiedClassName = StringUtil.replace(
 			srcFile.substring(0, srcFile.length() - 5), "/", ".");
 
-		JavaClass javaClass = _javaClasses.get(className);
+		JavaClass javaClass = _javaClasses.get(fullyQualifiedClassName);
 
 		if (javaClass == null) {
 			ClassLibrary classLibrary = new ClassLibrary();
@@ -4219,7 +4219,7 @@ public class ServiceBuilder {
 
 			JavaDocBuilder builder = new JavaDocBuilder(classLibrary);
 
-			File file = new File(fileName);
+			File file = new File(filePath);
 
 			if (!file.exists()) {
 				return null;
@@ -4227,9 +4227,9 @@ public class ServiceBuilder {
 
 			builder.addSource(file);
 
-			javaClass = builder.getClassByName(className);
+			javaClass = builder.getClassByName(fullyQualifiedClassName);
 
-			_javaClasses.put(className, javaClass);
+			_javaClasses.put(fullyQualifiedClassName, javaClass);
 		}
 
 		return javaClass;

--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
  */
 public class JavaSourceProcessor extends BaseSourceProcessor {
 
-	public static String _stripFullyQualifiedClassNames(
+	public static String stripFullyQualifiedClassNames(
 			String content, File file)
 		throws IOException {
 
@@ -56,7 +56,8 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 			return content;
 		}
 
-		String filePath = StringUtil.replace(file.getCanonicalPath(), "\\", "/");
+		String filePath = StringUtil.replace(
+			file.getCanonicalPath(), "\\", "/");
 
 		filePath = filePath.substring(filePath.lastIndexOf("/src/") + 5);
 
@@ -66,7 +67,9 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 		JavaDocBuilder javadocBuilder = new JavaDocBuilder();
 		javadocBuilder.addSource(new UnsyncStringReader(content));
 
-		JavaClass javaClass = javadocBuilder.getClassByName(fullyQualifiedClassName);
+		JavaClass javaClass = javadocBuilder.getClassByName(
+			fullyQualifiedClassName);
+
 		JavaSource javaSource = javaClass.getSource();
 		String[] imports = javaSource.getImports();
 

--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
@@ -96,7 +96,7 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 						content, importToExclude, importClassName, pos);
 				}
 
-				fromIndex = pos + importToExclude.length();
+				fromIndex = pos + 1;
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
@@ -79,8 +79,15 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 				int endPos = pos + importToExclude.length();
 				String charAfter = content.substring(endPos, endPos + 1);
 
+				String charBefore = StringPool.BLANK;
+
+				if (pos > 0) {
+					charBefore = content.substring(pos - 1, pos);
+				}
+
 				if ((content.length() > endPos) &&
-					!charAfter.matches("[a-zA-Z;]")) {
+					!charAfter.matches("[a-zA-Z;\"]") &&
+					!charBefore.matches("[\"]")) {
 
 					String importClassName = importToExclude.substring(
 						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);

--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaSourceProcessor.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaSource;
 
 import java.io.File;
@@ -40,8 +41,60 @@ import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
+ * @author Cody Hoag
+ * @author James Hinkey
  */
 public class JavaSourceProcessor extends BaseSourceProcessor {
+
+	public static String _stripFullyQualifiedClassNames(
+			String content, File file)
+		throws IOException {
+
+		Matcher matcher = _importsPattern.matcher(content);
+
+		if (!matcher.find()) {
+			return content;
+		}
+
+		String filePath = StringUtil.replace(file.getCanonicalPath(), "\\", "/");
+
+		filePath = filePath.substring(filePath.lastIndexOf("/src/") + 5);
+
+		String fullyQualifiedClassName = StringUtil.replace(
+			filePath.substring(0, filePath.length() - 5), "/", ".");
+
+		JavaDocBuilder javadocBuilder = new JavaDocBuilder();
+		javadocBuilder.addSource(new UnsyncStringReader(content));
+
+		JavaClass javaClass = javadocBuilder.getClassByName(fullyQualifiedClassName);
+		JavaSource javaSource = javaClass.getSource();
+		String[] imports = javaSource.getImports();
+
+		for (String importToExclude : imports) {
+			int fromIndex = 0;
+			int pos = content.indexOf(importToExclude, fromIndex);
+
+			for (; pos > -1; pos = content.indexOf(importToExclude, fromIndex))
+			{
+				int endPos = pos + importToExclude.length();
+				String charAfter = content.substring(endPos, endPos + 1);
+
+				if ((content.length() > endPos) &&
+					!charAfter.matches("[a-zA-Z;]")) {
+
+					String importClassName = importToExclude.substring(
+						importToExclude.lastIndexOf(StringPool.PERIOD) + 1);
+
+					content = StringUtil.replaceFirst(
+						content, importToExclude, importClassName, pos);
+				}
+
+				fromIndex = pos + importToExclude.length();
+			}
+		}
+
+		return content;
+	}
 
 	public static String stripJavaImports(
 			String content, String packageDir, String className)


### PR DESCRIPTION
Hey Hugo,

I spoke with @jhinkey about the logic regarding the preservation of the PersistenceImpl methods. We've decided we'll hold off on submitting this, for now. That specific logic fixed Javadoc-related issues only, and will be worked in with the upcoming Javadoc fixes we'll submit in the next few weeks.

Everything compiles successfully after building services, so the unneeded fully qualified class names in the actual code are stripped successfully.

Thanks!

