### PR TITLE
LPS-54100 Unable to start local staging when the site has a structure containing image fields.

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.TransientValue;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Image;
 import com.liferay.portal.model.LocalizedModel;
 import com.liferay.portal.model.StagedGroupedModel;
 import com.liferay.portal.model.StagedModel;
@@ -730,7 +731,8 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 
 			if (className.equals(AssetCategory.class.getName()) ||
 				className.equals(RatingsEntry.class.getName()) ||
-				className.equals(MBMessage.class.getName())) {
+				className.equals(MBMessage.class.getName()) ||
+				className.equals(Image.class.getName())) {
 
 				continue;
 			}


### PR DESCRIPTION
Hey Hugo 

This pr extends https://github.com/matethurzo/liferay-portal/pull/945#issuecomment-87664384.

Daniel fixed partially this issue of image not exported in this commit https://github.com/danielkocsis/liferay-portal/commit/aaae17877df1e6a644648720375c1b25e7e5332b.

But the issue is still there

In portlet-data.xml 
```
<reference class-name="com.liferay.portal.model.Image" class-pk="20513" path="/group/20182/com.liferay.portlet.journal.model.JournalArticle/20511/_Image1916_0_en_US" type="dependency"/></references>
```

We have image as reference.

But this image we do not need to be import as reference since we will import it when importing journal article.

See https://github.com/zxdgoal/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/journal/lar/JournalArticleStagedModelDataHandler.java#L390.

BTW, you can not test this pr now due to https://issues.liferay.com/browse/LPS-54678

I will fix LPS-54678 later.

Thanks
John.