### PR TITLE
LPS-54938 Content in quote requires wrapped by div.

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
@@ -691,17 +691,17 @@
 
 			var cite = token.attribute;
 
-			var result = '<blockquote>';
+			var result = '<blockquote><div>';
 
 			if (cite && cite.length) {
 				cite = BBCodeUtil.escape(cite);
 
-				result = '<blockquote><cite>' + cite + '</cite>';
+				result = '<blockquote><div><cite>' + cite + '</cite>';
 			}
 
 			instance._result.push(result);
 
-			instance._stack.push('</blockquote>');
+			instance._stack.push('</div></blockquote>');
 		},
 
 		_handleSimpleTag: function(tagName) {


### PR DESCRIPTION
Hey Hugo 

This is a fix for LPS-54938 (Ckeditor issue from our JP customer).

Some explanations:

When handling quote tag, we need to wrap the content by div.

In bbcode/plugin.js of Ckeditor repository, it dose this by 

```
			bbcodeFilter.addRules( {
				elements: {
					blockquote: function( element ) {
						var quoted = new CKEDITOR.htmlParser.element( 'div' );
						quoted.children = element.children;
						element.children = [ quoted ];
						var citeText = element.attributes.cite;
						if ( citeText ) {
							var cite = new CKEDITOR.htmlParser.element( 'cite' );
							cite.add( new CKEDITOR.htmlParser.text( citeText.replace( /^"|"$/g, '' ) ) );
							delete element.attributes.cite;
							element.children.unshift( cite );
						}
					}
```
Please refer to http://ckeditor.com/demo#bbcode to demostate that the content is wrapped by ``<div>`` after changing mode from source to rick edit.

I believe we need to follow this logic.

Thanks
John

/cc @blzaugg