### PR TITLE
LPS-55018 Indent is lost after switching to Source mode and back in CKEditor

### DIFF
--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_data_processor.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_data_processor.js
@@ -729,6 +729,18 @@
 			}
 		},
 
+		_handleStyleIndent: function(element, stylesTagsIn, stylesTagsOut) {
+			var style = element.style;
+
+			var marginLeft = style.marginLeft;
+
+			if (marginLeft) {
+				stylesTagsIn.push('[indent=', parseInt(marginLeft), ']');
+
+				stylesTagsOut.push('[/indent]');
+			}
+		},
+
 		_handleStyleItalic: function(element, stylesTagsIn, stylesTagsOut) {
 			var style = element.style;
 
@@ -755,6 +767,7 @@
 				instance._handleStyleColor(element, stylesTagsIn, stylesTagsOut);
 				instance._handleStyleFontFamily(element, stylesTagsIn, stylesTagsOut);
 				instance._handleStyleFontSize(element, stylesTagsIn, stylesTagsOut);
+				instance._handleStyleIndent(element, stylesTagsIn, stylesTagsOut);
 				instance._handleStyleItalic(element, stylesTagsIn, stylesTagsOut);
 				instance._handleStyleTextDecoration(element, stylesTagsIn, stylesTagsOut);
 			}

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
@@ -738,7 +738,7 @@
 				size = '1';
 			}
 
-			instance._result.push(STR_TAG_SPAN_STYLE_OPEN, 'font-size: ', instance._getFontSize(size), 'px', STR_TAG_ATTR_CLOSE);
+			instance._result.push(STR_TAG_SPAN_STYLE_OPEN, 'font-size: ', instance._getFontSize(size), 'px;', STR_TAG_ATTR_CLOSE);
 
 			instance._stack.push(STR_TAG_SPAN_CLOSE);
 		},

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
@@ -298,6 +298,7 @@
 		font: '_handleFont',
 		i: '_handleEm',
 		img: '_handleImage',
+		indent: '_handleIndent',
 		list: '_handleList',
 		s: '_handleStrikeThrough',
 		size: '_handleSize',
@@ -363,7 +364,7 @@
 
 	var REGEX_STRING_IS_NEW_LINE = /^\r?\n$/;
 
-	var REGEX_TAG_NAME = /^\/?(?:b|center|code|colou?r|email|i|img|justify|left|pre|q|quote|right|\*|s|size|table|tr|th|td|li|list|font|u|url)$/i;
+	var REGEX_TAG_NAME = /^\/?(?:b|center|code|colou?r|email|i|img|indent|justify|left|pre|q|quote|right|\*|s|size|table|tr|th|td|li|list|font|u|url)$/i;
 
 	var REGEX_URI = /^[-;\/\?:@&=\+\$,_\.!~\*'\(\)%0-9a-z#]{1,512}$|\${\S+}/i;
 
@@ -398,6 +399,8 @@
 	var STR_TAG_SPAN_CLOSE = '</span>';
 
 	var STR_TAG_SPAN_STYLE_OPEN = '<span style="';
+
+	var STR_TAG_DIV_STYLE_OPEN = '<div style="';
 
 	var STR_TAG_URL = 'url';
 
@@ -615,6 +618,14 @@
 			}
 
 			return attrs;
+		},
+
+		_handleIndent: function(token) {
+			var instance = this;
+
+			var indent = token.attribute;
+
+			instance._result.push(STR_TAG_DIV_STYLE_OPEN, 'margin-left: ', indent, 'px;', STR_TAG_ATTR_CLOSE);
 		},
 
 		_handleList: function(token) {

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/converter.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/converter.js
@@ -125,6 +125,8 @@
 
 	var STR_TAG_SPAN_STYLE_OPEN = '<span style="';
 
+	var STR_TAG_DIV_STYLE_OPEN = '<div style="';
+
 	var STR_TAG_URL = 'url';
 
 	var STR_TEXT_ALIGN = '<p style="text-align: ';
@@ -341,6 +343,14 @@
 			}
 
 			return attrs;
+		},
+
+		_handleIndent: function(token) {
+			var instance = this;
+
+			var indent = token.attribute;
+
+			instance._result.push(STR_TAG_DIV_STYLE_OPEN, 'margin-left: ', indent, 'px;', STR_TAG_ATTR_CLOSE);
 		},
 
 		_handleList: function(token) {

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/converter.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/editor/ckeditor_diffs/plugins/bbcode/converter.js
@@ -463,7 +463,7 @@
 				size = '1';
 			}
 
-			instance._result.push(STR_TAG_SPAN_STYLE_OPEN, 'font-size: ', instance._getFontSize(size), 'px', STR_TAG_ATTR_CLOSE);
+			instance._result.push(STR_TAG_SPAN_STYLE_OPEN, 'font-size: ', instance._getFontSize(size), 'px;', STR_TAG_ATTR_CLOSE);
 
 			instance._stack.push(STR_TAG_SPAN_CLOSE);
 		},


### PR DESCRIPTION
Hey Hugo

This is a fix for another issue about CKeditor.

Please help review.

There is a hidden bug my fix expose. not caused by my fix.

1. Apply my fix.
2. Type in something in editor.
3. Click on increase indent button.
4. Click on source button.
5. Click on source button again.
6. Note the decrease button is disabled (Should be enabled.)

I think every time the decrease button is initialized as disabled since every time the indent is lost after clicking on source button twice.

I need @blzaugg help looking at this issue.

This is issue is very similar to LPP-16063, maybe we can solve them together.
 
Thanks
John.