### PR TITLE
LPS-55048 Setting font-weight for hyperlink impedes inheritance from user agent.

### DIFF
--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom_common.css
@@ -18,7 +18,6 @@ body {
 
 a {
 	color: #009AE5;
-	font-weight: 200;
 
 	&:hover {
 		color: #009AE5;


### PR DESCRIPTION
Hey Hugo.

This issue is reported as one about Ckeditor, but it proves to be a CSS issue.

Considering two hyper link : 
``<strong><a href="www.google.com">goToGoogle</a></strong>``
and
``<a href="www.google.com"><strong>goToGoogle</strong></a>``

We expected ``goToGoogle`` to be bold for two links, but in fact only the first one gets bold.

The reason is we specify ``font-weight`` as 200 for ``<a>``.

For the second link, it will use the ``font-weight`` from ``<a>`` style, rather than the ``font-weight : bold`` from user agent. This is not our expected behaviour.

Simply remove ``font-weight`` for ``<a>`` seems to be a good solution since it can still inherit ``font-weight: 200`` from the body in  this custom_common.css if there is no style from user agent.

Thanks
John.