### PR TITLE
Revert LPS-13264

### DIFF
--- a/portal-impl/src/com/liferay/portlet/myaccount/action/EditUserAction.java
+++ b/portal-impl/src/com/liferay/portlet/myaccount/action/EditUserAction.java
@@ -89,10 +89,6 @@ public class EditUserAction
 		User user = PortalUtil.getSelectedUser(actionRequest);
 
 		if (Validator.isNotNull(currentPassword)) {
-			if (Validator.isNull(newPassword)) {
-				throw new UserPasswordException.MustNotBeNull(user.getUserId());
-			}
-
 			Company company = PortalUtil.getCompany(actionRequest);
 
 			String authType = company.getAuthType();


### PR DESCRIPTION
I want to revert [LPS-13264](https://issues.liferay.com/browse/LPS-13264).

In Firefox 38, the browser will fill current password field even if we specify autocomplete as off.  

This will block end users saving settings with error messages. Let us stick to the original design: If the current password is valid and new password is empty, we assume the end user does not intend to change his password and we will keep the original password.

Refer to the code in UserLocalServiceImpl.java
```
		if (Validator.isNotNull(newPassword1) ||
			Validator.isNotNull(newPassword2)) {

			user = updatePassword(
				userId, newPassword1, newPassword2, passwordReset);

			password = newPassword1;

			user.setDigest(StringPool.BLANK);
		}
```
We only change password when new password is not null. 

Related LPP : [LPP-16719](https://issues.liferay.com/browse/LPP-16719).

/cc @blzaugg @natecavanaugh 

Thanks
John.
