### PR TITLE
LPS-55874

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
+++ b/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
@@ -66,7 +66,7 @@ public class RecurrenceSerializer {
 						dayOfWeek += StringPool.COMMA;
 					}
 
-					dayOfWeek += byDay[i].getDayOfWeek();
+					dayOfWeek += toDayOfWeekWord(byDay[i].getDayOfWeek());
 				}
 			}
 		}
@@ -83,36 +83,7 @@ public class RecurrenceSerializer {
 						dayOfWeek += StringPool.COMMA;
 					}
 
-					switch (byDay[i].getDayOfWeek()) {
-
-						case Calendar.SUNDAY :
-							dayOfWeek += "SUN";
-							break;
-
-						case Calendar.MONDAY :
-							dayOfWeek += "MON";
-							break;
-
-						case Calendar.TUESDAY :
-							dayOfWeek += "TUE";
-							break;
-
-						case Calendar.WEDNESDAY :
-							dayOfWeek += "WED";
-							break;
-
-						case Calendar.THURSDAY :
-							dayOfWeek += "THU";
-							break;
-
-						case Calendar.FRIDAY :
-							dayOfWeek += "FRI";
-							break;
-
-						case Calendar.SATURDAY :
-							dayOfWeek += "SAT";
-							break;
-					}
+					dayOfWeek += toDayOfWeekWord(byDay[i].getDayOfWeek());
 				}
 			}
 
@@ -131,11 +102,12 @@ public class RecurrenceSerializer {
 				String pos = String.valueOf(byDay[0].getDayPosition());
 
 				if (pos.equals("-1")) {
-					dayOfWeek = byDay[0].getDayOfWeek() + "L";
+					dayOfWeek = toDayOfWeekWord(byDay[0].getDayOfWeek()) + "L";
 				}
 				else {
 					dayOfWeek =
-						byDay[0].getDayOfWeek() + StringPool.POUND + pos;
+						toDayOfWeekWord(byDay[0].getDayOfWeek()) +
+							StringPool.POUND + pos;
 				}
 			}
 		}
@@ -154,11 +126,13 @@ public class RecurrenceSerializer {
 					String pos = String.valueOf(byDay[0].getDayPosition());
 
 					if (pos.equals("-1")) {
-						dayOfWeek = byDay[0].getDayOfWeek() + "L";
+						dayOfWeek =
+							toDayOfWeekWord(byDay[0].getDayOfWeek()) + "L";
 					}
 					else {
 						dayOfWeek =
-							byDay[0].getDayOfWeek() + StringPool.POUND + pos;
+							toDayOfWeekWord(byDay[0].getDayOfWeek()) +
+								StringPool.POUND + pos;
 					}
 				}
 			}
@@ -181,6 +155,35 @@ public class RecurrenceSerializer {
 		sb.append(year);
 
 		return sb.toString();
+	}
+
+	protected static String toDayOfWeekWord(int dayOfWeekNum) {
+		switch (dayOfWeekNum) {
+
+			case Calendar.SUNDAY :
+				return "SUN";
+
+			case Calendar.MONDAY :
+				return "MON";
+
+			case Calendar.TUESDAY :
+				return "TUE";
+
+			case Calendar.WEDNESDAY :
+				return "WED";
+
+			case Calendar.THURSDAY :
+				return "THU";
+
+			case Calendar.FRIDAY :
+				return "FRI";
+
+			case Calendar.SATURDAY :
+				return "SAT";
+
+			default:
+				return "MON";
+		}
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
+++ b/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
@@ -83,7 +83,36 @@ public class RecurrenceSerializer {
 						dayOfWeek += StringPool.COMMA;
 					}
 
-					dayOfWeek += byDay[i].getDayOfWeek();
+					switch (byDay[i].getDayOfWeek()) {
+
+						case Calendar.SUNDAY :
+							dayOfWeek += "SUN";
+							break;
+
+						case Calendar.MONDAY :
+							dayOfWeek += "MON";
+							break;
+
+						case Calendar.TUESDAY :
+							dayOfWeek += "TUE";
+							break;
+
+						case Calendar.WEDNESDAY :
+							dayOfWeek += "WED";
+							break;
+
+						case Calendar.THURSDAY :
+							dayOfWeek += "THU";
+							break;
+
+						case Calendar.FRIDAY :
+							dayOfWeek += "FRI";
+							break;
+
+						case Calendar.SATURDAY :
+							dayOfWeek += "SAT";
+							break;
+					}
 				}
 			}
 


### PR DESCRIPTION
The pull request extends from https://github.com/hhuijser/liferay-portal/pull/2373.

The issue occurs when check the past day of week to schedule weekly function. The cronExpression '1-7' doesn't work.

We can test the cronExpression from http://www.cronmaker.com/.

Before fix, byDay[i].getDayOfWeek() will be "1-7", if current day is Thursday, when I enter "0 48 5 ? * 2/1 *", the next scheduled will be 
1.Thursday, June 4, 2015 5:48 AM
2.Friday, June 5, 2015 5:48 AM
...

After fix, the cronExpression will be "0 48 5 ? * MON/1 *", the next scheduled days will be 
1.Monday, June 8, 2015 5:48 AM
2.Monday, June 15, 2015 5:48 AM 
....

I have tested the fix by using report portlet in ee-7.0.x and it can work for me.

Thanks,
Hai