### PR TITLE
LPS-56239 Unable to remove code style for single line of text when editing a published MB thread.

### DIFF
--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/plugins/bbcode/bbcode_parser.js
@@ -698,13 +698,13 @@
 						value = value.substring(0, value.length - 1);
 					}
 				}
+			}
 
-				if (value) {
-					value = value.replace(
-						REGEX_NEW_LINE,
-						'<br>'
-					);
-				}
+			if (value) {
+				value = value.replace(
+					REGEX_NEW_LINE,
+					'<br>'
+				);
 			}
 
 			return value;

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/plugins/bbcode/converter.js
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/plugins/bbcode/converter.js
@@ -426,13 +426,13 @@
 						value = value.substring(0, value.length - 1);
 					}
 				}
+			}
 
-				if (value) {
-					value = value.replace(
-						REGEX_NEW_LINE,
-						'<br>'
-					);
-				}
+			if (value) {
+				value = value.replace(
+					REGEX_NEW_LINE,
+					'<br>'
+				);
 			}
 
 			return value;


### PR DESCRIPTION
Hey Hugo 

In [LPS-55288](https://issues.liferay.com/browse/LPS-55288), we decided to keeping ``</br>``  in ``<pre>``.

So we need to replacing new line with ``</br>`` for code style ``<pre>`` to follow this design when rendering bbcode.

Refer to https://github.com/liferay/liferay-ckeditor/compare/8ac2157801c92b11e23586b1a1ec0cf53475bf89~1...794f1786666ff12b8da14b354e7d7e85e082aa52

/cc @blzaugg

Thanks
John.