### PR TITLE
LPS-57300 Duplicated and redundant UI messages are shown for selecting organization when creating a user.

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/user/organizations.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/organizations.jsp
@@ -43,7 +43,6 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "organi
 
 <liferay-ui:search-container
 	curParam="organizationsCur"
-	emptyResultsMessage="no-organizations-were-found"
 	headerNames="name,type,roles,null"
 	iteratorURL="<%= currentURLObj %>"
 	total="<%= organizations.size() %>"

--- a/portal-web/docroot/html/portlet/users_admin/user/user_groups.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/user_groups.jsp
@@ -42,7 +42,6 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "userGr
 
 <liferay-ui:search-container
 	curParam="userGroupsCur"
-	emptyResultsMessage="no-user-groups-were-found"
 	headerNames="name,null"
 	iteratorURL="<%= currentURLObj %>"
 	total="<%= userGroups.size() %>"


### PR DESCRIPTION
Hey Hugo

I want to revert the fix in [LPS-55487](https://issues.liferay.com/browse/LPS-55487) as it causes a more obvious bug [LPS-57300](https://issues.liferay.com/browse/LPS-57300).

The reason why we want to revert rather than fix it is that the UI messages are rendered in  organizations.jsp and even when we choose an organization with a popup, the page will not be reloaded. So the UI messages are still there.

Cannot figure out an easy fix for this but reverting the fix (It is not that obvious to consider LPS-55487 as bug)

/cc @adolfopa

Thanks
John