### PR TITLE
LPS-58293 [Technical Support]

### DIFF
--- a/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/lar/PortletDataContextImpl.java
@@ -399,7 +399,14 @@ public class PortletDataContextImpl implements PortletDataContext {
 			String roleName = role.getName();
 
 			if (role.isTeam()) {
-				roleName = PermissionExporter.ROLE_TEAM_PREFIX + roleName;
+				try {
+					roleName =
+						PermissionExporter.ROLE_TEAM_PREFIX +
+							role.getDescriptiveName();
+				}
+				catch (Exception e) {
+					_log.error(e, e);
+				}
 			}
 
 			KeyValuePair permission = new KeyValuePair(


### PR DESCRIPTION
For team's role, its name is teamId by referring to TeamLocalServiceImpl.addTeam().

In order to match Team.LocalServiceUtil.getTeam(liveGroupId, roleName) in PortletDataContextImpl.importPermissions method, we should use team's name as roleName to export. Otherwise team role's permission won't be imported.

Thanks,
Hai