### PR TITLE
LPS-58622 Breadcrumb is missing in media gallery portlet.

### DIFF
--- a/modules/apps/document-library/document-library-web/src/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/META-INF/resources/image_gallery_display/configuration.jsp
@@ -113,6 +113,8 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 					<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 						<portlet:param name="mvcRenderCommandName" value='<%= "/document_library/select_folder" %>' />
+						<portlet:param name="folderId" value="<%= String.valueOf(rootFolderId) %>" />
+						<portlet:param name="ignoreRootFolder" value="<%= Boolean.TRUE.toString() %>" />
 					</liferay-portlet:renderURL>
 
 					uri: '<%= selectFolderURL.toString() %>'


### PR DESCRIPTION
Hey Hugo

I did fix a very similar issue in DM and DM display

See: https://github.com/brianchandotcom/liferay-portal/pull/24298

Somehow Media Galeery is omitted.

Thanks
John.