### PR TITLE
[Technical Support] LPS-59502 When defaultUser use resources-importer-web to import site,…

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -41,6 +41,7 @@ import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.Organization;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.CompanyLocalService;
 import com.liferay.portal.service.LayoutLocalService;
@@ -734,10 +735,13 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			String newValue = StringUtil.replace(
 				oldValue, "[$COMPANY_GROUP_SCOPE_ID$]", companyGroupScopeId);
 
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
 			try {
-				if (!AssetPublisherUtil.isScopeIdSelectable(
-						PermissionThreadLocal.getPermissionChecker(), newValue,
-						companyGroupId, layout)) {
+				if ((permissionChecker == null) ||
+					!AssetPublisherUtil.isScopeIdSelectable(
+						permissionChecker, newValue, companyGroupId, layout)) {
 
 					continue;
 				}


### PR DESCRIPTION
… permissionChecker is null so we should add the logic to avoid the NPE.

The issue can be reproduced on ee-6.2.x. And it can't reproduce on master because resources-importer-web doesn't invoke the import process. But master's logic is also not right.

When use resources-importer-web to import site lar, due to the user is defaultUser who deploys one portlet so that resources-importer-web can be invoked to import lar, in this process, we don't set PermissionThreadLocal.setPermissionChecker(), so when asset publisher configuration includes "scopeIds:values", the NPE will occur. 

The fix refers to SitesImpl.setLayoutSetPrototypeLinkEnabledParameter(){1954 lines} to instead of setting the PermissionThreadLocal.setPermissionChecker() in resources-importer-web.

Why the user is defaultUser?
Please refer to the below logic.
ResourcesImporterHotDeployMessageListener.importResources()->ImporterFactory.createImporter()->configureImporter() (importer.afterPropertiesSet();)-> BaseImporter.afterPropertiesSet()

DefaultUser own Guest Role(that is to say, defaultuser is guest user), so he won't own update permission.

Thanks,
Hai