### PR TITLE
[Technical-Support] LPS-59573 When index < -1, remove method shouldn't execute, otherwise…

### DIFF
--- a/modules/apps/calendar/calendar-web/src/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/META-INF/resources/edit_calendar_booking.jsp
@@ -426,7 +426,11 @@ for (long otherCalendarId : otherCalendarIds) {
 				var calendarId = A.one('#<portlet:namespace />calendarId').val();
 				var childCalendarIds = A.Object.keys(Liferay.CalendarUtil.availableCalendars);
 
-				A.Array.remove(childCalendarIds, A.Array.indexOf(childCalendarIds, calendarId));
+				var index = A.Array.indexOf(childCalendarIds, calendarId);
+
+				if (index > -1) {
+					A.Array.remove(childCalendarIds, index);
+				}
 
 				A.one('#<portlet:namespace />childCalendarIds').val(childCalendarIds.join(','));
 			</c:if>


### PR DESCRIPTION
… it will remove the array's one element.

The fix refers to the below pull request (calendar-portlet/docroot/js/components.js):
https://github.com/brianchandotcom/liferay-plugins/pull/684
The below link is detailed fix link:
https://github.com/natecavanaugh/liferay-plugins/commit/48347d4ee89ecf45177ab687bb8ea386045b25bd  (calendar-portlet/docroot/js/components.js)

When index<-1, if remove method executes, it will remove the array's one element.
```
in aui-base-lang.js
  remove: function(a, from, to) {
            var rest = a.slice((to || from) + 1 || a.length);
            a.length = (from < 0) ? (a.length + from) : from;

            return a.push.apply(a, rest);
        },
```
At this case, a = ["21445", "22171"], from = -1, to = undefined. rest=[], the a will delete one element.
Please refer to LPS-59573's description:
calendarId=22160 (user yu, the current calendar)
childCalendarIds=[21445,22171] (21445(Liferay),22171(user hai))

After applying the fix, CalendarPortlet.updateCalendarBooking() method will get right childCalendarIds[].

Thanks,
Hai
