### PR TITLE
[Technical Support] LPS-59581

### DIFF
--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
@@ -1065,6 +1065,10 @@ public class ExpandoValueLocalServiceImpl
 			else if (type == ExpandoColumnConstants.STRING_ARRAY) {
 				value.setStringArray((String[])attributeValue);
 			}
+			else if (type == ExpandoColumnConstants.STRING_LOCALIZED) {
+				value.setStringMap(
+					(Map<Locale, String>)attributeValue, Locale.getDefault());
+			}
 			else {
 				value.setString((String)attributeValue);
 			}

--- a/portal-service/src/com/liferay/portlet/expando/util/ExpandoConverterUtil.java
+++ b/portal-service/src/com/liferay/portlet/expando/util/ExpandoConverterUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.expando.util;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.expando.model.ExpandoColumnConstants;
@@ -86,6 +87,9 @@ public class ExpandoConverterUtil {
 		}
 		else if (type == ExpandoColumnConstants.STRING_ARRAY) {
 			return StringUtil.split(attribute);
+		}
+		else if (type == ExpandoColumnConstants.STRING_LOCALIZED) {
+			return (Serializable)LocalizationUtil.getLocalizationMap(attribute);
 		}
 		else {
 			return attribute;


### PR DESCRIPTION
The fix only solves the STRING_LOCALIZED type import issue.

**The first commit:** It solves import expandocolumn defaultData. defaultData is created by edit the custom field's default value in Custom Field portlet. If we enter the value, it will save by using xml format. When export, the defaultData is exported as string (using xml format) by referring to PortletExportController.exportExpandoTables(). When import, it will cause the current error **"java.lang.String cannot be cast to java.util.Map"**.

The fix refers to export journalArticle related custom field. **The progress convert string(xml) to Map<Locale, String>**. Please refer to the below logic:
JournalArticleStagedModelDataHandler.doExportStagedModel()->PortletDataContextImpl.addClassedModel()->addExpando() {2040 line}..->ExpandoBridgeImpl.getAttributes(){282 line}->getAttribute(){213 line}->..->ExpandoValueLocalServiceImpl.doGetData(){2419 line}->getData(){1635 line}->ExpandoValueImpl.getStringMap(){330 line}

**The second commit:** It solves import the detailed entry(journalArticle related expandovalue data_). The data_ is created by adding one web content (if we add the custom field's default value, when create web content, the data_  will use custom field's default value). When import journalArticle related expandovalue, due to expandoBridgeAttributes is defined as Map<String, Serializable>, please refer to ServiceContext._expandoBridgeAttributes field, so it will cause **"java.util.HashMap cannot be cast to java.lang.String"** error.

The fix refers to add journalArticle logic in UI:
JournalArticleLocalServiceImpl.addArticle{article.setExpandoBridgeAttributes(serviceContext); 415 line}->ExpandoBridgeImpl.setAttributes(){554 lines}->setAttributes(secure=true){ExpandoValueServiceUtil.addValues()}->...->ExpandoValueLocalServiceImpl.addValue(){384 lines}.

In addition, I think STRING_ARRAY_LOCALIZED type field also exist the similar issue. But it doesn't been allowed using in Custom Field portlet. Please refer to https://github.com/brianchandotcom/liferay-portal/pull/15395. That is to say, for the current case, the customer won't encounter the issue. So I skip the STRING_ARRAY_LOCALIZED type field fix. 

Thanks,
Hai


