### PR TITLE
LPS-59252  Inconsistent locale between URL and page content	

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -317,80 +317,81 @@ public class FriendlyURLServlet extends HttpServlet {
 			ServiceContextThreadLocal.pushServiceContext(serviceContext);
 		}
 
-		if (Validator.isNotNull(friendlyURL)) {
-			try {
-				LayoutFriendlyURLComposite layoutFriendlyURLComposite =
-					PortalUtil.getLayoutFriendlyURLComposite(
-						group.getGroupId(), _private, friendlyURL, params,
-						requestContext);
+		try {
+			LayoutFriendlyURLComposite layoutFriendlyURLComposite =
+				PortalUtil.getLayoutFriendlyURLComposite(
+					group.getGroupId(), _private, friendlyURL, params,
+					requestContext);
 
-				Layout layout = layoutFriendlyURLComposite.getLayout();
+			Layout layout = layoutFriendlyURLComposite.getLayout();
 
-				request.setAttribute(WebKeys.LAYOUT, layout);
+			request.setAttribute(WebKeys.LAYOUT, layout);
 
-				String layoutFriendlyURLCompositeFriendlyURL =
-					layoutFriendlyURLComposite.getFriendlyURL();
+			Locale locale = PortalUtil.getLocale(request);
 
-				pos = layoutFriendlyURLCompositeFriendlyURL.indexOf(
-					Portal.FRIENDLY_URL_SEPARATOR);
+			String layoutFriendlyURLCompositeFriendlyURL =
+				layoutFriendlyURLComposite.getFriendlyURL();
 
-				if (pos != 0) {
-					if (pos != -1) {
-						layoutFriendlyURLCompositeFriendlyURL =
-							layoutFriendlyURLCompositeFriendlyURL.substring(
-								0, pos);
-					}
-
-					Locale locale = PortalUtil.getLocale(request);
-
-					boolean i18nRedirect = false;
-
-					String i18nLanguageId = (String)request.getAttribute(
-						WebKeys.I18N_LANGUAGE_ID);
-
-					if (Validator.isNotNull(i18nLanguageId)) {
-						Locale i18nLocale = LocaleUtil.fromLanguageId(
-							i18nLanguageId);
-
-						if (!LanguageUtil.isAvailableLocale(
-								group.getGroupId(), i18nLocale)) {
-
-							i18nRedirect = true;
-						}
-					}
-
-					if (i18nRedirect ||
-						!StringUtil.equalsIgnoreCase(
-							layoutFriendlyURLCompositeFriendlyURL,
-							layout.getFriendlyURL(locale))) {
-
-						Locale originalLocale = setAlternativeLayoutFriendlyURL(
-							request, layout,
-							layoutFriendlyURLCompositeFriendlyURL);
-
-						String redirect = PortalUtil.getLocalizedFriendlyURL(
-							request, layout, locale, originalLocale);
-
-						return new Object[] {redirect, Boolean.TRUE};
-					}
-				}
+			if (Validator.isNull(layoutFriendlyURLCompositeFriendlyURL)) {
+				layoutFriendlyURLCompositeFriendlyURL = layout.getFriendlyURL(
+					locale);
 			}
-			catch (NoSuchLayoutException nsle) {
-				List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-					group.getGroupId(), _private,
-					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-				for (Layout layout : layouts) {
-					if (layout.matches(request, friendlyURL)) {
-						String redirect = PortalUtil.getLayoutActualURL(
-							layout, mainPath);
+			pos = layoutFriendlyURLCompositeFriendlyURL.indexOf(
+				Portal.FRIENDLY_URL_SEPARATOR);
 
-						return new Object[] {redirect, Boolean.FALSE};
+			if (pos != 0) {
+				if (pos != -1) {
+					layoutFriendlyURLCompositeFriendlyURL =
+						layoutFriendlyURLCompositeFriendlyURL.substring(0, pos);
+				}
+
+				boolean i18nRedirect = false;
+
+				String i18nLanguageId = (String)request.getAttribute(
+					WebKeys.I18N_LANGUAGE_ID);
+
+				if (Validator.isNotNull(i18nLanguageId)) {
+					Locale i18nLocale = LocaleUtil.fromLanguageId(
+						i18nLanguageId);
+
+					if (!LanguageUtil.isAvailableLocale(
+							group.getGroupId(), i18nLocale)) {
+
+						i18nRedirect = true;
 					}
 				}
 
-				throw nsle;
+				if (i18nRedirect ||
+					!StringUtil.equalsIgnoreCase(
+						layoutFriendlyURLCompositeFriendlyURL,
+						layout.getFriendlyURL(locale))) {
+
+					Locale originalLocale = setAlternativeLayoutFriendlyURL(
+						request, layout, layoutFriendlyURLCompositeFriendlyURL);
+
+					String redirect = PortalUtil.getLocalizedFriendlyURL(
+						request, layout, locale, originalLocale);
+
+					return new Object[] {redirect, Boolean.TRUE};
+				}
 			}
+		}
+		catch (NoSuchLayoutException nsle) {
+			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
+				group.getGroupId(), _private,
+				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+			for (Layout layout : layouts) {
+				if (layout.matches(request, friendlyURL)) {
+					String redirect = PortalUtil.getLayoutActualURL(
+						layout, mainPath);
+
+					return new Object[] {redirect, Boolean.FALSE};
+				}
+			}
+
+			throw nsle;
 		}
 
 		String actualURL = PortalUtil.getActualURL(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3421,9 +3421,25 @@ public class PortalImpl implements Portal {
 			layoutFriendlyURL = layout.getFriendlyURL(originalLocale);
 		}
 
+		String friendlyURL = StringPool.SLASH;
+
 		if (requestURI.contains(layoutFriendlyURL)) {
 			requestURI = StringUtil.replaceFirst(
 				requestURI, layoutFriendlyURL, layout.getFriendlyURL(locale));
+
+			friendlyURL = layout.getFriendlyURL(locale);
+		}
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		String virtualHostname = layoutSet.getVirtualHostname();
+
+		String portalURL = getPortalURL(request);
+
+		if (Validator.isNull(virtualHostname) ||
+			!portalURL.contains(virtualHostname)) {
+
+			friendlyURL = requestURI;
 		}
 
 		String i18nPath =
@@ -3445,7 +3461,7 @@ public class PortalImpl implements Portal {
 			localizedFriendlyURL += i18nPath;
 		}
 
-		localizedFriendlyURL += requestURI;
+		localizedFriendlyURL += friendlyURL;
 
 		String queryString = request.getQueryString();
 

--- a/portal-impl/test/integration/com/liferay/portal/servlet/FriendlyURLServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/FriendlyURLServletTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.service.ServiceContext;
@@ -26,11 +27,11 @@ import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.MainServletTestRule;
 import com.liferay.portal.util.Portal;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.WebKeys;
 import com.liferay.portal.util.test.LayoutTestUtil;
 
 import java.util.Collections;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -77,6 +78,27 @@ public class FriendlyURLServletTest {
 	}
 
 	@Test
+	public void testGetRedirectWithInvalidI18nPath() throws Exception {
+		Layout layout = LayoutTestUtil.addLayout(_group);
+
+		String requestURI =
+			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+				getPath(_group, layout);
+
+		_request.setRequestURI(requestURI);
+		_request.setAttribute(WebKeys.I18N_LANGUAGE_ID, "fr");
+		_request.setPathInfo(StringPool.SLASH);
+
+		testGetRedirect(
+			_group.getFriendlyURL(), Portal.PATH_MAIN,
+			new Object[] {"/en" + requestURI, true});
+
+		testGetRedirect(
+			getPath(_group, layout), Portal.PATH_MAIN,
+			new Object[] {"/en" + requestURI, true});
+	}
+
+	@Test
 	public void testGetRedirectWithInvalidPath() throws Exception {
 		testGetRedirect(
 			null, Portal.PATH_MAIN, new Object[] {Portal.PATH_MAIN, false});
@@ -114,6 +136,7 @@ public class FriendlyURLServletTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
-	private final HttpServletRequest _request = new MockHttpServletRequest();
+	private final MockHttpServletRequest _request =
+		new MockHttpServletRequest();
 
 }


### PR DESCRIPTION
Hey Hugo 

Only [commit when layout set is ....](https://github.com/hhuijser/liferay-portal/commit/1d557ba979bb2a6a28474a4fcae980e848fc3fa1) is newly added.

What this commit is trying to fix:

If public page url is configured as localhost and French is not an available locale for the site, for example:
1. ``localhost:8080/fr/`` should be redirected to ``localhost:8080/en/``
2. ``localhost:8080/fr/home`` should be redirected to ``localhost:8080/en/home``

If public page url is not configured with a virtual host:
1.``localhost:8080/fr/`` should be redirected to ``localhost:8080/en/web/guest/``
2.``localhost:8080/fr/home`` should be redirected to ``localhost:8080/en/web/guest/home``

Thanks
John