### PR TITLE
LPS-58702: Upgrade process to correct the existing Layoutoutsets which is not referenced to Site Templates

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -118,6 +118,10 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			layoutSet = initLayoutSet(layoutSet);
 
 			layoutSet.setLogoId(layoutSet.getLogoId());
+			layoutSet.setPageCount(0);
+			layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
+			layoutSet.setLayoutSetPrototypeLinkEnabled(false);
+			layoutSet.setModifiedDate(new Date());
 
 			layoutSetPersistence.update(layoutSet);
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
@@ -30,6 +30,7 @@ import com.liferay.portal.upgrade.v7_0_0.UpgradeEmailNotificationPreferences;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeExpando;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeGroup;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeLastPublishDate;
+import com.liferay.portal.upgrade.v7_0_0.UpgradeLayoutSet;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeListType;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMembershipRequest;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMessageBoards;
@@ -75,6 +76,7 @@ public class UpgradeProcess_7_0_0 extends UpgradeProcess {
 		upgrade(UpgradeExpando.class);
 		upgrade(UpgradeGroup.class);
 		upgrade(UpgradeLastPublishDate.class);
+		upgrade(UpgradeLayoutSet.class);
 		upgrade(UpgradeListType.class);
 		upgrade(UpgradeMembershipRequest.class);
 		upgrade(UpgradeMessageBoards.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeLayoutSet.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeLayoutSet.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.util.PortalUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+/**
+ * @author Mohit Soni
+ */
+public class UpgradeLayoutSet extends UpgradeProcess {
+
+	public boolean _isOrganization = false;
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgradeLayoutSet();
+	}
+
+	protected int getLayoutsByGroupAndPrivateLayout(
+			long groupId, boolean privateLayout)
+		throws Exception {
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select count(*) from Layout " +
+					"where groupId = ? and privateLayout = ?");
+
+			ps.setLong(1, groupId);
+			ps.setBoolean(2, privateLayout);
+
+			rs = ps.executeQuery();
+
+			if (rs.next()) {
+				int count = rs.getInt(1);
+
+				return count;
+			}
+
+			return 0;
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected boolean hasGroupAnySite(long groupId) throws Exception {
+		long classNameId = PortalUtil.getClassNameId(
+			"com.liferay.portal.model.Organization");
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select site, classNameId from Group_ " + "where groupId = ?");
+
+			ps.setLong(1, groupId);
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				boolean site = rs.getBoolean("site");
+
+				hasGroupAnOrganization(classNameId, rs.getLong("classNameId"));
+
+				return site;
+			}
+
+			return false;
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected void hasGroupAnOrganization(
+		long orgClassNameId, long classNameId) {
+
+		if (orgClassNameId == classNameId) {
+			_isOrganization = true;
+		}
+	}
+
+	protected void upgradeLayoutSet() throws Exception {
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select layoutSetId, groupId, privateLayout from layoutset " +
+					"where layoutSetPrototypeUuid != ''");
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long layoutSetId = rs.getLong("layoutSetId");
+				long groupId = rs.getLong("groupId");
+				boolean privateLayout = rs.getBoolean("privateLayout");
+
+				boolean updateLayoutSetRequired = false;
+
+				if (hasGroupAnySite(groupId)) {
+					if ((getLayoutsByGroupAndPrivateLayout(
+							groupId, privateLayout) == 0 ) &&
+						_isOrganization) {
+						updateLayoutSetRequired = true;
+					}
+				} else if (_isOrganization) {
+
+					updateLayoutSetRequired = true;
+				}
+
+				if (updateLayoutSetRequired) {
+					updateLayoutSet(layoutSetId);
+
+					updateGroupSite(groupId);
+				}
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected void updateLayoutSet(long layoutSetId)
+			throws Exception {
+
+			Connection con = null;
+			PreparedStatement ps = null;
+			ResultSet rs = null;
+
+			try {
+				con = DataAccess.getUpgradeOptimizedConnection();
+
+				Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+
+				ps = con.prepareStatement(
+					"update LayoutSet set layoutSetPrototypeLinkEnabled = ? ," +
+					" layoutSetPrototypeUuid = '' , modifiedDate = ?," +
+						"pageCount = ? where layoutSetId = ?");
+
+				ps.setInt(1, 0);
+				ps.setTimestamp(2, timestamp);
+				ps.setInt(3, 0);
+				ps.setLong(4, layoutSetId);
+
+				ps.executeUpdate();
+			}
+			catch (Exception e) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to update layoutSet " + layoutSetId, e);
+				}
+			}
+			finally {
+				DataAccess.cleanUp(con, ps, rs);
+			}
+		}
+
+	protected void updateGroupSite(long groupId)
+			throws Exception {
+
+			Connection con = null;
+			PreparedStatement ps = null;
+			ResultSet rs = null;
+
+			try {
+				con = DataAccess.getUpgradeOptimizedConnection();
+
+				ps = con.prepareStatement(
+					"update Group_ set site = ? where groupId = ?");
+
+				ps.setInt(1, 0);
+				ps.setLong(2, groupId);
+
+				ps.executeUpdate();
+			}
+			catch (Exception e) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to update Group " + groupId, e);
+				}
+			}
+			finally {
+				DataAccess.cleanUp(con, ps, rs);
+			}
+		}
+
+private static final Log _log = LogFactoryUtil.getLog(UpgradeLayoutSet.class);
+
+}


### PR DESCRIPTION
Hi Hugo,

With respect to Brian's comment on https://github.com/brianchandotcom/liferay-portal/pull/31218 and discussion with Jonathan i have removed the Verify process and added an upgrade process.

Here is the summary of the issue:

While deleting the Site Templates it looks for reference in layoutset table, if any reference found then it doesn't delete the template and displays a validation message that "template is in use" which is correct. In this case , Organization Site was created with Site template and when we delete that site then it doesn't update the layoutsetprototypeuuid and layoutSetPrototypeLinkEnabled column from layoutset table which should be updated as BLANK and false respectively.

When we delete the Site then it deletes the entry from Layout table, which means there will not be any entry corresponding to group of LayoutSet. Therefore while deleting the site , the page count should be 0 because there is no layout is associated anymore.

Also the test cases created by Jonathan is not applicable in this case because its an upgrade to correct the data.

To run the process, please add following properties in portal-ext.properties.

upgrade.processes.6210=${upgrade.processes.master} 

Thanks,
Mohit
