### PR TITLE
LPS-58702: Reference to SiteTemplates should be removed from LayoutSet , If its not referenced

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -117,7 +117,11 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 
 			layoutSet = initLayoutSet(layoutSet);
 
+			layoutSet.setModifiedDate(new Date());
 			layoutSet.setLogoId(layoutSet.getLogoId());
+			layoutSet.setPageCount(0);
+			layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
+			layoutSet.setLayoutSetPrototypeLinkEnabled(Boolean.FALSE);
 
 			layoutSetPersistence.update(layoutSet);
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
@@ -30,6 +30,7 @@ import com.liferay.portal.upgrade.v7_0_0.UpgradeEmailNotificationPreferences;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeExpando;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeGroup;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeLastPublishDate;
+import com.liferay.portal.upgrade.v7_0_0.UpgradeLayoutSet;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeListType;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMembershipRequest;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMessageBoards;
@@ -75,6 +76,7 @@ public class UpgradeProcess_7_0_0 extends UpgradeProcess {
 		upgrade(UpgradeExpando.class);
 		upgrade(UpgradeGroup.class);
 		upgrade(UpgradeLastPublishDate.class);
+		upgrade(UpgradeLayoutSet.class);
 		upgrade(UpgradeListType.class);
 		upgrade(UpgradeMembershipRequest.class);
 		upgrade(UpgradeMessageBoards.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeLayoutSet.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeLayoutSet.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.util.PortalUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+/**
+ * @author Mohit Soni
+ */
+public class UpgradeLayoutSet extends UpgradeProcess {
+
+	public boolean _isOrganization = false;
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgradeLayoutSet();
+	}
+
+	protected int getLayoutsByGroupAndPrivateLayout(
+			long groupId, boolean privateLayout)
+		throws Exception {
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select count(*) from Layout " +
+					"where groupId = ? and privateLayout = ?");
+
+			ps.setLong(1, groupId);
+			ps.setBoolean(2, privateLayout);
+
+			rs = ps.executeQuery();
+
+			if (rs.next()) {
+				int count = rs.getInt(1);
+
+				return count;
+			}
+
+			return 0;
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected boolean hasGroupAnySite(long groupId) throws Exception {
+		long classNameId = PortalUtil.getClassNameId(
+			"com.liferay.portal.model.Organization");
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select site, classNameId from Group_ " + "where groupId = ?");
+
+			ps.setLong(1, groupId);
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				boolean site = rs.getBoolean("site");
+
+				hasGroupAnOrganization(classNameId, rs.getLong("classNameId"));
+
+				return site;
+			}
+
+			return false;
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected void hasGroupAnOrganization(
+		long orgClassNameId, long classNameId) {
+
+		if (orgClassNameId == classNameId) {
+			_isOrganization = true;
+		}
+	}
+
+	protected void upgradeLayoutSet() throws Exception {
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"select layoutSetId, groupId, privateLayout from layoutset " +
+					"where layoutSetPrototypeUuid != ''");
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long layoutSetId = rs.getLong("layoutSetId");
+				long groupId = rs.getLong("groupId");
+				boolean privateLayout = rs.getBoolean("privateLayout");
+
+				boolean updateLayoutSetRequired = false;
+
+				if (hasGroupAnySite(groupId)) {
+					if ((getLayoutsByGroupAndPrivateLayout(
+							groupId, privateLayout) == 0 ) &&
+						_isOrganization) {
+							updateLayoutSetRequired = true;
+						}
+				}
+				else if (_isOrganization) {
+					updateLayoutSetRequired = true;
+				}
+
+				if (updateLayoutSetRequired) {
+					updateLayoutSet(layoutSetId);
+
+					updateGroupSite(groupId);
+				}
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected void updateLayoutSet(long layoutSetId) throws Exception {
+
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+
+			ps = con.prepareStatement(
+				"update LayoutSet set layoutSetPrototypeLinkEnabled = ? ," +
+					" layoutSetPrototypeUuid = '' , modifiedDate = ?," +
+						"pageCount = ? where layoutSetId = ?");
+
+			ps.setInt(1, 0);
+			ps.setTimestamp(2, timestamp);
+			ps.setInt(3, 0);
+			ps.setLong(4, layoutSetId);
+
+			ps.executeUpdate();
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to update layoutSet " + layoutSetId, e);
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	protected void updateGroupSite(long groupId) throws Exception {
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement(
+				"update Group_ set site = ? where groupId = ?");
+
+			ps.setInt(1, 0);
+			ps.setLong(2, groupId);
+
+			ps.executeUpdate();
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to update Group " + groupId, e);
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(UpgradeLayoutSet.class);
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/service/LayoutSetLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/LayoutSetLocalServiceTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service;
+
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.LayoutSet;
+import com.liferay.portal.model.LayoutSetPrototype;
+import com.liferay.portal.model.Organization;
+import com.liferay.portal.model.OrganizationConstants;
+import com.liferay.portal.model.User;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.MainServletTestRule;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portlet.sites.util.SitesUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+* @author Jonathan McCann
+*/
+public class LayoutSetLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE);
+
+	@Test
+	public void testDeleteOrganizationSite() throws Exception {
+		User user = TestPropsValues.getUser();
+
+		_organization = OrganizationLocalServiceUtil.addOrganization(
+			user.getUserId(),
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			RandomTestUtil.randomString(), true);
+
+		Group group = _organization.getGroup();
+
+		List<LayoutSetPrototype> layoutSetPrototypes =
+			LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototypes(
+				PortalUtil.getDefaultCompanyId());
+
+		LayoutSetPrototype layoutSetPrototype = layoutSetPrototypes.get(0);
+
+		SitesUtil.updateLayoutSetPrototypesLinks(
+			group, layoutSetPrototype.getLayoutSetPrototypeId(),
+			layoutSetPrototype.getLayoutSetPrototypeId(), true, true);
+
+		group = _organization.getGroup();
+
+		Assert.assertFalse(group.isSite());
+
+		GroupLocalServiceUtil.deleteGroup(group);
+
+		LayoutSet privateLayoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
+			_organization.getGroupId(), true);
+
+		Assert.assertEquals(
+			StringPool.BLANK, privateLayoutSet.getLayoutSetPrototypeUuid());
+		Assert.assertFalse(privateLayoutSet.getLayoutSetPrototypeLinkEnabled());
+		Assert.assertEquals(0, _organization.getPrivateLayoutsPageCount());
+
+		LayoutSet publicLayoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
+			_organization.getGroupId(), false);
+
+		Assert.assertEquals(
+			StringPool.BLANK, publicLayoutSet.getLayoutSetPrototypeUuid());
+		Assert.assertFalse(publicLayoutSet.getLayoutSetPrototypeLinkEnabled());
+		Assert.assertEquals(0, _organization.getPublicLayoutsPageCount());
+	}
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+}


### PR DESCRIPTION
Hi Hugo,

Please find the inline answers to questions mentioned in https://github.com/hhuijser/liferay-portal/pull/2529

1) What are the changes in LayoutLocalServiceImpl about? You should do those in a separate commit, because those are not part of the upgrade process (as the commit message says).
 Whenever we create a site using Site template then Layout set table then its column (pageCount,layoutSetPrototypeUuid,layoutSetPrototypeLinkEnabled) holds the referenced data and when we delete the Site then Logically this data should be deleted/removed, but it wasn't happening.
So i have added logic in com.liferay.portal.service.impl.LayoutSetLocalServiceImpl.deleteLayoutSet(long, boolean, ServiceContext) method , which will delete/remove this reference . But it will work for new records i.e. Site deleted with this changes.
Also as suggested, i have separated the commit.

2) When you call layoutSet.setXXX, you should order those calls by the way the columns are sorted in the table. See portal-tables.sql
Changes done as suggested.

3) Let's include the test that Jonathan McCann added.
Test class added.

4) When you run ant format-source, you'll see that there a bunch of warnings. Please clean those up.
Cleaned the warnings and errors.

Thanks,
Mohit

