### PR TITLE
LPS-60832:While adding/updating page titles should be validated irrespective of HEAD

### DIFF
--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -3137,7 +3137,10 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			nodeId = newNodeId;
 		}
 
-		validate(newTitle, nodeId, content, format);
+		String title = Validator.isNull(
+			newTitle) ? oldPage.getTitle() : newTitle;
+
+		validate(title, nodeId, content, format);
 
 		serviceContext.validateModifiedDate(
 			oldPage, PageVersionException.class);
@@ -3167,8 +3170,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		page.setUserName(user.getFullName());
 		page.setCreateDate(oldPage.getCreateDate());
 		page.setNodeId(nodeId);
-		page.setTitle(
-			Validator.isNull(newTitle) ? oldPage.getTitle() : newTitle);
+		page.setTitle(title);
 		page.setVersion(newVersion);
 		page.setMinorEdit(minorEdit);
 		page.setContent(content);

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -3137,7 +3137,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			nodeId = newNodeId;
 		}
 
-		validate(nodeId, content, format);
+		validate(newTitle, nodeId, content, format);
 
 		serviceContext.validateModifiedDate(
 			oldPage, PageVersionException.class);
@@ -3236,7 +3236,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			throw new PageTitleException();
 		}
 
-		if (isUsedTitle(nodeId, title)) {
+		if (getPagesCount(nodeId, title) > 0) {
 			throw new DuplicatePageException("{nodeId=" + nodeId + "}");
 		}
 

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/error.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/error.jsp
@@ -70,6 +70,7 @@
 	</div>
 </c:if>
 
+<liferay-ui:error exception="<%= DuplicatePageException.class %>" message="there-is-already-a-page-with-the-specified-title" />
 <liferay-ui:error exception="<%= PageTitleException.class %>" message="please-enter-a-valid-page-title" />
 
 <liferay-ui:error-principal />


### PR DESCRIPTION
While adding wiki page validation was based on HEAD = true , in this case Head remains false because its in pending status and doesn't validate it. So when it tries to add same title in DB it throws an exception. therefore i have made changes in validation , so that it can check all the available titles irrespective of HEAD.
Same logic has been added while updating. Also it should give a proper validation message.