### PR TITLE
[TECHNICAL-SUPPORT] LPS-61779 OrganizationLocalService.hasUserOrganization throws NPE if both parameters are true 

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -977,17 +977,22 @@ public class OrganizationLocalServiceImpl
 		Organization organization = organizationPersistence.findByPrimaryKey(
 			organizationId);
 
-		if (!includeSpecifiedOrganization) {
+		if (includeSpecifiedOrganization) {
 			organizationsTree.add(organization);
 		}
 		else {
-			organizationsTree.add(organization.getParentOrganization());
+			List<Organization> subOrganizations = getSuborganizations(
+				organization.getCompanyId(), organizationId);
+
+			organizationsTree.addAll(subOrganizations);
 		}
 
-		params.put("usersOrgsTree", organizationsTree);
+		if (organizationsTree.size() > 0) {
+			params.put("usersOrgsTree", organizationsTree);
 
-		if (userFinder.countByUser(userId, params) > 0) {
-			return true;
+			if (userFinder.countByUser(userId, params) > 0) {
+				return true;
+			}
 		}
 
 		return false;

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -981,18 +981,13 @@ public class OrganizationLocalServiceImpl
 			organizationsTree.add(organization);
 		}
 		else {
-			List<Organization> subOrganizations = getSuborganizations(
-				organization.getCompanyId(), organizationId);
-
-			organizationsTree.addAll(subOrganizations);
+			organizationsTree.addAll(organization.getSuborganizations());
 		}
 
-		if (organizationsTree.size() > 0) {
-			params.put("usersOrgsTree", organizationsTree);
+		params.put("usersOrgsTree", organizationsTree);
 
-			if (userFinder.countByUser(userId, params) > 0) {
-				return true;
-			}
+		if (userFinder.countByUser(userId, params) > 0) {
+			return true;
 		}
 
 		return false;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-61779

Hi Hugo,

Happy New Year! ;-) I hope everything is OK in your new team.

Here's Dani's comments:
>OrganizationLocalService.hasUserOrganization threw a NullPointerException if both inheritSuborganizations and includeSpecifiedOrganization parameters were true, and the organization's parent was the default organization id. In addition, there was a scenario in which the logic returned wrong result. Consider the following scenario:

>Organization A has two sub organization: Organization B and C. The user is the member of Organization C.

>If I run the original code on Organization B with both parameters set to true, the method would check the organization's parent (Org A). Since sub-organizations are also checked, the method returned true because the user in question was the member of Organization C. This is wrong, as I wanted to know if the user is the member of Organization B or any of its sub-organizations.

Let us know if you have any concerns.

Cheers,
Tibor

/cc @djavorszky: Dani: I think this issue could be tested easily and com.liferay.portal.service.OrganizationLocalServiceTest is pretty self-educating, so I'd like to ask you to add some new tests to cover the possible combinations and the expected results of the hasUserOrganization method. :-)