### PR TITLE
LPS-68355 SF complains about '{' instead of '}'

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JavaSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JavaSourceProcessor.java
@@ -2612,7 +2612,7 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 
 					if (trimmedLine.matches("^\\} (catch|else|finally) .*")) {
 						processMessage(
-							fileName, "There should be a line break after '{'",
+							fileName, "There should be a line break after '}'",
 							lineCount);
 					}
 


### PR DESCRIPTION
Hi Hugo,

[LPS-68355](https://issues.liferay.com/browse/LPS-68355)

The commit simply fixes a misleading SF message.

Thanks for reviewing,
Istvan