### PR TITLE
LPS-63827

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/poller/PollerHeader.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/poller/PollerHeader.java
@@ -81,7 +81,7 @@ public class PollerHeader implements Serializable {
 		return sb.toString();
 	}
 
-	private static final long _TIMESTAMP = System.currentTimeMillis();
+	private long _TIMESTAMP = System.currentTimeMillis();
 
 	private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Hey @hhuijser,

Attached is an update for http://issues.liferay.com/browse/LPS-63827.  I sent this to you because you made a change with the source formatter (https://github.com/liferay/liferay-portal/commit/138cf20890ff328a40512f4b2545c5fb83b00d9f) which changed this variable to a static constant for the timestamp.

Comparing ee-6.2.x and master for this variable:
ee-6.2.x: https://github.com/liferay/liferay-portal-ee/blob/ee-6.2.x/portal-service/src/com/liferay/portal/kernel/poller/PollerHeader.java#L86

master: https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/poller/PollerHeader.java#L84

Please let me know if you have any questions. Thanks!