### PR TITLE
[Technical-Support] LPS-70392 

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeModules.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeModules.java
@@ -97,6 +97,7 @@ public class UpgradeModules extends UpgradeProcess {
 						else {
 							updateServletContextName(
 								oldServletContextName, newServletContextName);
+							updateSchemaVersion(newServletContextName);
 						}
 					}
 				}
@@ -108,6 +109,14 @@ public class UpgradeModules extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			addRelease(getBundleSymbolicNames());
 		}
+	}
+
+	protected void updateSchemaVersion(String newServletContextName)
+		throws IOException, SQLException {
+
+		runSQL(
+			"update Release_ set schemaVersion = '0.0.1' where " +
+				"servletContextName = '" + newServletContextName + "'");
 	}
 
 	protected void updateServletContextName(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0


### PR DESCRIPTION
**Root issue:** 
In release_ table, for 6.1 plugins, if its buildNumber is not null (for example, marketplace-portlet-6.1.30.8.war and its buildNumber is 100). When upgrade from 6.1 to 7.0, SchemaVersion will be "1.0.0". This will miss upgrade step lower than 1.0.0. For example, for "com.liferay.marketplace.service", it will miss '0.0.1' step and it will start from 1.0.0.

**Why miss upgrade step lower than 1.0.0?**
If marketplace-portlet buildNumber is 100 in 6.1, when upgrade from 6.1 to 7.0, https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRelease.java#L34-L47 will set 1.0.0 in SchemaVersion  column. Please refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerOSGiCommands.java#L313-L320, this will get upgrade step from 1.0.0, and it will miss lower than 1.0.0 version.

Refer to upgrade step define class and missed upgrade process.
https://github.com/liferay/liferay-portal/blob/master/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/MarketplaceServiceUpgrade.java#L35-L42
(for example, for "com.liferay.portal.workflow.kaleo.service", its buildNumber is 110 in 6.1,  in upgrade process, it will missed below steps:)
https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/KaleoServiceUpgrade.java#L38-L46

Regards,
Hai

