### PR TITLE
[Technical-Support] LPS-70740

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -234,7 +234,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		Fields fields = toFields(
 			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), LocaleUtil.getSiteDefault(), true);
+			serviceContext.getLocale(), LocaleUtil.getSiteDefault());
 
 		return ddlRecordLocalService.addRecord(
 			userId, groupId, recordSetId, displayIndex, fields, serviceContext);
@@ -996,8 +996,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		Fields fields = toFields(
 			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), oldDDMFormValues.getDefaultLocale(),
-			false);
+			serviceContext.getLocale(), oldDDMFormValues.getDefaultLocale());
 
 		return ddlRecordLocalService.updateRecord(
 			userId, recordId, false, displayIndex, fields, mergeFields,
@@ -1267,7 +1266,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	protected Fields toFields(
 		long ddmStructureId, Map<String, Serializable> fieldsMap, Locale locale,
-		Locale defaultLocale, boolean create) {
+		Locale defaultLocale) {
 
 		Fields fields = new Fields();
 
@@ -1278,7 +1277,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			field.setName(entry.getKey());
 			field.addValue(locale, String.valueOf(entry.getValue()));
 
-			if (create && !locale.equals(defaultLocale)) {
+			if (!locale.equals(defaultLocale)) {
 				field.addValue(defaultLocale, String.valueOf(entry.getValue()));
 			}
 

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 042cc4c30a1c863c675c4fd1efe537c906e1dbc5
+	commit = 325f0207b011481bb2be22d0c60f7cceac089a8c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b6a0c8609fb619e6f4a276e3f3f8e6b52511f734
+	parent = 0f0dff279c148d88c07a082d97eb8e842fb01a5e
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 66c5e24d5692488e9e3ea778678ebbdc56f36903
+	commit = d08d21013910f0219d837c4d433d80daeb8ed165
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6356c886eaf34605d1eb6c22759e0c482531b82f
+	parent = b93cb069bc8a39ecc2383654e7b3b3a341459425
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 692f24e31273d135b76db2c8101e7f79da6601a1
+	commit = 74e606afa21a79574c52884e73e8d7dd3ad3073f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 566b6d50e72c9466a3e181ad1ad8809f458b6cf2
+	parent = a522fa7b4f70313aa21b2599607f16ac12740df8
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c24006d03476ab4437a8b7ff34d69b2180050736
+	commit = fbcb0154e37e7042da7bd935f23f8fdf63e5fc2f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = da5b3dcb72cf7542c6ee7ed1e51c90ec48c507d6
+	parent = 1bf76878400d3d641f4146fbb023afdbfb59c24e
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 80a9f08ec9ed1d4f722a900a60163f4dcc9a9e3f
+	commit = 0bfba331a7a6218584637b87da13b962b88ef35f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6ca08a868f24d794c45c55d33cd03b657da1c018
+	parent = 5e71ff08c6037850161d8499e4a7d76098a74178
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/portlet-configuration/.gitrepo
+++ b/modules/apps/web-experience/portlet-configuration/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0ff9a39d436e7d0a8c24ae8e5e7f321dcde3f851
+	commit = 3da71fa2074526884b8dc85bb345fc9498596632
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c4d787a21abd1da789cf2e2f351ebbca6bed0993
+	parent = 028a116b43039e03287029198c99bc68637377f1
 	remote = git@github.com:liferay/com-liferay-portlet-configuration.git

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 2fd121b7c29b704e43304f8d425f401c65f1c503
+	commit = ec0d989c3dca2dfbab947306d84aec33a109fa51
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 8a41253fe9d925dc63972b52ac2d6946f6ba3e82
+	parent = c128badbfd3a6c4439d24ed650fff441445809ca
 	remote = git@github.com:liferay/com-liferay-product-navigation.git


### PR DESCRIPTION
Hi Hugo,

This fix reverts the java fix of LPS-50193. 

When current locale is not default locale with old record, we edit one record in Spreadsheet. We need to add new defaultLocale value for this field. Otherwise, in DDMImpl.mergeFields(), the array newFieldsDisplayValues is empty(https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java#L522-L523) and mergedLocaleValues is also null(https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java#L1197-L1200) so that edit value can't be saved and field value of new version record is null.

In addition, after reverts the java fix of LPS-50193, LPS-50193 can't occur.

Regards,
Hai