### PR TITLE
[Technical-Support] LPS-70790

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exportimport/staged/model/repository/DDLRecordSetStagedModelRepository.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exportimport/staged/model/repository/DDLRecordSetStagedModelRepository.java
@@ -72,6 +72,9 @@ public class DDLRecordSetStagedModelRepository
 		if (portletDataContext.isDataStrategyMirror()) {
 			serviceContext.setUuid(ddlRecordSet.getUuid());
 		}
+		else {
+			ddlRecordSet.setRecordSetKey(null);
+		}
 
 		return _ddlRecordSetLocalService.addRecordSet(
 			userId, ddlRecordSet.getGroupId(), ddlRecordSet.getDDMStructureId(),


### PR DESCRIPTION
Hi Hugo,

This PR extends from https://github.com/hhuijser/liferay-portal/pull/2822

Please refer to https://github.com/hhuijser/liferay-portal/pull/2822 test failure(https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch%28master%29/AXIS_VARIABLE=7,label_exp=!master/39075//testReport/com.liferay.dynamic.data.lists.internal.exportimport.data.handler.test/DDLFormStagedModelDataHandlerTest/testStagedModelDataHandler).

The root issue: When import uses "Copy as New" stategy in same site, we used exist recordSetKey to create new list (DDLRecordSet). This will cause https://issues.liferay.com/browse/LPS-70790 issue. You may check LPS-70790 to know the issue. 

The fix sets recordSetKey for null when import using "Copy as New" stategy so that it can generated new recordSetKey.

When using DATA_STRATEGY_MIRROR and DATA_STRATEGY_MIRROR_OVERWRITE stategy, if targetSite doesn't exist the RecordSet, it also adds new recordSet (refer to refer1). Based on the test example (refer2), we can use same recordSetKey for this new recordSet in different sites. So I resubmit the fix.

refer1: https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/DDLRecordSetStagedModelDataHandler.java#L172-L181

refer2:https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/data/handler/test/DDLRecordSetStagedModelDataHandlerTest.java#L176-L177

Regards,
Hai