### PR TITLE
LPS-71124 - Users with Organization Administrators in a nested/child organization are unable to modify their respective organization sites

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -1196,8 +1196,10 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			stopWatch.start();
 
-			while (!group.isRoot()) {
-				Group parentGroup = group.getParentGroup();
+			Group currentGroup = group;
+
+			while (!currentGroup.isRoot()) {
+				Group parentGroup = currentGroup.getParentGroup();
 
 				long[] roleIds = getRoleIds(
 					getUserId(), parentGroup.getGroupId());
@@ -1211,7 +1213,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					return true;
 				}
 
-				group = parentGroup;
+				currentGroup = parentGroup;
 			}
 		}
 


### PR DESCRIPTION
This issue is caused by the "child group id"  is converted to the "parent group id“.

at last, there is no such "user group role"[userId, groupId, roleId]
