### PR TITLE
[Technical-Support] LPS-71094 

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
+++ b/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
@@ -17,92 +17,97 @@
 <%@ include file="/init.jsp" %>
 
 <%
+PanelAppRegistry panelAppRegistry = (PanelAppRegistry)request.getAttribute(ApplicationListWebKeys.PANEL_APP_REGISTRY);
 PanelCategory panelCategory = (PanelCategory)request.getAttribute(ApplicationListWebKeys.PANEL_CATEGORY);
 PanelCategoryHelper panelCategoryHelper = (PanelCategoryHelper)request.getAttribute(ApplicationListWebKeys.PANEL_CATEGORY_HELPER);
+
+List<PanelApp> panelApps = panelAppRegistry.getPanelApps(panelCategory, themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup());
 %>
 
-<liferay-application-list:panel-category panelCategory="<%= panelCategory %>" showBody="<%= false %>">
+<c:if test="<%= !panelApps.isEmpty() %>">
+	<liferay-application-list:panel-category panelCategory="<%= panelCategory %>" showBody="<%= false %>">
 
-	<%
-	Group curSite = themeDisplay.getSiteGroup();
+		<%
+		Group curSite = themeDisplay.getSiteGroup();
 
-	List<Layout> scopeLayouts = LayoutLocalServiceUtil.getScopeGroupLayouts(curSite.getGroupId());
-	%>
+		List<Layout> scopeLayouts = LayoutLocalServiceUtil.getScopeGroupLayouts(curSite.getGroupId());
+		%>
 
-	<c:choose>
-		<c:when test="<%= scopeLayouts.isEmpty() %>">
-			<liferay-application-list:panel-category-body panelCategory="<%= panelCategory %>" />
-		</c:when>
-		<c:otherwise>
-			<ul class="nav nav-equal-height nav-nested">
-				<li>
-					<div class="scope-selector">
+		<c:choose>
+			<c:when test="<%= scopeLayouts.isEmpty() %>">
+				<liferay-application-list:panel-category-body panelCategory="<%= panelCategory %>" />
+			</c:when>
+			<c:otherwise>
+				<ul class="nav nav-equal-height nav-nested">
+					<li>
+						<div class="scope-selector">
 
-						<%
-						Group curScopeGroup = themeDisplay.getScopeGroup();
-						%>
+							<%
+							Group curScopeGroup = themeDisplay.getScopeGroup();
+							%>
 
-						<span class="scope-name">
-							<c:choose>
-								<c:when test="<%= curScopeGroup.isLayout() %>">
-									<%= curScopeGroup.getDescriptiveName(locale) %> (<liferay-ui:message key="scope" />)
-								</c:when>
-								<c:otherwise>
-									<liferay-ui:message key="default-scope" />
-								</c:otherwise>
-							</c:choose>
-						</span>
-						<span class="nav-equal-height-heading-field">
-							<liferay-ui:icon-menu direction="left" icon="cog" markupView="lexicon" message="" showArrow="<%= false %>">
+							<span class="scope-name">
+								<c:choose>
+									<c:when test="<%= curScopeGroup.isLayout() %>">
+										<%= curScopeGroup.getDescriptiveName(locale) %> (<liferay-ui:message key="scope" />)
+									</c:when>
+									<c:otherwise>
+										<liferay-ui:message key="default-scope" />
+									</c:otherwise>
+								</c:choose>
+							</span>
+							<span class="nav-equal-height-heading-field">
+								<liferay-ui:icon-menu direction="left" icon="cog" markupView="lexicon" message="" showArrow="<%= false %>">
 
-								<%
-								Map<String, Object> data = new HashMap<String, Object>();
+									<%
+									Map<String, Object> data = new HashMap<String, Object>();
 
-								String portletId = themeDisplay.getPpid();
+									String portletId = themeDisplay.getPpid();
 
-								if (Validator.isNull(portletId) || !panelCategoryHelper.containsPortlet(portletId, PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, curSite)) {
-									portletId = panelCategoryHelper.getFirstPortletId(PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, curSite);
-								}
-
-								PortletURL portletURL = PortalUtil.getControlPanelPortletURL(request, curSite, portletId, 0, 0, PortletRequest.RENDER_PHASE);
-								%>
-
-								<liferay-ui:icon
-									cssClass='<%= (curScopeGroup.getGroupId() == curSite.getGroupId()) ? "active" : StringPool.BLANK %>'
-									data="<%= data %>"
-									message="default-scope"
-									url="<%= portletURL.toString() %>"
-								/>
-
-								<%
-								for (Layout curScopeLayout : scopeLayouts) {
-									Group scopeGroup = curScopeLayout.getScopeGroup();
-
-									if (Validator.isNull(portletId) || !panelCategoryHelper.containsPortlet(portletId, PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, scopeGroup)) {
-										portletId = panelCategoryHelper.getFirstPortletId(PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, scopeGroup);
+									if (Validator.isNull(portletId) || !panelCategoryHelper.containsPortlet(portletId, PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, curSite)) {
+										portletId = panelCategoryHelper.getFirstPortletId(PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, curSite);
 									}
 
-									portletURL = PortalUtil.getControlPanelPortletURL(request, scopeGroup, portletId, 0, 0, PortletRequest.RENDER_PHASE);
-								%>
+									PortletURL portletURL = PortalUtil.getControlPanelPortletURL(request, curSite, portletId, 0, 0, PortletRequest.RENDER_PHASE);
+									%>
 
 									<liferay-ui:icon
-										cssClass='<%= (curScopeGroup.getGroupId() == scopeGroup.getGroupId()) ? "active" : StringPool.BLANK %>'
+										cssClass='<%= (curScopeGroup.getGroupId() == curSite.getGroupId()) ? "active" : StringPool.BLANK %>'
 										data="<%= data %>"
-										message="<%= HtmlUtil.escape(curScopeLayout.getName(locale)) %>"
+										message="default-scope"
 										url="<%= portletURL.toString() %>"
 									/>
 
-								<%
-								}
-								%>
+									<%
+									for (Layout curScopeLayout : scopeLayouts) {
+										Group scopeGroup = curScopeLayout.getScopeGroup();
 
-							</liferay-ui:icon-menu>
-						</span>
-					</div>
+										if (Validator.isNull(portletId) || !panelCategoryHelper.containsPortlet(portletId, PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, scopeGroup)) {
+											portletId = panelCategoryHelper.getFirstPortletId(PanelCategoryKeys.SITE_ADMINISTRATION_CONTENT, permissionChecker, scopeGroup);
+										}
 
-					<liferay-application-list:panel-category-body panelCategory="<%= panelCategory %>" />
-				</li>
-			</ul>
-		</c:otherwise>
-	</c:choose>
-</liferay-application-list:panel-category>
+										portletURL = PortalUtil.getControlPanelPortletURL(request, scopeGroup, portletId, 0, 0, PortletRequest.RENDER_PHASE);
+									%>
+
+										<liferay-ui:icon
+											cssClass='<%= (curScopeGroup.getGroupId() == scopeGroup.getGroupId()) ? "active" : StringPool.BLANK %>'
+											data="<%= data %>"
+											message="<%= HtmlUtil.escape(curScopeLayout.getName(locale)) %>"
+											url="<%= portletURL.toString() %>"
+										/>
+
+									<%
+									}
+									%>
+
+								</liferay-ui:icon-menu>
+							</span>
+						</div>
+
+						<liferay-application-list:panel-category-body panelCategory="<%= panelCategory %>" />
+					</li>
+				</ul>
+			</c:otherwise>
+		</c:choose>
+	</liferay-application-list:panel-category>
+</c:if>

--- a/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -24,7 +24,9 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.application.list.PanelCategory" %><%@
+<%@ page import="com.liferay.application.list.PanelApp" %><%@
+page import="com.liferay.application.list.PanelAppRegistry" %><%@
+page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%@
 page import="com.liferay.application.list.constants.PanelCategoryKeys" %><%@
 page import="com.liferay.application.list.display.context.logic.PanelCategoryHelper" %><%@


### PR DESCRIPTION
Hi Hugo,

**The root issue:**
If the user own "View Site Administration Menu" permission, we will render its six childPanel(NavigationPanelCategory, ContentPanelCategory, MembersPanelCategory, ConfigurationPanelCategory, PublishingPanelCategory), when render ContentPanelCategory in (https://github.com/yuhai/liferay-portal/blob/LPS-71094/modules/apps/web-experience/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/page.jsp#L30), because ContentPanelCategory override getJspPath() (https://github.com/yuhai/liferay-portal/blob/LPS-71094/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/ContentPanelCategory.java#L43-L45), it will invoke /content/content.jsp (https://github.com/yuhai/liferay-portal/blob/LPS-71094/modules/apps/web-experience/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/servlet/taglib/PanelCategoryContentTag.java#L39-L40). This is different from other four childPanels.

if the user doesn't own access any one site_administration.content's portlets permission, the NPE error will occur. 

In https://github.com/yuhai/liferay-portal/blob/LPS-71094/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp#L85-L89
portletId will be null because the user doesn't own access any one of site_administration.content's portlets permission. In 89 line, it will throw NPE.

**The fix** adds the logic about whether the users can access any one of site_administration.content's portlets. If panelApps is empty, the whole logic needn't be executed.

Regards,
Hai