### PR TITLE
[Technical-Support] LPS-71388 

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -42,6 +42,7 @@ import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.exportimport.Modifications;
 import com.liferay.portal.security.ldap.exportimport.PortalToLDAPConverter;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
 
@@ -435,7 +436,10 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 		try {
 			StringBundler sb = new StringBundler(4);
 
-			if (!algorithm.equals(PasswordEncryptorUtil.TYPE_NONE)) {
+			if (!algorithm.equals(PasswordEncryptorUtil.TYPE_NONE) &&
+				Validator.isNull(
+					PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY)) {
+
 				sb.append(StringPool.OPEN_CURLY_BRACE);
 				sb.append(algorithm);
 				sb.append(StringPool.CLOSE_CURLY_BRACE);


### PR DESCRIPTION
Hi Hugo,

The issue only occurs when the properties ldap.auth.password.encryption.algorithm(set in UI) and passwords.encryption.algorithm.legacy are not null.

In this case, we will append "algorithm" twice with encryptedPassword (ex, {SSHA}{SSHA}pw...). The commit will remove one ({SSHA}) so that export right password for LDAP.

Why append "algorithm" twice? Please refer to the below logic.
https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java#L438-L444  (the first)->https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/pwd/LegacyAlgorithmAwarePasswordEncryptor.java#L47-L122 (The second)

Regards,
Hai

