### PR TITLE
fix knowledge display

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBNavigationDisplayContext.java
@@ -117,6 +117,14 @@ public class KBNavigationDisplayContext {
 		return pageTitle;
 	}
 
+	public long getParentResourcePrimKey() throws PortalException {
+		if (_kbArticle != null) {
+			return _kbArticle.getParentResourcePrimKey();
+		}
+
+		return getRootResourcePrimKey();
+	}
+
 	public long getRootResourcePrimKey() throws PortalException {
 		if (_rootResourcePrimKey == null) {
 			_rootResourcePrimKey = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBArticleKBArticleSelector.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBArticleKBArticleSelector.java
@@ -50,7 +50,11 @@ public class KBArticleKBArticleSelector implements KBArticleSelector {
 		if (resourcePrimKey ==
 				KBArticleConstants.DEFAULT_PARENT_RESOURCE_PRIM_KEY) {
 
-			return new KBArticleSelection(ancestorKBArticle, true);
+			KBArticle kbArticle =
+				_kbArticleLocalService.fetchFirstChildKBArticle(
+					groupId, ancestorKBArticle.getResourcePrimKey());
+
+			return new KBArticleSelection(kbArticle, true);
 		}
 
 		KBArticle kbArticle = _kbArticleLocalService.fetchLatestKBArticle(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_navigation.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_navigation.jsp
@@ -21,7 +21,7 @@ KBNavigationDisplayContext kbNavigationDisplayContext = (KBNavigationDisplayCont
 
 List<Long> ancestorResourcePrimaryKeys = kbNavigationDisplayContext.getAncestorResourcePrimaryKeys();
 
-long rootResourcePrimKey = kbNavigationDisplayContext.getRootResourcePrimKey();
+long parentResourcePrimKey = kbNavigationDisplayContext.getParentResourcePrimKey();
 
 String pageTitle = kbNavigationDisplayContext.getPageTitle();
 
@@ -41,7 +41,7 @@ KBArticleURLHelper kbArticleURLHelper = new KBArticleURLHelper(renderRequest, re
 	request.setAttribute("view_navigation_articles.jsp-ancestorResourcePrimaryKeys", ancestorResourcePrimaryKeys);
 	request.setAttribute("view_navigation_articles.jsp-kbArticleURLHelper", kbArticleURLHelper);
 	request.setAttribute("view_navigation_articles.jsp-level", 0);
-	request.setAttribute("view_navigation_articles.jsp-parentResourcePrimKey", rootResourcePrimKey);
+	request.setAttribute("view_navigation_articles.jsp-parentResourcePrimKey", parentResourcePrimKey);
 	%>
 
 	<liferay-util:include page="/display/view_navigation_articles.jsp" servletContext="<%= application %>" />


### PR DESCRIPTION
In knowledgebase display portlet, configure a specific article as parent resource in configuration.
Actual behavior: Its sibling articles are still there and when you click on one of them, there will be a warning message saying it's not found.
Expected behavior: only children articles of configured article should be displayed.

Another thing needs pointing out is that inside kbarticledisplaycontext class, there is a method called getRootResourcePrimKey() which does not return a rootResourcePrimKey but instead, it is returning parent folderid. In this method, it is calling a getRootResourcePrimKey() method from a util class, but that method is also returning parentfolderId.

I think someone needs to change the name of the method to avoid confusion.