### PR TITLE
LPS 71504 fix

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBFolderKBArticleSelector.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBFolderKBArticleSelector.java
@@ -228,6 +228,12 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 			return true;
 		}
 
+		if (kbArticle.getKbFolderId() ==
+				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+
+			return false;
+		}
+
 		KBFolder parentKBFolder = _kbFolderService.getKBFolder(
 			kbArticle.getKbFolderId());
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_navigation.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_navigation.jsp
@@ -21,7 +21,7 @@ KBNavigationDisplayContext kbNavigationDisplayContext = (KBNavigationDisplayCont
 
 List<Long> ancestorResourcePrimaryKeys = kbNavigationDisplayContext.getAncestorResourcePrimaryKeys();
 
-long parentResourcePrimKey = kbNavigationDisplayContext.getParentResourcePrimKey();
+long parentResourcePrimKey = GetterUtil.getLong(portletPreferences.getValue("resourcePrimKey", null));
 
 String pageTitle = kbNavigationDisplayContext.getPageTitle();
 


### PR DESCRIPTION
The configuration of selecting a folder or an article is to set a parent resource so that kb display portlet will display parent's child articles. See https://issues.liferay.com/browse/LPS-71539 for detail description.
Also https://github.com/liferay/liferay-portal/blob/master/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/DisplayPortlet.java#L365 shows that the particular attribute of resourcePrimKey from frontend is the configured folder/article id.

Original parentResourcePrimKey from context class is the parent of article in resource hierachy, not the configured resource from portlet configuration.