### PR TITLE
[Technical-Support] LPS-71916 

### DIFF
--- a/definitions/liferay-workflow-definition_6_1_0.xsd
+++ b/definitions/liferay-workflow-definition_6_1_0.xsd
@@ -277,7 +277,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="user" type="user-complex-type" />
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="user" type="user-complex-type" />
 		</xs:choice>
 	</xs:group>
 	<xs:group name="nodes-group">

--- a/definitions/liferay-workflow-definition_6_2_0.xsd
+++ b/definitions/liferay-workflow-definition_6_2_0.xsd
@@ -328,7 +328,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="user" type="user-complex-type" />
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="user" type="user-complex-type" />
 		</xs:choice>
 	</xs:group>
 	<xs:group name="nodes-group">

--- a/definitions/liferay-workflow-definition_7_0_0.xsd
+++ b/definitions/liferay-workflow-definition_7_0_0.xsd
@@ -329,7 +329,7 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="scripted-assignment" type="script-complex-type" />
-			<xs:element name="user" type="user-complex-type" />
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="user" type="user-complex-type" />
 		</xs:choice>
 	</xs:group>
 	<xs:group name="nodes-group">

--- a/definitions/liferay-workflow-definition_7_1_0.xsd
+++ b/definitions/liferay-workflow-definition_7_1_0.xsd
@@ -357,7 +357,7 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="scripted-assignment" type="script-complex-type" />
-			<xs:element name="user" type="user-complex-type" />
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="user" type="user-complex-type" />
 		</xs:choice>
 	</xs:group>
 	<xs:group name="nodes-group">


### PR DESCRIPTION
Hi Hugo,

The root issue is that we don't allow to add multi users for task->assignments in validated xsd file.

Since we can add multi users in UI for task->assignments and we also have java logic to handle this, so we should allow this in xsd file.

Please refer to java logic: https://github.com/yuhai/liferay-portal/blob/master/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java#L288-L303

By the way, if use this definition file (https://issues.liferay.com/secure/attachment/211844/sample.xml) to test , please change 
`xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.0.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_0_0.xsd"`
for
`xsi:schemaLocation="http://www.w3schools.com file:///D:/liferay_code/code/70x/tomcat/tomcat-8.0.32/webapps/ROOT/dtd/liferay-workflow-definition_7_0_0.xsd"`
so that we can specify schema location in fixed xsd file, otherwise it won't work.


Regards,
Hai