### PR TITLE
Different behavior when running source formatter in subrepo

### DIFF
--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/poller/ChatPollerProcessor.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/poller/ChatPollerProcessor.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.poller.PollerResponse;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringPool;
@@ -144,7 +144,7 @@ public class ChatPollerProcessor extends BasePollerProcessor {
 					displayURL = _portal.getLayoutSetDisplayURL(
 						layoutSet, false);
 
-					displayURL = HttpUtil.removeDomain(displayURL);
+					displayURL = _http.removeDomain(displayURL);
 				}
 			}
 			catch (NoSuchLayoutSetException nslse) {
@@ -307,6 +307,10 @@ public class ChatPollerProcessor extends BasePollerProcessor {
 		ChatPollerProcessor.class);
 
 	private ChatGroupServiceConfiguration _chatGroupServiceConfiguration;
+
+	@Reference
+	private Http _http;
+
 	private LayoutSetLocalService _layoutSetLocalService;
 
 	@Reference

--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -280,7 +280,7 @@ public class PingbackMethodImpl implements Method {
 	}
 
 	protected String getExcerpt() throws IOException {
-		String html = HttpUtil.URLtoString(_sourceURI);
+		String html = _http.URLtoString(_sourceURI);
 
 		Source source = new Source(html);
 
@@ -360,7 +360,7 @@ public class PingbackMethodImpl implements Method {
 		Source source = null;
 
 		try {
-			String html = HttpUtil.URLtoString(_sourceURI);
+			String html = _http.URLtoString(_sourceURI);
 
 			source = new Source(html);
 		}
@@ -395,6 +395,9 @@ public class PingbackMethodImpl implements Method {
 
 	@Reference
 	private CommentManager _commentManager;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/linkback/LinkbackConsumer.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/linkback/LinkbackConsumer.java
@@ -17,7 +17,7 @@ package com.liferay.blogs.linkback;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Tuple;
 
 import java.util.ArrayList;
@@ -56,7 +56,7 @@ public class LinkbackConsumer {
 
 	public void verifyTrackback(long commentId, String url, String entryURL) {
 		try {
-			String result = HttpUtil.URLtoString(url);
+			String result = _http.URLtoString(url);
 
 			if (result.contains(entryURL)) {
 				return;
@@ -78,6 +78,9 @@ public class LinkbackConsumer {
 
 	@Reference
 	private CommentManager _commentManager;
+
+	@Reference
+	private Http _http;
 
 	private final List<Tuple> _trackbacks = Collections.synchronizedList(
 		new ArrayList<Tuple>());

--- a/modules/apps/collaboration/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
@@ -358,6 +358,8 @@ public class PingbackMethodImplTest extends PowerMockito {
 	protected void execute(String targetURI) {
 		PingbackMethodImpl pingbackMethodImpl = getPingbackMethodImpl();
 
+		ReflectionTestUtil.setFieldValue(pingbackMethodImpl, "_http", _http);
+
 		pingbackMethodImpl.setArguments(new Object[] {_SOURCE_URI, targetURI});
 
 		pingbackMethodImpl.execute(_COMPANY_ID);

--- a/modules/apps/collaboration/blogs/blogs-service/src/test/java/com/liferay/blogs/linkback/LinkbackConsumerTest.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/test/java/com/liferay/blogs/linkback/LinkbackConsumerTest.java
@@ -53,12 +53,13 @@ public class LinkbackConsumerTest extends PowerMockito {
 		RegistryUtil.setRegistry(new BasicRegistryImpl());
 
 		setUpBlogsUtil();
-		setUpHttpUtil();
 
 		_linkbackConsumer = new LinkbackConsumer();
 
 		ReflectionTestUtil.setFieldValue(
 			_linkbackConsumer, "_commentManager", _commentManager);
+
+		ReflectionTestUtil.setFieldValue(_linkbackConsumer, "_http", _http);
 	}
 
 	@Test

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -64,7 +64,7 @@ import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -210,7 +210,7 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			String redirect = ParamUtil.getString(actionRequest, "redirect");
 
-			String portletId = HttpUtil.getParameter(redirect, "p_p_id", false);
+			String portletId = _http.getParameter(redirect, "p_p_id", false);
 
 			int workflowAction = ParamUtil.getInteger(
 				actionRequest, "workflowAction",
@@ -258,10 +258,10 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 							String namespace = _portal.getPortletNamespace(
 								portletId);
 
-							redirect = HttpUtil.addParameter(
+							redirect = _http.addParameter(
 								redirect, namespace + "className",
 								BlogsEntry.class.getName());
-							redirect = HttpUtil.addParameter(
+							redirect = _http.addParameter(
 								redirect, namespace + "classPK",
 								entry.getEntryId());
 						}
@@ -614,6 +614,9 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 		_blogsEntryAttachmentContentUpdater;
 	private BlogsEntryLocalService _blogsEntryLocalService;
 	private BlogsEntryService _blogsEntryService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/TrackbackMVCActionCommand.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/TrackbackMVCActionCommand.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -209,7 +209,7 @@ public class TrackbackMVCActionCommand extends BaseMVCActionCommand {
 				"Trackback requires a valid permanent URL");
 		}
 
-		String trackbackIP = HttpUtil.getIpAddress(url);
+		String trackbackIP = _http.getIpAddress(url);
 
 		if (!remoteIP.equals(trackbackIP)) {
 			throw new TrackbackValidationException(
@@ -228,6 +228,9 @@ public class TrackbackMVCActionCommand extends BaseMVCActionCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		TrackbackMVCActionCommand.class);
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/collaboration/blogs/blogs-web/src/test/java/com/liferay/blogs/web/internal/portlet/action/TrackbackMVCActionCommandTest.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/test/java/com/liferay/blogs/web/internal/portlet/action/TrackbackMVCActionCommandTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Function;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Props;
@@ -72,7 +71,6 @@ public class TrackbackMVCActionCommandTest extends PowerMockito {
 		setUpActionRequest();
 		setUpActionUtil();
 		setUpBlogsEntry();
-		setUpHttpUtil();
 		setUpPortalUtil();
 		setUpPortletPreferencesFactoryUtil();
 		setUpPropsUtil();
@@ -180,6 +178,8 @@ public class TrackbackMVCActionCommandTest extends PowerMockito {
 			new TrackbackMVCActionCommand();
 
 		ReflectionTestUtil.setFieldValue(
+			trackbackMVCActionCommand, "_http", _http);
+		ReflectionTestUtil.setFieldValue(
 			trackbackMVCActionCommand, "_portal", PortalUtil.getPortal());
 		ReflectionTestUtil.setFieldValue(
 			trackbackMVCActionCommand, "_trackback", _trackback);
@@ -250,12 +250,6 @@ public class TrackbackMVCActionCommandTest extends PowerMockito {
 		).thenReturn(
 			true
 		);
-	}
-
-	protected void setUpHttpUtil() throws Exception {
-		HttpUtil httpUtil = new HttpUtil();
-
-		httpUtil.setHttp(_http);
 	}
 
 	protected void setUpPortalUtil() throws Exception {

--- a/modules/apps/collaboration/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -165,16 +165,16 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				if (Validator.isNotNull(redirect)) {
 					if (cmd.equals(Constants.ADD) && (entry != null)) {
-						String portletId = HttpUtil.getParameter(
+						String portletId = _http.getParameter(
 							redirect, "p_p_id", false);
 
 						String namespace = _portal.getPortletNamespace(
 							portletId);
 
-						redirect = HttpUtil.addParameter(
+						redirect = _http.addParameter(
 							redirect, namespace + "className",
 							BookmarksEntry.class.getName());
-						redirect = HttpUtil.addParameter(
+						redirect = _http.addParameter(
 							redirect, namespace + "classPK",
 							entry.getEntryId());
 					}
@@ -312,6 +312,9 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	private BookmarksEntryService _bookmarksEntryService;
 	private BookmarksFolderService _bookmarksFolderService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -69,7 +69,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -558,16 +558,16 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 							if (cmd.equals(Constants.ADD) &&
 								(fileEntry != null)) {
 
-								String portletId = HttpUtil.getParameter(
+								String portletId = _http.getParameter(
 									redirect, "p_p_id", false);
 
 								String namespace = _portal.getPortletNamespace(
 									portletId);
 
-								redirect = HttpUtil.addParameter(
+								redirect = _http.addParameter(
 									redirect, namespace + "className",
 									DLFileEntry.class.getName());
-								redirect = HttpUtil.addParameter(
+								redirect = _http.addParameter(
 									redirect, namespace + "classPK",
 									fileEntry.getFileEntryId());
 							}
@@ -1037,6 +1037,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/collaboration/invitation/invitation-invite-members-service/src/main/java/com/liferay/invitation/invite/members/internal/model/listener/UserModelListener.java
+++ b/modules/apps/collaboration/invitation/invitation-invite-members-service/src/main/java/com/liferay/invitation/invite/members/internal/model/listener/UserModelListener.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -55,14 +55,13 @@ public class UserModelListener extends BaseModelListener<User> {
 
 			String refererURL = headers.get(WebKeys.REFERER);
 
-			String portletId = HttpUtil.getParameter(
-				refererURL, "p_p_id", false);
+			String portletId = _http.getParameter(refererURL, "p_p_id", false);
 
-			String redirectURL = HttpUtil.getParameter(
+			String redirectURL = _http.getParameter(
 				refererURL,
 				_portal.getPortletNamespace(portletId) + "redirectURL", false);
 
-			String key = HttpUtil.getParameter(
+			String key = _http.getParameter(
 				redirectURL, _portal.getPortletNamespace(portletId) + "key",
 				false);
 
@@ -87,6 +86,9 @@ public class UserModelListener extends BaseModelListener<User> {
 	protected void setPortal(Portal portal) {
 		_portal = portal;
 	}
+
+	@Reference
+	private Http _http;
 
 	private MemberRequestLocalService _memberRequestLocalService;
 	private Portal _portal;

--- a/modules/apps/collaboration/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
+++ b/modules/apps/collaboration/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
@@ -74,7 +74,7 @@ public class ItemSelectorImpl implements ItemSelector {
 		String namespace = _portal.getPortletNamespace(
 			ItemSelectorPortletKeys.ITEM_SELECTOR);
 
-		return HttpUtil.getParameter(
+		return _http.getParameter(
 			itemSelectorURL,
 			namespace.concat(PARAMETER_ITEM_SELECTED_EVENT_NAME), false);
 	}
@@ -108,7 +108,7 @@ public class ItemSelectorImpl implements ItemSelector {
 	public List<ItemSelectorCriterion> getItemSelectorCriteria(
 		String itemSelectorURL) {
 
-		Map<String, String[]> parameters = HttpUtil.getParameterMap(
+		Map<String, String[]> parameters = _http.getParameterMap(
 			itemSelectorURL);
 
 		Map<String, String[]> itemSelectorURLParameterMap = new HashMap<>();
@@ -392,6 +392,9 @@ public class ItemSelectorImpl implements ItemSelector {
 		_itemSelectionCriterionHandlers.remove(
 			itemSelectorCriterionClass.getName());
 	}
+
+	@Reference
+	private Http _http;
 
 	private final ConcurrentMap
 		<String, ItemSelectorCriterionHandler<ItemSelectorCriterion>>

--- a/modules/apps/collaboration/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/ItemSelectorImplTest.java
+++ b/modules/apps/collaboration/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/ItemSelectorImplTest.java
@@ -78,6 +78,8 @@ public class ItemSelectorImplTest extends PowerMockito {
 			_stubItemSelectorCriterionSerializer);
 
 		ReflectionTestUtil.setFieldValue(
+			_itemSelectorImpl, "_http", new HttpImpl());
+		ReflectionTestUtil.setFieldValue(
 			_itemSelectorImpl, "_portal", new PortalImpl());
 
 		_mediaItemSelectorCriterion = new MediaItemSelectorCriterion();

--- a/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/service/SubscriptionMBMessageLocalServiceWrapper.java
+++ b/modules/apps/collaboration/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/service/SubscriptionMBMessageLocalServiceWrapper.java
@@ -43,7 +43,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -268,7 +268,7 @@ public class SubscriptionMBMessageLocalServiceWrapper
 
 		String contentURL = (String)serviceContext.getAttribute("contentURL");
 
-		contentURL = HttpUtil.addParameter(
+		contentURL = _http.addParameter(
 			contentURL, serviceContext.getAttribute("namespace") + "messageId",
 			message.getMessageId());
 
@@ -587,6 +587,10 @@ public class SubscriptionMBMessageLocalServiceWrapper
 
 	private CompanyLocalService _companyLocalService;
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
+
 	private MBDiscussionLocalService _mbDiscussionLocalService;
 	private MBMessageLocalService _mbMessageLocalService;
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -93,7 +93,7 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -530,7 +530,7 @@ public class CalendarPortlet extends MVCPortlet {
 
 		String redirect = getRedirect(actionRequest, actionResponse);
 
-		redirect = HttpUtil.setParameter(
+		redirect = _http.setParameter(
 			redirect, actionResponse.getNamespace() + "calendarBookingId",
 			calendarBooking.getCalendarBookingId());
 
@@ -758,18 +758,18 @@ public class CalendarPortlet extends MVCPortlet {
 
 		String namespace = actionResponse.getNamespace();
 
-		editCalendarURL = HttpUtil.setParameter(
+		editCalendarURL = _http.setParameter(
 			editCalendarURL, "p_p_id", themeDisplay.getPpid());
-		editCalendarURL = HttpUtil.setParameter(
+		editCalendarURL = _http.setParameter(
 			editCalendarURL, namespace + "mvcPath",
 			templatePath + "edit_calendar.jsp");
-		editCalendarURL = HttpUtil.setParameter(
+		editCalendarURL = _http.setParameter(
 			editCalendarURL, namespace + "redirect",
 			getRedirect(actionRequest, actionResponse));
-		editCalendarURL = HttpUtil.setParameter(
+		editCalendarURL = _http.setParameter(
 			editCalendarURL, namespace + "backURL",
 			ParamUtil.getString(actionRequest, "backURL"));
-		editCalendarURL = HttpUtil.setParameter(
+		editCalendarURL = _http.setParameter(
 			editCalendarURL, namespace + "calendarId",
 			calendar.getCalendarId());
 
@@ -1651,6 +1651,9 @@ public class CalendarPortlet extends MVCPortlet {
 	private CalendarResourceService _calendarResourceService;
 	private CalendarService _calendarService;
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/foundation/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/filter/SPAFilter.java
+++ b/modules/apps/foundation/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/filter/SPAFilter.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.BaseFilter;
 import com.liferay.portal.kernel.servlet.BrowserSniffer;
 import com.liferay.portal.kernel.servlet.TryFilter;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
@@ -47,7 +47,7 @@ public class SPAFilter extends BaseFilter implements TryFilter {
 			HttpServletRequest request, HttpServletResponse response)
 		throws Exception {
 
-		response.setHeader("X-Request-URL", HttpUtil.getCompleteURL(request));
+		response.setHeader("X-Request-URL", _http.getCompleteURL(request));
 
 		return null;
 	}
@@ -68,5 +68,8 @@ public class SPAFilter extends BaseFilter implements TryFilter {
 
 	@Reference
 	private BrowserSniffer _browserSniffer;
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/PasswordPoliciesAdminPortlet.java
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/PasswordPoliciesAdminPortlet.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -178,7 +178,7 @@ public class PasswordPoliciesAdminPortlet extends MVCPortlet {
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
 
 		if (Validator.isNotNull(redirect)) {
-			redirect = HttpUtil.setParameter(
+			redirect = _http.setParameter(
 				redirect, actionResponse.getNamespace() + "passwordPolicyId",
 				passwordPolicyId);
 
@@ -280,6 +280,9 @@ public class PasswordPoliciesAdminPortlet extends MVCPortlet {
 	protected void setUserService(UserService userService) {
 		_userService = userService;
 	}
+
+	@Reference
+	private Http _http;
 
 	private OrganizationService _organizationService;
 	private PasswordPolicyService _passwordPolicyService;

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/PortletSharedRequestHelperImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/PortletSharedRequestHelperImpl.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.search.web.internal.portlet.shared.task;
 
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.web.internal.util.SearchArrayUtil;
 import com.liferay.portal.search.web.internal.util.SearchStringUtil;
@@ -45,11 +45,7 @@ public class PortletSharedRequestHelperImpl
 
 	@Override
 	public String getCompleteURL(RenderRequest renderRequest) {
-
-		// Must use HttpUtil instead of @Reference Http, otherwise, the
-		// component remains undeployed, with no stack trace
-
-		String urlString = HttpUtil.getCompleteURL(
+		String urlString = _http.getCompleteURL(
 			getSharedRequest(renderRequest));
 
 		return urlString;
@@ -100,5 +96,8 @@ public class PortletSharedRequestHelperImpl
 
 	@Reference
 	protected Portal portal;
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/action/SearchBarRedirectMVCActionCommand.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/action/SearchBarRedirectMVCActionCommand.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.web.internal.display.context.PortletRequestThemeDisplaySupplier;
 import com.liferay.portal.search.web.internal.display.context.ThemeDisplaySupplier;
@@ -57,7 +57,7 @@ public class SearchBarRedirectMVCActionCommand extends BaseMVCActionCommand {
 
 		Optional<String> urlOptional = parameterValueOptional.map(
 			parameterValue ->
-				HttpUtil.addParameter(url, parameterName, parameterValue));
+				_http.addParameter(url, parameterName, parameterValue));
 
 		return urlOptional.orElse(url);
 	}
@@ -137,5 +137,8 @@ public class SearchBarRedirectMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	protected Portal portal;
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.search.web.internal.display.context.PortletURLFactory;
 import com.liferay.portal.search.web.internal.display.context.PortletURLFactoryImpl;
@@ -356,9 +356,9 @@ public class SearchResultsPortlet
 		String urlString = portletSharedRequestHelper.getCompleteURL(
 			renderRequest);
 
-		urlString = HttpUtil.removeParameter(
+		urlString = _http.removeParameter(
 			urlString, paginationDeltaParameterName);
-		urlString = HttpUtil.removeParameter(
+		urlString = _http.removeParameter(
 			urlString, paginationStartParameterName);
 
 		return urlString;
@@ -432,6 +432,9 @@ public class SearchResultsPortlet
 
 	@Reference
 	protected ResourceActions resourceActions;
+
+	@Reference
+	private Http _http;
 
 	private final Set<SearchResultImageContributor>
 		_searchResultImageContributors = new HashSet<>();

--- a/modules/apps/foundation/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/action/SearchBarRedirectMVCActionCommandTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/action/SearchBarRedirectMVCActionCommandTest.java
@@ -16,10 +16,10 @@ package com.liferay.portal.search.web.internal.search.bar.portlet.action;
 
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -47,11 +47,13 @@ public class SearchBarRedirectMVCActionCommandTest {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 
-		setUpHttpUtil();
 		setUpPortalUtil();
 
 		searchBarRedirectMVCActionCommand =
 			createSearchBarRedirectMVCActionCommand();
+
+		ReflectionTestUtil.setFieldValue(
+			searchBarRedirectMVCActionCommand, "_http", http);
 	}
 
 	@Test
@@ -133,12 +135,6 @@ public class SearchBarRedirectMVCActionCommandTest {
 
 		searchBarRedirectMVCActionCommand.doProcessAction(
 			actionRequest, actionResponse);
-	}
-
-	protected void setUpHttpUtil() {
-		HttpUtil httpUtil = new HttpUtil();
-
-		httpUtil.setHttp(http);
 	}
 
 	protected void setUpPortalUtil() {

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.servlet.BaseFilter;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -226,8 +226,7 @@ public class CASFilter extends BaseFilter {
 			if (Validator.isNull(ticket)) {
 				String loginUrl = casConfiguration.loginURL();
 
-				loginUrl = HttpUtil.addParameter(
-					loginUrl, "service", serviceUrl);
+				loginUrl = _http.addParameter(loginUrl, "service", serviceUrl);
 
 				response.sendRedirect(loginUrl);
 
@@ -265,6 +264,9 @@ public class CASFilter extends BaseFilter {
 		new ConcurrentHashMap<>();
 
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.configuration.FacebookConnectConfiguration;
@@ -62,25 +61,25 @@ public class FacebookConnectImpl implements FacebookConnect {
 		FacebookConnectConfiguration facebookConnectConfiguration =
 			getFacebookConnectConfiguration(companyId);
 
-		String url = HttpUtil.addParameter(
+		String url = _http.addParameter(
 			facebookConnectConfiguration.oauthTokenURL(), "client_id",
 			facebookConnectConfiguration.appId());
 
 		String facebookConnectRedirectURL =
 			facebookConnectConfiguration.oauthRedirectURL();
 
-		url = HttpUtil.addParameter(
+		url = _http.addParameter(
 			url, "redirect_uri", facebookConnectRedirectURL);
 
-		facebookConnectRedirectURL = HttpUtil.addParameter(
+		facebookConnectRedirectURL = _http.addParameter(
 			facebookConnectRedirectURL, "redirect", redirect);
 
-		url = HttpUtil.addParameter(
+		url = _http.addParameter(
 			url, "redirect_uri", facebookConnectRedirectURL);
 
-		url = HttpUtil.addParameter(
+		url = _http.addParameter(
 			url, "client_secret", facebookConnectConfiguration.appSecret());
-		url = HttpUtil.addParameter(url, "code", code);
+		url = _http.addParameter(url, "code", code);
 
 		Http.Options options = new Http.Options();
 
@@ -88,7 +87,7 @@ public class FacebookConnectImpl implements FacebookConnect {
 		options.setPost(true);
 
 		try {
-			String content = HttpUtil.URLtoString(options);
+			String content = _http.URLtoString(options);
 
 			JSONObject contentJSONObject = JSONFactoryUtil.createJSONObject(
 				content);
@@ -144,19 +143,19 @@ public class FacebookConnectImpl implements FacebookConnect {
 		long companyId, String path, String accessToken, String fields) {
 
 		try {
-			String url = HttpUtil.addParameter(
+			String url = _http.addParameter(
 				getGraphURL(companyId).concat(path), "access_token",
 				accessToken);
 
 			if (Validator.isNotNull(fields)) {
-				url = HttpUtil.addParameter(url, "fields", fields);
+				url = _http.addParameter(url, "fields", fields);
 			}
 
 			Http.Options options = new Http.Options();
 
 			options.setLocation(url);
 
-			String json = HttpUtil.URLtoString(options);
+			String json = _http.URLtoString(options);
 
 			return JSONFactoryUtil.createJSONObject(json);
 		}
@@ -258,6 +257,9 @@ public class FacebookConnectImpl implements FacebookConnect {
 		FacebookConnectImpl.class);
 
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/OpenIdServiceHandlerImpl.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/OpenIdServiceHandlerImpl.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PwdGenerator;
@@ -258,13 +257,13 @@ public class OpenIdServiceHandlerImpl implements OpenIdServiceHandler {
 				String createAccountURL = _portal.getCreateAccountURL(
 					request, themeDisplay);
 
-				String portletId = HttpUtil.getParameter(
+				String portletId = _http.getParameter(
 					createAccountURL, "p_p_id", false);
 
 				String portletNamespace = _portal.getPortletNamespace(
 					portletId);
 
-				createAccountURL = HttpUtil.setParameter(
+				createAccountURL = _http.setParameter(
 					createAccountURL, portletNamespace + "openId", openId);
 
 				session.setAttribute(
@@ -519,6 +518,10 @@ public class OpenIdServiceHandlerImpl implements OpenIdServiceHandler {
 		OpenIdServiceHandlerImpl.class);
 
 	private ConsumerManager _consumerManager;
+
+	@Reference
+	private Http _http;
+
 	private OpenIdProviderRegistry _openIdProviderRegistry;
 
 	@Reference

--- a/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -51,7 +51,7 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -217,7 +217,7 @@ public class RolesAdminPortlet extends MVCPortlet {
 
 			String redirect = ParamUtil.getString(actionRequest, "redirect");
 
-			redirect = HttpUtil.setParameter(
+			redirect = _http.setParameter(
 				redirect, actionResponse.getNamespace() + "roleId",
 				role.getRoleId());
 
@@ -713,6 +713,10 @@ public class RolesAdminPortlet extends MVCPortlet {
 	}
 
 	private GroupService _groupService;
+
+	@Reference
+	private Http _http;
+
 	private PanelAppRegistry _panelAppRegistry;
 	private PanelCategoryRegistry _panelCategoryRegistry;
 

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditOrganizationMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditOrganizationMVCActionCommand.java
@@ -53,7 +53,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -120,7 +120,7 @@ public class EditOrganizationMVCActionCommand extends BaseMVCActionCommand {
 			String redirect = ParamUtil.getString(actionRequest, "redirect");
 
 			if (organization != null) {
-				redirect = HttpUtil.setParameter(
+				redirect = _http.setParameter(
 					redirect, actionResponse.getNamespace() + "organizationId",
 					organization.getOrganizationId());
 			}
@@ -177,7 +177,7 @@ public class EditOrganizationMVCActionCommand extends BaseMVCActionCommand {
 						actionRequest, "organizationId");
 
 					if (organizationId > 0) {
-						redirect = HttpUtil.setParameter(
+						redirect = _http.setParameter(
 							redirect,
 							actionResponse.getNamespace() + "organizationId",
 							organizationId);
@@ -316,6 +316,10 @@ public class EditOrganizationMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private Http _http;
+
 	private OrganizationService _organizationService;
 
 	@Reference

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -83,7 +83,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -382,7 +382,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 						redirect, themeDisplay.getI18nPath(), i18nPath);
 				}
 
-				redirect = HttpUtil.setParameter(
+				redirect = _http.setParameter(
 					redirect, actionResponse.getNamespace() + "p_u_i_d",
 					user.getUserId());
 			}
@@ -393,8 +393,8 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 				(userLocalService.fetchUserById(scopeGroup.getClassPK()) ==
 					null)) {
 
-				redirect = HttpUtil.setParameter(redirect, "doAsGroupId", 0);
-				redirect = HttpUtil.setParameter(redirect, "refererPlid", 0);
+				redirect = _http.setParameter(redirect, "doAsGroupId", 0);
+				redirect = _http.setParameter(redirect, "refererPlid", 0);
 			}
 
 			sendRedirect(actionRequest, actionResponse, redirect);
@@ -467,7 +467,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 					if (submittedPassword) {
 						User user = portal.getSelectedUser(actionRequest);
 
-						redirect = HttpUtil.setParameter(
+						redirect = _http.setParameter(
 							redirect, actionResponse.getNamespace() + "p_u_i_d",
 							user.getUserId());
 					}
@@ -828,6 +828,10 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private Http _http;
+
 	private ListTypeLocalService _listTypeLocalService;
 	private UserService _userService;
 

--- a/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/action/WebProxyConfigurationAction.java
+++ b/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/action/WebProxyConfigurationAction.java
@@ -16,7 +16,7 @@ package com.liferay.web.proxy.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.web.proxy.web.internal.constants.WebProxyPortletKeys;
 
@@ -58,7 +58,7 @@ public class WebProxyConfigurationAction extends DefaultConfigurationAction {
 			!StringUtil.startsWith(initUrl, "https://") &&
 			!StringUtil.startsWith(initUrl, "mhtml://")) {
 
-			initUrl = HttpUtil.getProtocol(actionRequest) + "://" + initUrl;
+			initUrl = _http.getProtocol(actionRequest) + "://" + initUrl;
 		}
 
 		setPreference(actionRequest, "initUrl", initUrl);
@@ -74,5 +74,8 @@ public class WebProxyConfigurationAction extends DefaultConfigurationAction {
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/events/KBServicePreAction.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/events/KBServicePreAction.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Peter Shin
@@ -96,7 +97,7 @@ public class KBServicePreAction extends Action {
 		// A guest user that signs in will cause the original portlet
 		// authentication token to become stale. See SessionAuthToken.
 
-		String redirect = HttpUtil.setParameter(
+		String redirect = _http.setParameter(
 			themeDisplay.getURLCurrent(), "p_p_auth", actual_p_p_auth);
 
 		response.sendRedirect(redirect);
@@ -109,5 +110,8 @@ public class KBServicePreAction extends Action {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		KBServicePreAction.class);
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
@@ -47,7 +47,6 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -424,7 +423,7 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 			options.setLocation(url);
 			options.setPost(false);
 
-			byte[] bytes = HttpUtil.URLtoByteArray(options);
+			byte[] bytes = _http.URLtoByteArray(options);
 
 			Http.Response response = options.getResponse();
 
@@ -532,6 +531,10 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 	private static final String _DEPLOY_TO_PREFIX = "DEPLOY_TO__";
 
 	private AppService _appService;
+
+	@Reference
+	private Http _http;
+
 	private PanelAppRegistry _panelAppRegistry;
 	private PanelCategoryRegistry _panelCategoryRegistry;
 	private PluginSettingLocalService _pluginSettingLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
@@ -17,7 +17,7 @@ package com.liferay.portal.osgi.web.wab.reference.support.internal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.DocumentException;
@@ -65,7 +65,7 @@ public class WabDirURLStreamHandlerService
 	@Override
 	public URLConnection openConnection(URL url) {
 		try {
-			String contextName = HttpUtil.getParameter(
+			String contextName = _http.getParameter(
 				url.toExternalForm(), "Web-ContextPath");
 
 			URI uri = new URI(url.getPath());
@@ -174,6 +174,10 @@ public class WabDirURLStreamHandlerService
 		".*\\/(.*-(T|t)heme)\\/.*");
 
 	private ClassLoader _classLoader;
+
+	@Reference
+	private Http _http;
+
 	private WabGenerator _wabGenerator;
 
 }

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/servlet/SyncDownloadServlet.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/servlet/SyncDownloadServlet.java
@@ -47,7 +47,7 @@ import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -128,7 +128,7 @@ public class SyncDownloadServlet extends HttpServlet {
 
 			PermissionThreadLocal.setPermissionChecker(permissionChecker);
 
-			String path = HttpUtil.fixPath(request.getPathInfo());
+			String path = _http.fixPath(request.getPathInfo());
 
 			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 
@@ -597,6 +597,10 @@ public class SyncDownloadServlet extends HttpServlet {
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 	private DLFileVersionLocalService _dlFileVersionLocalService;
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
+
 	private ImageLocalService _imageLocalService;
 
 	@Reference

--- a/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/deploy/hot/LegacyPortletPanelAppHotDeployListener.java
+++ b/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/deploy/hot/LegacyPortletPanelAppHotDeployListener.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.deploy.hot.HotDeployListener;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
@@ -131,7 +131,7 @@ public class LegacyPortletPanelAppHotDeployListener
 
 		ServletContext servletContext = hotDeployEvent.getServletContext();
 
-		String xml = HttpUtil.URLtoString(
+		String xml = _http.URLtoString(
 			servletContext.getResource("/WEB-INF/liferay-portlet.xml"));
 
 		if (xml == null) {
@@ -188,6 +188,9 @@ public class LegacyPortletPanelAppHotDeployListener
 	}
 
 	private BundleContext _bundleContext;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/DisplayPageFriendlyURLResolver.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/DisplayPageFriendlyURLResolver.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.model.PortletInstance;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.InheritableMap;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -137,7 +137,7 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 			namespace + "urlTitle",
 			new String[] {journalArticle.getUrlTitle()});
 
-		String queryString = HttpUtil.parameterMapToString(actualParams, false);
+		String queryString = _http.parameterMapToString(actualParams, false);
 
 		if (layoutActualURL.contains(StringPool.QUESTION)) {
 			layoutActualURL =
@@ -219,6 +219,10 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 	}
 
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private Http _http;
+
 	private JournalArticleLocalService _journalArticleLocalService;
 	private LayoutLocalService _layoutLocalService;
 

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -45,7 +45,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -146,7 +146,7 @@ public class DefaultTextExportImportContentProcessor
 
 		String urlParams = sb.substring(beginPos + 1, endPos);
 
-		urlParams = HttpUtil.removeParameter(urlParams, "t");
+		urlParams = _http.removeParameter(urlParams, "t");
 
 		sb.replace(beginPos + 1, endPos, urlParams);
 	}
@@ -191,8 +191,7 @@ public class DefaultTextExportImportContentProcessor
 			}
 			else if (pathArray.length == 5) {
 				map.put("folderId", new String[] {pathArray[3]});
-				map.put(
-					"title", new String[] {HttpUtil.decodeURL(pathArray[4])});
+				map.put("title", new String[] {_http.decodeURL(pathArray[4])});
 			}
 			else if (pathArray.length > 5) {
 				map.put("uuid", new String[] {pathArray[5]});
@@ -202,7 +201,7 @@ public class DefaultTextExportImportContentProcessor
 			dlReference = dlReference.substring(
 				dlReference.indexOf(CharPool.QUESTION) + 1);
 
-			map = HttpUtil.parameterMapFromString(dlReference);
+			map = _http.parameterMapFromString(dlReference);
 
 			String[] imageIds = null;
 
@@ -395,11 +394,11 @@ public class DefaultTextExportImportContentProcessor
 			long groupId, String url, StringBundler urlSB)
 		throws PortalException {
 
-		if (!HttpUtil.hasProtocol(url)) {
+		if (!_http.hasProtocol(url)) {
 			return url;
 		}
 
-		boolean secure = HttpUtil.isSecure(url);
+		boolean secure = _http.isSecure(url);
 
 		int serverPort = _portal.getPortalServerPort(secure);
 
@@ -1467,6 +1466,9 @@ public class DefaultTextExportImportContentProcessor
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;

--- a/modules/apps/web-experience/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
+++ b/modules/apps/web-experience/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/portlet/action/IFrameConfigurationAction.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -65,7 +65,7 @@ public class IFrameConfigurationAction extends DefaultConfigurationAction {
 			!StringUtil.startsWith(src, "https://") &&
 			!StringUtil.startsWith(src, "mhtml://")) {
 
-			src = HttpUtil.getProtocol(actionRequest) + "://" + src;
+			src = _http.getProtocol(actionRequest) + "://" + src;
 
 			setPreference(actionRequest, "src", src);
 		}
@@ -121,5 +121,8 @@ public class IFrameConfigurationAction extends DefaultConfigurationAction {
 			}
 		}
 	}
+
+	@Reference
+	private Http _http;
 
 }

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
@@ -77,7 +77,7 @@ import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -366,7 +366,7 @@ public class SiteAdminPortlet extends MVCPortlet {
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
 
-		return HttpUtil.getParameter(
+		return http.getParameter(
 			redirect, actionResponse.getNamespace() + "historyKey", false);
 	}
 
@@ -925,6 +925,10 @@ public class SiteAdminPortlet extends MVCPortlet {
 	protected GroupSearchProvider groupSearchProvider;
 	protected GroupService groupService;
 	protected GroupURLProvider groupURLProvider;
+
+	@Reference
+	protected Http http;
+
 	protected LayoutLocalService layoutLocalService;
 	protected LayoutSetLocalService layoutSetLocalService;
 	protected LayoutSetPrototypeService layoutSetPrototypeService;

--- a/modules/apps/web-experience/site/site-api/src/main/java/com/liferay/site/util/GroupURLProvider.java
+++ b/modules/apps/web-experience/site/site-api/src/main/java/com/liferay/site/util/GroupURLProvider.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -103,13 +103,13 @@ public class GroupURLProvider {
 		String groupDisplayURL = group.getDisplayURL(themeDisplay, false);
 
 		if (Validator.isNotNull(groupDisplayURL)) {
-			return HttpUtil.removeParameter(groupDisplayURL, "p_p_id");
+			return _http.removeParameter(groupDisplayURL, "p_p_id");
 		}
 
 		groupDisplayURL = group.getDisplayURL(themeDisplay, true);
 
 		if (Validator.isNotNull(groupDisplayURL)) {
-			return HttpUtil.removeParameter(groupDisplayURL, "p_p_id");
+			return _http.removeParameter(groupDisplayURL, "p_p_id");
 		}
 
 		if (includeStagingGroup && group.hasStagingGroup()) {
@@ -146,6 +146,9 @@ public class GroupURLProvider {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		GroupURLProvider.class);
+
+	@Reference
+	private Http _http;
 
 	private PanelAppRegistry _panelAppRegistry;
 	private PanelCategoryRegistry _panelCategoryRegistry;

--- a/modules/apps/wsrp/wsrp-service/src/main/java/com/liferay/wsrp/internal/servlet/ProxyServlet.java
+++ b/modules/apps/wsrp/wsrp-service/src/main/java/com/liferay/wsrp/internal/servlet/ProxyServlet.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -96,7 +96,7 @@ public class ProxyServlet extends HttpServlet {
 			return true;
 		}
 
-		String domain = HttpUtil.getDomain(url);
+		String domain = _http.getDomain(url);
 
 		int pos = domain.indexOf(CharPool.COLON);
 
@@ -200,6 +200,9 @@ public class ProxyServlet extends HttpServlet {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(ProxyServlet.class);
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Portal _portal;

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -375,9 +375,7 @@
 		<property name="html" ref="com.liferay.portal.util.HtmlImpl" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.util.HttpUtil" id="com.liferay.portal.kernel.util.HttpUtil">
-		<property name="http">
-			<bean class="com.liferay.portal.util.HttpImpl" />
-		</property>
+		<property name="http" ref="com.liferay.portal.util.HttpImpl" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.util.LocalizationUtil" id="com.liferay.portal.kernel.util.LocalizationUtil">
 		<property name="localization">
@@ -497,6 +495,7 @@
 	<bean class="com.liferay.portal.template.DDMTemplateResourceParser" id="com.liferay.portal.template.DDMTemplateResourceParser" />
 	<bean class="com.liferay.portal.template.ThemeResourceParser" id="com.liferay.portal.template.ThemeResourceParser" />
 	<bean class="com.liferay.portal.util.HtmlImpl" id="com.liferay.portal.util.HtmlImpl" />
+	<bean class="com.liferay.portal.util.HttpImpl" id="com.liferay.portal.util.HttpImpl" />
 	<bean class="com.liferay.portal.util.PortalImpl" id="com.liferay.portal.util.Portal" />
 	<bean class="com.liferay.portal.verify.model.AddressVerifiableModel" />
 	<bean class="com.liferay.portal.verify.model.AnnouncementsEntryVerifiableModel" />

--- a/portal-impl/src/source-formatter.properties
+++ b/portal-impl/src/source-formatter.properties
@@ -233,6 +233,7 @@
     # See LPS-69661.
     #
     service.reference.util.class.names=\
+        com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 
 ##


### PR DESCRIPTION
Hi Hugo, I am trying to run SF on the com-liferay-journal subrepo after changing a SF property in portal-impl (5129bda) and I am running into 2 different behaviors:

1. Running `~/liferay-portal/gradlew formatSource` inside` com-liferay-journal` subrepo results in SF not picking up the lines inside com-liferay-journal that violates the rule set in above commit.

2. After copying` com-liferay-journal/.git` directory into `/liferay-portal/modules/apps/web-experience/journal` and then running `gw formatSource` from `/liferay-portal/modules/apps/web-experience/journal` results in SF picking up the lines that violates the rule set. (gw is an alias to /liferay-portal/gradlew)

So our question is: should SF pick up the properties set in portal-impl?

Thanks!