### PR TITLE
[TS] LPS-72841

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -1006,7 +1006,7 @@ AUI.add(
 				'keyword': Liferay.Language.get('yes')
 			};
 
-			if (type == 'text') {
+			if (type == 'ddm-image' || type == 'text') {
 				indexTypeOptions = {
 					'': Liferay.Language.get('not-indexable'),
 					'keyword': Liferay.Language.get('indexable-keyword'),
@@ -1376,6 +1376,10 @@ AUI.add(
 
 					fieldNamespace: {
 						value: 'ddm'
+					},
+
+					indexType: {
+						value: 'text'
 					}
 				},
 


### PR DESCRIPTION
Hi Hugo,

The root issue is we index ddm-image field as non-Tokenized ("indexType": "keyword"). The ddm-image field has <input type="text"> and we can input characters longer than 32766 in this <input>. When save, it won't index the content of this field and the error "whose UTF8 encoding is longer than the max length 32766" will occur from ES.

**Why the error occurs?**
https://discuss.elastic.co/t/encoding-is-longer-than-the-max-length-32766/17819/6
https://stackoverflow.com/questions/24019868/utf8-encoding-is-longer-than-the-max-length-32766

**We define ddm-image field as non-Tokenized ("indexType": "keyword")**, please refer to
https://github.com/yuhai/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L190
->
https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java#L428-L431
->...

The fix makes it as same as text field.

Regards,
Hai
