### PR TITLE
LPS-73078 - Workflow Notification says "Notification no longer applies"

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseUserNotificationHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseUserNotificationHandler.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.service.UserNotificationDeliveryLocalServiceUti
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Jonathan Lee
@@ -135,7 +134,7 @@ public abstract class BaseUserNotificationHandler
 
 		String body = getBody(userNotificationEvent, serviceContext);
 
-		if (Validator.isNull(body)) {
+		if (body == null) {
 			return null;
 		}
 


### PR DESCRIPTION
Hey @hhuijser  here are some details.

1: freemarker ignores superfluous line break like "\n\n". after calling template.process(map, stringWriter); 

2: stringWriter.toString() will be empty

3: this fix make it possible to send empty notification to the user. instead of "notification-for-x-was-deleted".
