### PR TITLE
[TS] LPS-73011 

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1189,6 +1189,13 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		String[] roleNames = portlet.getRolesArray();
 
+		Portlet existingPortlet = portletPersistence.fetchByC_P(
+			portlet.getCompanyId(), portlet.getPortletId());
+
+		if (existingPortlet != null) {
+			roleNames = existingPortlet.getRolesArray();
+		}
+
 		if (roleNames.length == 0) {
 			return;
 		}


### PR DESCRIPTION
Hi Hugo,

The issue is when we remove "ADD_TO_PAGE" permission on UI,  it will add back after restart portal.

**The issue didn't occur in 6.2. Please refer to the below reason.**
When the portal starts with empty database, we will firstly add portlet's "ADD_TO_PAGE" permission, and then add related data in the portlet table. When adding data into  portlet table, we set roles for BLANK (https://github.com/yuhai/liferay-portal-ee/blob/ee-6.2.x/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L181-L183). The purpose is when the portal restart again, we won't add "ADD_TO_PAGE" permission again, we use this way (https://github.com/yuhai/liferay-portal-ee/blob/ee-6.2.x/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L152-L153) to judge.  

Why portal restart and this **roleNames.length == 0**?
Because in the first (init portal, empty database) start, we add roles=BLANK for portlet data in portlet table. When restart portal, roleNames.length will be 0.
Please refer to PortletLocalServiceImpl.checkPortlets()->getPortlets()->_getPortletsPool()->loadGetPortletsPool()->https://github.com/yuhai/liferay-portal-ee/blob/ee-6.2.x/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L861-L878

On 7.0, since we use different framework, every module has own portlet definition file,  not like 6.2 (security-role-ref defines in https://github.com/yuhai/liferay-portal-ee/blob/ee-6.2.x/portal-web/docroot/WEB-INF/portlet-custom.xml). So when  PortletLocalServiceImpl.checkPortlets() executes, it won't check module's portlet. When portlet deploy (PortletTracker.deployPortlet()->PortletLocalServiceImpl.deployRemotePortlet()->checkPortlet()), the fix use the logic (**roleNames.length == 0**) to avoid the permission added again when restart.

Regards,
Hai