### PR TITLE
Lps 73181 fix

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -972,72 +972,6 @@ public class LayoutTypePortletImpl
 			StringUtil.merge(nestedColumnIdsArray));
 	}
 
-	private void _removeNestedColumns(
-		String portletNamespace, Set<String> portletIdList) {
-
-		UnicodeProperties typeSettingsProperties = getTypeSettingsProperties();
-
-		UnicodeProperties newTypeSettingsProperties = new UnicodeProperties();
-
-		String nestedPortletIds = "";
-
-		for (Map.Entry<String, String> entry :
-			typeSettingsProperties.entrySet()) {
-
-			String key = entry.getKey();
-	
-			if (key.startsWith(portletNamespace)) {
-				nestedPortletIds += entry.getValue();
-				nestedPortletIds += CharPool.COMMA;
-			}
-		}
-
-		if (Validator.isNotNull(nestedPortletIds)) {
-			for (String nestedPortletId :
-				StringUtil.split(nestedPortletIds)) {
-	
-				String childNestedPortletNamespace =
-					PortalUtil.getPortletNamespace(nestedPortletId);
-	
-				_removeNestedColumns(
-					childNestedPortletNamespace, portletIdList);
-	
-				removeModesPortletId(nestedPortletId);
-				removeStatesPortletId(nestedPortletId);
-	
-				portletIdList.add(nestedPortletId);
-			}
-		}
-
-		typeSettingsProperties = getTypeSettingsProperties();
-
-		for (Map.Entry<String, String> entry :
-				typeSettingsProperties.entrySet()) {
-
-			String key = entry.getKey();
-
-			if (!key.startsWith(portletNamespace)) {
-				newTypeSettingsProperties.setProperty(key, entry.getValue());
-				continue;
-			}
-		}
-
-		Layout layout = getLayout();
-
-		layout.setTypeSettingsProperties(newTypeSettingsProperties);
-
-		String nestedColumnIds = GetterUtil.getString(
-			getTypeSettingsProperty(
-				LayoutTypePortletConstants.NESTED_COLUMN_IDS));
-
-		String[] nestedColumnIdsArray = ArrayUtil.removeByPrefix(
-			StringUtil.split(nestedColumnIds), portletNamespace);
-
-		setTypeSettingsProperty(
-			LayoutTypePortletConstants.NESTED_COLUMN_IDS,
-			StringUtil.merge(nestedColumnIdsArray));
-	}
-
 	@Override
 	public void removePortletId(long userId, String portletId) {
 		removePortletId(userId, portletId, true);
@@ -1999,6 +1933,70 @@ public class LayoutTypePortletImpl
 		}
 
 		return _group;
+	}
+
+	private void _removeNestedColumns(
+		String portletNamespace, Set<String> portletIdList) {
+
+		UnicodeProperties typeSettingsProperties = getTypeSettingsProperties();
+
+		UnicodeProperties newTypeSettingsProperties = new UnicodeProperties();
+
+		String nestedPortletIds = "";
+
+		for (Map.Entry<String, String> entry :
+				typeSettingsProperties.entrySet()) {
+
+			String key = entry.getKey();
+
+			if (key.startsWith(portletNamespace)) {
+				nestedPortletIds += entry.getValue();
+				nestedPortletIds += CharPool.COMMA;
+			}
+		}
+
+		if (Validator.isNotNull(nestedPortletIds)) {
+			for (String nestedPortletId : StringUtil.split(nestedPortletIds)) {
+				String childNestedPortletNamespace =
+					PortalUtil.getPortletNamespace(nestedPortletId);
+
+				_removeNestedColumns(
+					childNestedPortletNamespace, portletIdList);
+
+				removeModesPortletId(nestedPortletId);
+				removeStatesPortletId(nestedPortletId);
+
+				portletIdList.add(nestedPortletId);
+			}
+		}
+
+		typeSettingsProperties = getTypeSettingsProperties();
+
+		for (Map.Entry<String, String> entry :
+				typeSettingsProperties.entrySet()) {
+
+			String key = entry.getKey();
+
+			if (!key.startsWith(portletNamespace)) {
+				newTypeSettingsProperties.setProperty(key, entry.getValue());
+				continue;
+			}
+		}
+
+		Layout layout = getLayout();
+
+		layout.setTypeSettingsProperties(newTypeSettingsProperties);
+
+		String nestedColumnIds = GetterUtil.getString(
+			getTypeSettingsProperty(
+				LayoutTypePortletConstants.NESTED_COLUMN_IDS));
+
+		String[] nestedColumnIdsArray = ArrayUtil.removeByPrefix(
+			StringUtil.split(nestedColumnIds), portletNamespace);
+
+		setTypeSettingsProperty(
+			LayoutTypePortletConstants.NESTED_COLUMN_IDS,
+			StringUtil.merge(nestedColumnIdsArray));
 	}
 
 	private static final String _MODIFIED_DATE = "modifiedDate";

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -971,6 +971,51 @@ public class LayoutTypePortletImpl
 			StringUtil.merge(nestedColumnIdsArray));
 	}
 
+	public void removeNestedColumns(
+		String portletNamespace, Set<String> portletIdList) {
+
+		UnicodeProperties typeSettingsProperties = getTypeSettingsProperties();
+
+		UnicodeProperties newTypeSettingsProperties = new UnicodeProperties();
+
+		for (Map.Entry<String, String> entry :
+				typeSettingsProperties.entrySet()) {
+
+			String key = entry.getKey();
+
+			if (!key.startsWith(portletNamespace)) {
+				newTypeSettingsProperties.setProperty(key, entry.getValue());
+				continue;
+			}
+
+			String nestedPortletIds = entry.getValue();
+
+			for (String nestedPortletId :
+				StringUtil.split(nestedPortletIds)) {
+
+				removeModesPortletId(nestedPortletId);
+				removeStatesPortletId(nestedPortletId);
+	
+				portletIdList.add(nestedPortletId);
+			}
+		}
+
+		Layout layout = getLayout();
+
+		layout.setTypeSettingsProperties(newTypeSettingsProperties);
+
+		String nestedColumnIds = GetterUtil.getString(
+			getTypeSettingsProperty(
+				LayoutTypePortletConstants.NESTED_COLUMN_IDS));
+
+		String[] nestedColumnIdsArray = ArrayUtil.removeByPrefix(
+			StringUtil.split(nestedColumnIds), portletNamespace);
+
+		setTypeSettingsProperty(
+			LayoutTypePortletConstants.NESTED_COLUMN_IDS,
+			StringUtil.merge(nestedColumnIdsArray));
+	}
+
 	@Override
 	public void removePortletId(long userId, String portletId) {
 		removePortletId(userId, portletId, true);
@@ -1884,31 +1929,7 @@ public class LayoutTypePortletImpl
 				String portletNamespace = PortalUtil.getPortletNamespace(
 					portletId);
 
-				UnicodeProperties typeSettingsProperties =
-					getTypeSettingsProperties();
-
-				for (Map.Entry<String, String> entry :
-						typeSettingsProperties.entrySet()) {
-
-					String key = entry.getKey();
-
-					if (!key.startsWith(portletNamespace)) {
-						continue;
-					}
-
-					String nestedPortletIds = entry.getValue();
-
-					for (String nestedPortletId :
-							StringUtil.split(nestedPortletIds)) {
-
-						removeModesPortletId(nestedPortletId);
-						removeStatesPortletId(nestedPortletId);
-
-						portletIdList.add(nestedPortletId);
-					}
-				}
-
-				removeNestedColumns(portletNamespace);
+				removeNestedColumns(portletNamespace, portletIdList);
 			}
 
 			Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -978,7 +979,7 @@ public class LayoutTypePortletImpl
 
 		UnicodeProperties newTypeSettingsProperties = new UnicodeProperties();
 
-		String nestedPortletIds = null;
+		String nestedPortletIds = "";
 
 		for (Map.Entry<String, String> entry :
 			typeSettingsProperties.entrySet()) {
@@ -986,8 +987,8 @@ public class LayoutTypePortletImpl
 			String key = entry.getKey();
 	
 			if (key.startsWith(portletNamespace)) {
-				nestedPortletIds = entry.getValue();
-				break;
+				nestedPortletIds += entry.getValue();
+				nestedPortletIds += CharPool.COMMA;
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -972,7 +972,7 @@ public class LayoutTypePortletImpl
 			StringUtil.merge(nestedColumnIdsArray));
 	}
 
-	public void removeNestedColumns(
+	private void _removeNestedColumns(
 		String portletNamespace, Set<String> portletIdList) {
 
 		UnicodeProperties typeSettingsProperties = getTypeSettingsProperties();
@@ -999,7 +999,7 @@ public class LayoutTypePortletImpl
 				String childNestedPortletNamespace =
 					PortalUtil.getPortletNamespace(nestedPortletId);
 	
-				removeNestedColumns(
+				_removeNestedColumns(
 					childNestedPortletNamespace, portletIdList);
 	
 				removeModesPortletId(nestedPortletId);
@@ -1951,7 +1951,7 @@ public class LayoutTypePortletImpl
 				String portletNamespace = PortalUtil.getPortletNamespace(
 					portletId);
 
-				removeNestedColumns(portletNamespace, portletIdList);
+				_removeNestedColumns(portletNamespace, portletIdList);
 			}
 
 			Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -978,6 +978,38 @@ public class LayoutTypePortletImpl
 
 		UnicodeProperties newTypeSettingsProperties = new UnicodeProperties();
 
+		String nestedPortletIds = null;
+
+		for (Map.Entry<String, String> entry :
+			typeSettingsProperties.entrySet()) {
+
+			String key = entry.getKey();
+	
+			if (key.startsWith(portletNamespace)) {
+				nestedPortletIds = entry.getValue();
+				break;
+			}
+		}
+
+		if (Validator.isNotNull(nestedPortletIds)) {
+			for (String nestedPortletId :
+				StringUtil.split(nestedPortletIds)) {
+	
+				String childNestedPortletNamespace =
+					PortalUtil.getPortletNamespace(nestedPortletId);
+	
+				removeNestedColumns(
+					childNestedPortletNamespace, portletIdList);
+	
+				removeModesPortletId(nestedPortletId);
+				removeStatesPortletId(nestedPortletId);
+	
+				portletIdList.add(nestedPortletId);
+			}
+		}
+
+		typeSettingsProperties = getTypeSettingsProperties();
+
 		for (Map.Entry<String, String> entry :
 				typeSettingsProperties.entrySet()) {
 
@@ -986,17 +1018,6 @@ public class LayoutTypePortletImpl
 			if (!key.startsWith(portletNamespace)) {
 				newTypeSettingsProperties.setProperty(key, entry.getValue());
 				continue;
-			}
-
-			String nestedPortletIds = entry.getValue();
-
-			for (String nestedPortletId :
-				StringUtil.split(nestedPortletIds)) {
-
-				removeModesPortletId(nestedPortletId);
-				removeStatesPortletId(nestedPortletId);
-	
-				portletIdList.add(nestedPortletId);
 			}
 		}
 


### PR DESCRIPTION
not sure about if we can remove the old `public void removeNestedColumns(string)`, I dont see it used anywhere except in `public void removePortletId(long userId, String portletId)` and since I changed its calling method to my new created method, so I almost wanted to delete the old the method, but again it's a public method, I guess I just leave it there.