### PR TITLE
[TS] LPS-73479

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -253,7 +253,7 @@ AUI.add(
 
 						var portletNamespace = instance.get('portletNamespace');
 
-						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getURLControlPanel());
+						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getLayoutRelativeControlPanelURL());
 
 						portletURL.setParameter('criteria', 'com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion');
 						portletURL.setParameter('itemSelectedEventName', portletNamespace + 'selectDocumentLibrary');
@@ -281,7 +281,7 @@ AUI.add(
 					_getUploadURL: function() {
 						var instance = this;
 
-						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getURLControlPanel());
+						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getLayoutRelativeControlPanelURL());
 
 						portletURL.setLifecycle(Liferay.PortletURL.ACTION_PHASE);
 						portletURL.setParameter('cmd', 'add_temp');

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1096,7 +1096,7 @@ AUI.add(
 
 						var portletNamespace = instance.get('portletNamespace');
 
-						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getURLControlPanel());
+						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getLayoutRelativeControlPanelURL());
 
 						portletURL.setParameter('criteria', criteria);
 						portletURL.setParameter('itemSelectedEventName', portletNamespace + 'selectDocumentLibrary');
@@ -1141,7 +1141,7 @@ AUI.add(
 					getUploadURL: function() {
 						var instance = this;
 
-						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getURLControlPanel());
+						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getLayoutRelativeControlPanelURL());
 
 						portletURL.setLifecycle(Liferay.PortletURL.ACTION_PHASE);
 						portletURL.setParameter('cmd', 'add_temp');
@@ -2418,7 +2418,7 @@ AUI.add(
 
 						var portletNamespace = instance.get('portletNamespace');
 
-						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getURLControlPanel());
+						var portletURL = Liferay.PortletURL.createURL(themeDisplay.getLayoutRelativeControlPanelURL());
 
 						portletURL.setParameter('criteria', criteria);
 						portletURL.setParameter('itemSelectedEventName', portletNamespace + 'selectDocumentLibrary');

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -143,9 +143,25 @@
 
 		Liferay.ThemeDisplay = {
 			<c:if test="<%= layout != null %>">
+
+				<%
+				Group scopeGroup = themeDisplay.getScopeGroup();
+
+				Group liveGroup = StagingUtil.getLiveGroup(scopeGroup);
+
+				Layout controlPanelLayout = themeDisplay.getControlPanelLayout();
+				%>
+
 				getLayoutId: function() {
 					return '<%= layout.getLayoutId() %>';
 				},
+
+				<c:if test="<%= controlPanelLayout.getGroupId() != scopeGroup.getGroupId() %>">
+					getLayoutRelativeControlPanelURL: function() {
+						return '<%= PortalUtil.getLayoutRelativeURL(new VirtualLayout(controlPanelLayout, scopeGroup), themeDisplay) %>';
+					},
+				</c:if>
+
 				getLayoutRelativeURL: function() {
 					return '<%= PortalUtil.getLayoutRelativeURL(layout, themeDisplay) %>';
 				},
@@ -220,13 +236,6 @@
 			getPortalURL: function() {
 				return '<%= themeDisplay.getPortalURL() %>';
 			},
-
-			<%
-			Group scopeGroup = themeDisplay.getScopeGroup();
-
-			Group liveGroup = StagingUtil.getLiveGroup(scopeGroup);
-			%>
-
 			getScopeGroupId: function() {
 				return '<%= scopeGroup.getGroupId() %>';
 			},


### PR DESCRIPTION
Hi Hugo,

The issue was caused by LPS-71548. LPS-71548 looks like necessary (
Ask: https://issues.liferay.com/browse/LPS-73176?focusedCommentId=1056941&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1056941
Answer: https://github.com/liferay/liferay-portal/commit/2c532b54831e175232bee49dab1bb08ea81a3c7f)

The root issue is that when using getURLControlPanel(), its basePortletURL is '/group/control_panel?refererPlid=20132', it won't let https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/portlet/VirtualLayoutFriendlyURLResolver.java#L83-L85 executed because this url won't be treated as friendlyURL. If p_v_l_s_g_id =0, it won't execute 
https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/events/ServicePreAction.java#L371-L383. So that this layout will completely be control panel, in ItemSelector dialog, the CONTROL PANEL site will be default.

For the case, I thought add related param (p_v_l_s_g_id ) for portletURL (in getDocumentLibraryURL() method in ddm_form.js). However, this won't work because it will generate one array to include it (for example, the array element will be [0]=0, [1]=scoureGroupId. The p_v_l_s_g_id =0 will be added in https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L2676-L2678

So the fix logic is that generate own friendlyURL basePortletURL. I create one method in themeDisplay, its basePortletURL seems "/group/guest/~/control_panel/manage?". it will be treated as friendlyURL and can let https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/portlet/VirtualLayoutFriendlyURLResolver.java#L83-L85 executed.

Regards,
Hai


