### PR TITLE
LPS-70650 Autofocus not being set on Sign In portlet

### DIFF
--- a/portal-web/docroot/html/taglib/aui/form/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/end.jsp
@@ -84,6 +84,14 @@ String fullName = namespace + HtmlUtil.escapeJS(name);
 
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 		A.all('#<%= fullName %> .input-container').removeAttribute('disabled');
+		
+		<%if( GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:autoFocus")))){%>
+		       
+		       AUI.$('#<%=request.getAttribute("aui:input:id")%>').focus();
+		       
+		<%}%>
+
+		
 	</c:if>
 
 	Liferay.fire(


### PR DESCRIPTION
The root cause is  "form tag" is also kind of Portlet which disabled the fieldset when rendering .

Please refer to LPS-45613

Fix it by re-focus it after form rendering.

