### PR TITLE
[TS] LPS-73480

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -1337,7 +1337,7 @@ public class DLAppHelperLocalServiceImpl
 			dlFileVersionStatusOVPs = getDlFileVersionStatuses(dlFileVersions);
 		}
 
-		FileVersion fileVersion = fileEntry.getFileVersion();
+		FileVersion fileVersion = fileEntry.getLatestFileVersion();
 
 		int oldStatus = fileVersion.getStatus();
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -1337,7 +1337,7 @@ public class DLAppHelperLocalServiceImpl
 			dlFileVersionStatusOVPs = getDlFileVersionStatuses(dlFileVersions);
 		}
 
-		FileVersion fileVersion = fileEntry.getLatestFileVersion();
+		FileVersion fileVersion = fileEntry.getLatestFileVersion(true);
 
 		int oldStatus = fileVersion.getStatus();
 


### PR DESCRIPTION
Hi Hugo,

The pr is related with https://github.com/hhuijser/liferay-portal/pull/2912. The second commit solves test error.

The root issue is that if the latest version(1.1) status is pending,  when move it to trash, it won't execute deleting related workflowInstance data (https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java#L1425-L1430) BECAUSE fileEntry.getFileVersion() will get fileEntry(version:1.0, status: approved).

At here, the fix uses the latest version.

Regards,
Hai
