### PR TITLE
[TS] LPS-73594 View Permission does not work for User

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UserIndexer.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UserIndexer.java
@@ -37,8 +37,10 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.auth.FullNameGenerator;
 import com.liferay.portal.kernel.security.auth.FullNameGeneratorFactory;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.UserPermission;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -76,6 +78,7 @@ public class UserIndexer extends BaseIndexer<User> {
 			Field.ASSET_TAG_NAMES, Field.COMPANY_ID, Field.ENTRY_CLASS_NAME,
 			Field.ENTRY_CLASS_PK, Field.GROUP_ID, Field.MODIFIED_DATE,
 			Field.SCOPE_GROUP_ID, Field.UID, Field.USER_ID);
+		setFilterSearch(true);
 		setPermissionAware(true);
 		setStagingAware(false);
 	}
@@ -83,6 +86,18 @@ public class UserIndexer extends BaseIndexer<User> {
 	@Override
 	public String getClassName() {
 		return CLASS_NAME;
+	}
+
+	@Override
+	public boolean hasPermission(
+			PermissionChecker permissionChecker, String entryClassName,
+			long entryClassPK, String actionId)
+		throws Exception {
+
+		User user = userLocalService.getUser(entryClassPK);
+
+		return userPermission.contains(
+			permissionChecker, user.getUserId(), actionId);
 	}
 
 	@Override
@@ -429,6 +444,9 @@ public class UserIndexer extends BaseIndexer<User> {
 
 	@Reference
 	protected UserLocalService userLocalService;
+
+	@Reference
+	protected UserPermission userPermission;
 
 	private static final Log _log = LogFactoryUtil.getLog(UserIndexer.class);
 


### PR DESCRIPTION
Hi Hugo,

Please refer to view permission issue (the second) in LPS-73594 description. The customer encountered the first issue (after reindex, the result only displays default pagination, for example: 20). Actually, the fix should match with the view permission issue.

The root issue is that UserIndexer doesn't own setFilterSearch for true. When return total (using searchCount() method), it used the search query
"rows=0&q=&fq=%2B%28%2B%28%2B%28%28%2Bstatus%3A0+%2B%28entryClassName%3Acom.liferay.portal.kernel.model.User%29%29%29%29%29+%2B%28companyId%3A20111%29
" to search. Due to q=(blank), so its return total is 0. As a result, if created 30 users, only 20 (if default pagination is 20) users are displayed because returned results is right(its followed logic can let q=*:* to  search).

So the root logic is if searchCount doesn't enter into https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java#L677-L683. The issue will occur. You will find https://github.com/yuhai/liferay-portal/blob/master/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java#L450-L452 *query will be blank(q=blank)*

**The fix refers to LPS-62886**. For organization, it doesn't exist the issue, it doesn't use searchCount() (please refer to https://github.com/yuhai/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/organization_search_container_results/page.jsp#L48-L49.). In addition, I don't find we can define permission for organization in UI.

If there is any unclear, please kindly let me know.

Regards,
Hai




