### PR TITLE
LPS-73868 - NoSuchEntryException thrown when search * character using Solr 5.2.1

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -462,7 +462,7 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 
 		if (query.getPostFilter() != null) {
 			String filterQuery = _filterTranslator.translate(
-				query.getPreBooleanFilter(), searchContext);
+				query.getPostFilter(), searchContext);
 
 			filterQueries.add(filterQuery);
 		}


### PR DESCRIPTION
Hey @hhuijser 
I think the issue is caused by https://github.com/brianchandotcom/liferay-portal/pull/30181.
https://github.com/brianchandotcom/liferay-portal/pull/30181/commits/e898e058f0d68448f9cd38ba8608d67811ef6633#diff-213d4b420370fc8765a71f601129b570R406

ES works but Solr Failed.  


