### PR TITLE
[TS] LPS-73594

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -704,7 +704,15 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 		searchContext.setSearchEngineId(getSearchEngineId());
 
-		BooleanQuery fullQuery = getFullQuery(searchContext);
+		Query fullQuery = getFullQuery(searchContext);
+
+		if (!fullQuery.hasChildren()) {
+			BooleanFilter preBooleanFilter = fullQuery.getPreBooleanFilter();
+
+			fullQuery = new MatchAllQuery();
+
+			fullQuery.setPreBooleanFilter(preBooleanFilter);
+		}
 
 		fullQuery.setQueryConfig(queryConfig);
 


### PR DESCRIPTION
Hi Hugo,

The previous commit has been reverted from https://github.com/brianchandotcom/liferay-portal/pull/50667. If we add filter the search returned result. I think the previous fix is necessary because setFilterSearch(true) is common way to filter the view permission from search result. However, if we add the filter for user and it will cause many issue. For example,  if one user own "assign members" permission in Site Memberships portlet, before fix, the user can see all users. If we add user permission filter, the function will be broken. Please refer to some comment in LPS-73594. In my opinion, this may be a big change for us.

For now, I add strikethrough for the view issue because the customer only encountered "some users were not displayed in Users and Organizations.". So the ticket will ignore the filter view permission from search results. Please refer to the fix explanation.

**Explanation:**
The issue only occur when using solr. When return total (using searchCount() method), it used the search query
"rows=0&q=&fq=%2B%28%2B%28%2B%28%28%2Bstatus%3A0+%2B%28entryClassName%3Acom.liferay.portal.kernel.model.User%29%29%29%29%29+%2B%28companyId%3A20111%29
" to search. Due to q=(blank), so its return total is 0. As a result, if created 30 users, only 20 (if default pagination is 20) users are displayed because returned results is right(search() method) (its followed logic can let q=*:* to search).

**Why doesn't the issue occur in elasticSearch?**
The query is as the follow:
``
{
  "bool" : {
    "must" : {
      "bool" : { }
    },
    "filter" : {
      "bool" : {
        "must" : {
          "bool" : {
            "must" : {
              "bool" : {
                "should" : {
                  "bool" : {
                    "must" : [ {
                      "term" : {
                        "status" : "0"
                      }
                    }, {
                      "bool" : {
                        "should" : {
                          "term" : {
                            "entryClassName" : "com.liferay.portal.kernel.model.User"
                          }
                        }
                      }
                    } ]
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
``
I think because must is empty (this may mean match all doucments) and it will use filter to search, it will get right results. This is different from solr. Refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html

The fix refers to "LPS-56251 if no children for fullQuery, then send MatchAllQuery" commit (https://github.com/brianchandotcom/liferay-portal/pull/27266/commits/7affb4d31460a4cdfd7cdc1366d342198e157362). For solr, it will let q=*:* so that we can search right. For elasticsearch, it will use  "must" : {"match_all" : { } }, instead of using "must" : {"bool" : { }},.

Regards,
Hai