### PR TITLE
LPS-74064 New role with all permissions to License Manager fails to view License Manager in control panel

### DIFF
--- a/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_navigation.jspf
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_navigation.jspf
@@ -148,6 +148,9 @@ PanelCategoryRegistry panelCategoryRegistry = (PanelCategoryRegistry)request.get
 												if (Objects.equals(panelAppPortlet.getControlPanelEntryClass(), com.liferay.portal.kernel.portlet.OmniadminControlPanelEntry.class.getName())) {
 													continue;
 												}
+												else if (Objects.equals(panelAppPortlet.getPortletName(), PortletKeys.LICENSE_MANAGER)) {
+													continue;
+												}
 
 												editPermissionsResourceURL.setParameter("portletResource", panelAppPortlet.getPortletId());
 


### PR DESCRIPTION
The license manager permissions are never used. Solving this problem by removing the license manager permissions.