### PR TITLE
[TS] LPS-74083

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
@@ -714,7 +714,12 @@ public class BaseTextExportImportContentProcessor
 					throw new NoSuchLayoutException();
 				}
 
-				urlSB.append(DATA_HANDLER_GROUP_FRIENDLY_URL);
+				if (urlGroup.getGroupId() == groupId) {
+					urlSB.append(DATA_HANDLER_GROUP_FRIENDLY_URL);
+				}
+				else {
+					urlSB.append(groupFriendlyURL);
+				}
 
 				String siteAdminURL =
 					GroupConstants.CONTROL_PANEL_FRIENDLY_URL +

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java
@@ -702,7 +702,12 @@ public class DefaultTextExportImportContentProcessor
 					throw new NoSuchLayoutException();
 				}
 
-				urlSB.append(_DATA_HANDLER_GROUP_FRIENDLY_URL);
+				if (urlGroup.getGroupId() == groupId) {
+					urlSB.append(_DATA_HANDLER_GROUP_FRIENDLY_URL);
+				}
+				else {
+					urlSB.append(groupFriendlyURL);
+				}
 
 				String siteAdminURL =
 					GroupConstants.CONTROL_PANEL_FRIENDLY_URL +

--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -352,7 +352,7 @@ public class DefaultExportImportContentProcessorTest {
 
 		Assert.assertFalse(
 			content.contains(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			content.contains(GroupConstants.CONTROL_PANEL_FRIENDLY_URL));
 		Assert.assertFalse(
 			content.contains(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL));
@@ -409,7 +409,7 @@ public class DefaultExportImportContentProcessorTest {
 
 		Assert.assertFalse(
 			content.contains(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			content.contains(GroupConstants.CONTROL_PANEL_FRIENDLY_URL));
 		Assert.assertFalse(
 			content.contains(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL));


### PR DESCRIPTION
Hi Hugo,

Please refer to the below case:

DXP site: exist one page "testPage",  http://localhost:8080/web/guest/testPage
Export **Site1**: create one web content, its content includes: 
`<p><a href="http://localhost:8080/web/guest/testPage">invoke testPage from DXP site</a></p>`
Import Target **Site2**:

When we export, guest will be replaced with DATA_HANDLER_GROUP_FRIENDLY_URL.
When import this lar, it will be replaced with Import Target Site2 group, Please refer to 
 https://github.com/yuhai/liferay-portal/blob/c6e8030ca5e11f7408925020169adb77c8ebf9ef/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/DefaultTextExportImportContentProcessor.java#L1009-L1010. Its content will be
`<p><a href="http://localhost:8080/web/site2/testPage">invoke testPage from DXP site</a></p>`. 
Please note **guest** is replaced with **site2**, this is wrong. 

So the fix is when exportLayoutReferences's group (DXP site) is not current group(group:Site1), we should keep its group. Otherwise, when import it to targetGroup (group: Site2), it will be replaced with targetGroup(Site2).

Regards,
Hai