### PR TITLE
LPS-67352 Relax check and only format dependencies without inner curly braces

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleDependenciesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleDependenciesCheck.java
@@ -157,7 +157,8 @@ public class GradleDependenciesCheck extends BaseFileCheck {
 	}
 
 	private final Pattern _dependenciesPattern = Pattern.compile(
-		"^dependencies \\{(.+?\n)\\}", Pattern.DOTALL | Pattern.MULTILINE);
+		"^dependencies \\{(((?![\\{\\}]).)+?\n)\\}",
+		Pattern.DOTALL | Pattern.MULTILINE);
 	private final Pattern _incorrectGroupNameVersionPattern = Pattern.compile(
 		"(^[^\\s]+)\\s+\"([^:]+?):([^:]+?):([^\"]+?)\"(.*?)", Pattern.DOTALL);
 	private final Pattern _incorrectWhitespacePattern = Pattern.compile(


### PR DESCRIPTION
This will still cover over 90% of the use cases and also allow devs to add more complex logic w/o issue

Greg's example:
```
dependencies {
    compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
    compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

    testCompile group: "com.liferay.arquillian", name: "com.liferay.arquillian.arquillian-container-liferay", version: "1.0.6", {
        exclude group: "com.liferay.portal", module: "com.liferay.portal.kernel"
    }

    testCompile group: "junit", name: "junit", version: "4.12"
    testCompile group: "org.jboss.arquillian.junit", name: "arquillian-junit-container", version: "1.1.11.Final"
}
```