### PR TITLE
[TS] LPS-74239 

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/SearchPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/SearchPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.display-category=category.cms",
 		"com.liferay.portlet.header-portlet-css=/admin/css/common.css",
 		"com.liferay.portlet.icon=/icons/search.png",
+		"com.liferay.portlet.restore-current-view=false",
 		"com.liferay.portlet.scopeable=true",
 		"javax.portlet.display-name=Knowledge Base Search",
 		"javax.portlet.expiration-cache=0",


### PR DESCRIPTION
Hi Hugo,

The issue is after search in kbsearch portlet,  and then click "return-to-full-page" and it will take this keywords back so that the search result can't be cleaned. Please refer to the below logic.

(render return-to-full-page part)https://github.com/yuhai/liferay-portal/blob/LPS-74239/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/portlet.ftl#L46-L47 -> (KBsearch portlet doesn't enter this https://github.com/yuhai/liferay-portal/blob/LPS-74239/portal-web/docroot/html/portal/render_portlet.jsp#L634-L638) -> (it will enter the block code and keep keywords existed) https://github.com/yuhai/liferay-portal/blob/LPS-74239/portal-web/docroot/html/portal/render_portlet.jsp#L665-L687 -> (Finally, set the urlMax to urlBack) https://github.com/yuhai/liferay-portal/blob/LPS-74239/portal-web/docroot/html/portal/render_portlet.jsp#L806-L808

The fix referred to portal-search portlet, set kbsearch portlet restoseCurrentView = fasle.  Please refer to https://github.com/yuhai/liferay-portal/blob/LPS-74239/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/SearchPortlet.java#L62 AND https://github.com/yuhai/liferay-portal/blob/LPS-74239/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java#L3725-L3735

Regards,
Hai