### PR TITLE
 LPS-74081 A page might not be imported to a site from a LAR file if it has a numeric friendly URL

### DIFF
--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 610663927e96daea8412661e1b529e63c9a396b9
+	commit = 7c7ce63601d820b21fb6fc50093850f4d5301629
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 53452f2320ca86504d8b0c9cadcd3d1ad8b64bc1
+	parent = e23001a614b45d2dc43ee6b13887e920c74c2673
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -250,16 +250,16 @@ public class VerifyProcessTrackerOSGiCommands {
 
 			if (verifyException == null) {
 				release.setVerified(true);
+				release.setState(ReleaseConstants.STATE_GOOD);
 
 				releaseLocalService.updateRelease(release);
 
 				_registerVerifyProcessCompletionMarker(verifyProcessName);
 			}
 			else {
-				if (release.isVerified()) {
-					release.setVerified(false);
-					releaseLocalService.updateRelease(release);
-				}
+				release.setVerified(false);
+				release.setState(ReleaseConstants.STATE_VERIFY_FAILURE);
+				releaseLocalService.updateRelease(release);
 			}
 		}
 		finally {

--- a/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -67,6 +67,7 @@ import org.osgi.service.component.annotations.Reference;
 	configurationPid = "com.liferay.portal.verify.extender.internal.configuration.VerifyProcessTrackerConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
 	property = {
+		"osgi.command.function=check", "osgi.command.function=checkAll",
 		"osgi.command.function=execute", "osgi.command.function=executeAll",
 		"osgi.command.function=list", "osgi.command.function=show",
 		"osgi.command.function=showReports", "osgi.command.scope=verify"
@@ -74,6 +75,38 @@ import org.osgi.service.component.annotations.Reference;
 	service = {VerifyProcessTrackerOSGiCommands.class}
 )
 public class VerifyProcessTrackerOSGiCommands {
+
+	public void check(final String verifyProcessName) {
+		Release release = releaseLocalService.fetchRelease(verifyProcessName);
+
+		if ((release == null) ||
+			(!release.isVerified() &&
+			 (release.getState() == ReleaseConstants.STATE_GOOD))) {
+
+			System.out.println(
+				verifyProcessName + " verify process hasn't been executed yet");
+		}
+		else {
+			if (release.isVerified()) {
+				System.out.println(
+					verifyProcessName +
+						" verify process was executed without errors");
+			}
+			else if (release.getState() ==
+						ReleaseConstants.STATE_VERIFY_FAILURE) {
+
+				System.out.println(
+					verifyProcessName +
+						" verify process failed last time it was executed");
+			}
+		}
+	}
+
+	public void checkAll() {
+		for (String verifyProcessName : _verifyProcesses.keySet()) {
+			check(verifyProcessName);
+		}
+	}
 
 	public void execute(final String verifyProcessName) {
 		_execute(verifyProcessName, null, true);

--- a/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -77,6 +77,16 @@ import org.osgi.service.component.annotations.Reference;
 public class VerifyProcessTrackerOSGiCommands {
 
 	public void check(final String verifyProcessName) {
+		try {
+			getVerifyProcesses(verifyProcessName);
+		}
+		catch (IllegalArgumentException iae) {
+			System.out.println(
+				"No verify process with name " + verifyProcessName);
+
+			return;
+		}
+
 		Release release = releaseLocalService.fetchRelease(verifyProcessName);
 
 		if ((release == null) ||

--- a/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -234,8 +234,7 @@ public class VerifyProcessTrackerOSGiCommands {
 	}
 
 	protected void executeVerifyProcesses(
-		String verifyProcessName, OutputStream outputStream,
-		boolean forceVerify) {
+		String verifyProcessName, OutputStream outputStream, boolean force) {
 
 		PrintWriter printWriter = new PrintWriter(outputStream, true);
 
@@ -255,7 +254,7 @@ public class VerifyProcessTrackerOSGiCommands {
 			Release release = releaseLocalService.fetchRelease(
 				verifyProcessName);
 
-			if ((release != null) && !forceVerify && release.isVerified()) {
+			if ((release != null) && !force && release.isVerified()) {
 				if (!_serviceRegistrations.containsKey(verifyProcessName)) {
 					_registerVerifyProcessCompletionMarker(verifyProcessName);
 				}
@@ -292,16 +291,17 @@ public class VerifyProcessTrackerOSGiCommands {
 			}
 
 			if (verifyException == null) {
-				release.setVerified(true);
 				release.setState(ReleaseConstants.STATE_GOOD);
+				release.setVerified(true);
 
 				releaseLocalService.updateRelease(release);
 
 				_registerVerifyProcessCompletionMarker(verifyProcessName);
 			}
 			else {
-				release.setVerified(false);
 				release.setState(ReleaseConstants.STATE_VERIFY_FAILURE);
+				release.setVerified(false);
+
 				releaseLocalService.updateRelease(release);
 			}
 		}
@@ -315,7 +315,7 @@ public class VerifyProcessTrackerOSGiCommands {
 
 	protected void executeVerifyProcesses(
 		final String verifyProcessName, String outputStreamContainerFactoryName,
-		String outputStreamName, final boolean forceVerify) {
+		String outputStreamName, final boolean force) {
 
 		OutputStreamContainerFactory outputStreamContainerFactory;
 
@@ -343,7 +343,7 @@ public class VerifyProcessTrackerOSGiCommands {
 				@Override
 				public void run() {
 					executeVerifyProcesses(
-						verifyProcessName, outputStream, forceVerify);
+						verifyProcessName, outputStream, force);
 				}
 
 			},
@@ -384,11 +384,11 @@ public class VerifyProcessTrackerOSGiCommands {
 
 	private void _execute(
 		final String verifyProcessName, String outputStreamContainerFactoryName,
-		final boolean forceVerify) {
+		final boolean force) {
 
 		executeVerifyProcesses(
 			verifyProcessName, outputStreamContainerFactoryName,
-			"verify-" + verifyProcessName, forceVerify);
+			"verify-" + verifyProcessName, force);
 	}
 
 	private void _registerVerifyProcessCompletionMarker(
@@ -408,7 +408,7 @@ public class VerifyProcessTrackerOSGiCommands {
 
 	private void _runAllVerifiersWithFactory(
 		OutputStreamContainerFactory outputStreamContainerFactory,
-		boolean forceVerify) {
+		boolean force) {
 
 		OutputStreamContainer outputStreamContainer =
 			outputStreamContainerFactory.create("all-verifiers");
@@ -417,7 +417,7 @@ public class VerifyProcessTrackerOSGiCommands {
 			outputStreamContainer.getOutputStream();
 
 		outputStreamContainerFactoryTracker.runWithSwappedLog(
-			new AllVerifiersRunnable(outputStream, forceVerify),
+			new AllVerifiersRunnable(outputStream, force),
 			outputStreamContainer.getDescription(), outputStream);
 	}
 
@@ -433,11 +433,9 @@ public class VerifyProcessTrackerOSGiCommands {
 
 	private class AllVerifiersRunnable implements Runnable {
 
-		public AllVerifiersRunnable(
-			OutputStream outputStream, boolean forceVerify) {
-
+		public AllVerifiersRunnable(OutputStream outputStream, boolean force) {
 			_outputStream = outputStream;
-			_forceVerify = forceVerify;
+			_force = force;
 		}
 
 		@Override
@@ -446,11 +444,11 @@ public class VerifyProcessTrackerOSGiCommands {
 
 			for (String verifyProcessName : verifyProcessNames) {
 				executeVerifyProcesses(
-					verifyProcessName, _outputStream, _forceVerify);
+					verifyProcessName, _outputStream, _force);
 			}
 		}
 
-		private final boolean _forceVerify;
+		private final boolean _force;
 		private final OutputStream _outputStream;
 
 	}

--- a/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -94,20 +94,18 @@ public class VerifyProcessTrackerOSGiCommands {
 			 (release.getState() == ReleaseConstants.STATE_GOOD))) {
 
 			System.out.println(
-				verifyProcessName + " verify process hasn't been executed yet");
+				verifyProcessName + " verify process has not executed");
 		}
 		else {
 			if (release.isVerified()) {
 				System.out.println(
-					verifyProcessName +
-						" verify process was executed without errors");
+					verifyProcessName + " verify process succeeded");
 			}
 			else if (release.getState() ==
 						ReleaseConstants.STATE_VERIFY_FAILURE) {
 
 				System.out.println(
-					verifyProcessName +
-						" verify process failed last time it was executed");
+					verifyProcessName + " verify process failed");
 			}
 		}
 	}

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lar/PortletDataContextImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lar/PortletDataContextImpl.java
@@ -988,6 +988,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 	}
 
 	@Override
+	public List<String> getImportedFriendlyURLs() {
+		return _importedFriendlyURLs;
+	}
+
+	@Override
 	public long[] getLayoutIds() {
 		return _layoutIds;
 	}
@@ -1948,6 +1953,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 	}
 
 	@Override
+	public void setImportedFriendlyURLs(List<String> importedFriendlyURLs) {
+		_importedFriendlyURLs = importedFriendlyURLs;
+	}
+
+	@Override
 	public void setLayoutIds(long[] layoutIds) {
 		_layoutIds = layoutIds;
 	}
@@ -2830,6 +2840,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 	private String _exportImportProcessId;
 	private long _groupId;
 	private transient Element _importDataRootElement;
+	private List<String> _importedFriendlyURLs;
 	private transient long[] _layoutIds;
 	private String _layoutSetPrototypeUuid;
 	private final transient LockManager _lockManager;

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
@@ -340,6 +340,8 @@ public interface PortletDataContext extends Serializable {
 
 	public Element getImportDataStagedModelElement(StagedModel stagedModel);
 
+	public List<String> getImportedFriendlyURLs();
+
 	public long[] getLayoutIds();
 
 	public String getLayoutSetPrototypeUuid();
@@ -643,6 +645,8 @@ public interface PortletDataContext extends Serializable {
 	public void setGroupId(long groupId);
 
 	public void setImportDataRootElement(Element importDataRootElement);
+
+	public void setImportedFriendlyURLs(List<String> importedFriendlyURL);
 
 	public void setLayoutIds(long[] layoutIds);
 


### PR DESCRIPTION
This issue was caused by duplicated " Friendly URL " when importing "lar file" into our system..

Add logic to get new different "Friendly URL " to solve this issue.