### PR TITLE
[TS] LPS-74231

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
@@ -59,6 +59,13 @@ public class CASCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean casEnabled = _prefsProps.getBoolean(
+			companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED);
+
+		if (!casEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			CASConfigurationKeys.AUTH_ENABLED,
 			_prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -59,6 +59,13 @@ public class FacebookConnectCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean facebookConnectEnabled = _prefsProps.getBoolean(
+			companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED);
+
+		if (!facebookConnectEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			FacebookConnectConfigurationKeys.AUTH_ENABLED,
 			_prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
@@ -57,6 +57,13 @@ public class GoogleLoginCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean googleLoginEnabled = _prefsProps.getBoolean(
+			companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED);
+
+		if (!googleLoginEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			GoogleAuthorizationConfigurationKeys.AUTH_ENABLED,
 			_prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
@@ -57,6 +57,13 @@ public class NtlmCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean ntlmEnabled = _prefsProps.getBoolean(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED);
+
+		if (!ntlmEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			NtlmConfigurationKeys.AUTH_DOMAIN,
 			_prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
@@ -57,6 +57,13 @@ public class OpenIdCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean openIdEnabled = _prefsProps.getBoolean(
+			companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED);
+
+		if (!openIdEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			OpenIdConfigurationKeys.AUTH_ENABLED,
 			_prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
@@ -57,6 +57,13 @@ public class OpenSSOCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
+		boolean openSSOEnabled = _prefsProps.getBoolean(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED);
+
+		if (!openSSOEnabled) {
+			return dictionary;
+		}
+
 		dictionary.put(
 			OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR,
 			_prefsProps.getString(


### PR DESCRIPTION
Hi Hugo,

The issue is that Dictionary still is not empty because it will use default value. Please refer to
https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java#L58-L114 -> https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/verify/BaseCompanySettingsVerifyProcess.java#L101-L104

When export the opensso system setting configuration from one DXP bundle to another bundle (empty database). You may refer to LPS-74231's description.  Since dictionary still is not empty, it will enter   BaseCompanySettingsVerifyProcess.storeSettings(). In this method it will use default value (if the default value is different from your configure file, com.liferay.portal.security.sso.opensso.configuration.OpenSSOConfiguration.config) to save in portletpreferences table(actually, portletpreferences save the instance setting value). This is not expected behavior because we don't save instance setting in UI.

Actually, for the below code:
```
_prefsProps.getString(companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR,
				"mail"));
```

It mainly should be used when upgrade from 6.2 to 7.0. Because the value (sso configuration) existed on portalPreferences in 6.2. In the upgrade process, we use this way to transfer the value from portalPreferences, and then delete them from portalPreferences (Please refer to https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/verify/BaseCompanySettingsVerifyProcess.java#L114-L116)

The fix refers to https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java#L62-L67 (FROM LPS-61440). 

In addition, I want to explain the fix which will miss the case:
On 6.2, configure openSSO properties, except "open.sso.auth.enabled=true", that is to say, I only enter other properties value and not enabled openSSO. After upgrade, these properties will be lost because the fix only transfers values when enable openSSO. We need to input these values in UI on 7.0. I think this is acceptable (this should be rare cases) because opensso was not enabled on 6.2. Otherwise, we will judge every property value whether exists in  portalPreferences table.

Regards,
Hai


