### PR TITLE
[TS] LPS-74231

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.cas.constants.CASConfigurationKeys;
 import com.liferay.portal.security.sso.cas.constants.CASConstants;
 import com.liferay.portal.security.sso.cas.constants.LegacyCASPropsKeys;
@@ -59,51 +58,73 @@ public class CASCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			CASConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.LOGIN_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGIN_URL,
-				"https://localhost:8443/cas-web/login"));
-		dictionary.put(
-			CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.LOGOUT_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGOUT_URL,
-				"https://localhost:8443/cas-web/logout"));
-		dictionary.put(
-			CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL,
-				"http://localhost:8080"));
-		dictionary.put(
-			CASConfigurationKeys.SERVER_NAME,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVER_NAME,
-				"https://localhost:8080"));
-		dictionary.put(
-			CASConfigurationKeys.SERVER_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVER_URL,
-				"https://localhost:8443/cas-web/"));
-		dictionary.put(
-			CASConfigurationKeys.SERVICE_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVICE_URL,
-				"https://localhost:8080"));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(CASConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				CASConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String loginURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGIN_URL);
+
+		if (loginURL != null) {
+			dictionary.put(CASConfigurationKeys.LOGIN_URL, loginURL);
+		}
+
+		String logoutOnSessionExpiration = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION);
+
+		if (logoutOnSessionExpiration != null) {
+			dictionary.put(
+				CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
+				logoutOnSessionExpiration);
+		}
+
+		String logoutURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGOUT_URL);
+
+		if (logoutURL != null) {
+			dictionary.put(CASConfigurationKeys.LOGOUT_URL, logoutURL);
+		}
+
+		String noSuchUserRedirectURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL);
+
+		if (noSuchUserRedirectURL != null) {
+			dictionary.put(
+				CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL,
+				noSuchUserRedirectURL);
+		}
+
+		String serverName = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVER_NAME);
+
+		if (serverName != null) {
+			dictionary.put(CASConfigurationKeys.SERVER_NAME, serverName);
+		}
+
+		String serverURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVER_URL);
+
+		if (serverURL != null) {
+			dictionary.put(CASConfigurationKeys.SERVER_URL, serverURL);
+		}
+
+		String serviceURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVICE_URL);
+
+		if (serviceURL != null) {
+			dictionary.put(CASConfigurationKeys.SERVICE_URL, serviceURL);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConfigurationKeys;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants;
@@ -59,49 +58,72 @@ public class FacebookConnectCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			FacebookConnectConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.APP_ID,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.APP_ID,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.APP_SECRET,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.APP_SECRET,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.GRAPH_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.GRAPH_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_AUTH_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
-			upgradeLegacyRedirectURI(
-				_prefsProps.getString(
-					companyId,
-					LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL,
-					StringPool.BLANK)));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED,
-			_prefsProps.getString(
-				companyId,
-				LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED,
-				StringPool.FALSE));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String appId = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.APP_ID);
+
+		if (appId != null) {
+			dictionary.put(FacebookConnectConfigurationKeys.APP_ID, appId);
+		}
+
+		String appSecret = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.APP_SECRET);
+
+		if (appSecret != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.APP_SECRET, appSecret);
+		}
+
+		String graphURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.GRAPH_URL);
+
+		if (graphURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.GRAPH_URL, graphURL);
+		}
+
+		String oauthAuthURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL);
+
+		if (oauthAuthURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_AUTH_URL, oauthAuthURL);
+		}
+
+		String oauthRedirectURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL);
+
+		if (oauthRedirectURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
+				oauthRedirectURL);
+		}
+
+		String oauthTokenURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL);
+
+		if (oauthTokenURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
+				oauthTokenURL);
+		}
+
+		String verifiedAccountRequired = _prefsProps.getString(
+			companyId,
+			LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED);
+
+		if (verifiedAccountRequired != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED,
+				verifiedAccountRequired);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.google.constants.GoogleAuthorizationConfigurationKeys;
 import com.liferay.portal.security.sso.google.constants.GoogleConstants;
 import com.liferay.portal.security.sso.google.constants.LegacyGoogleLoginPropsKeys;
@@ -57,21 +56,30 @@ public class GoogleLoginCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.CLIENT_ID,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.CLIENT_ID,
-				StringPool.BLANK));
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.CLIENT_SECRET,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.CLIENT_SECRET,
-				StringPool.BLANK));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String clientId = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.CLIENT_ID);
+
+		if (clientId != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.CLIENT_ID, clientId);
+		}
+
+		String clientSecret = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.CLIENT_SECRET);
+
+		if (clientSecret != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.CLIENT_SECRET,
+				clientSecret);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.ntlm.constants.LegacyNtlmPropsKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConfigurationKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConstants;
@@ -57,40 +56,60 @@ public class NtlmCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN, "EXAMPLE"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER,
-				"127.0.0.1"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME,
-				"EXAMPLE"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS,
-				"0x600FFFFF"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT,
-				"LIFERAY$@EXAMPLE.COM"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD,
-				"test"));
+		String domain = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN);
+
+		if (domain != null) {
+			dictionary.put(NtlmConfigurationKeys.AUTH_DOMAIN, domain);
+		}
+
+		String domainController = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER);
+
+		if (domainController != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER, domainController);
+		}
+
+		String domainControllerName = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME);
+
+		if (domainControllerName != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME,
+				domainControllerName);
+		}
+
+		String enabled = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(NtlmConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String negotiateFlags = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS);
+
+		if (negotiateFlags != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS, negotiateFlags);
+		}
+
+		String serviceAccount = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT);
+
+		if (serviceAccount != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT, serviceAccount);
+		}
+
+		String servicePassword = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD);
+
+		if (servicePassword != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD, servicePassword);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.openid.constants.LegacyOpenIdPropsKeys;
 import com.liferay.portal.security.sso.openid.constants.OpenIdConfigurationKeys;
 import com.liferay.portal.security.sso.openid.constants.OpenIdConstants;
@@ -57,11 +56,12 @@ public class OpenIdCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			OpenIdConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED,
-				StringPool.FALSE));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(OpenIdConfigurationKeys.AUTH_ENABLED, enabled);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.opensso.constants.LegacyOpenSSOPropsKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConfigurationKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants;
@@ -57,59 +56,83 @@ public class OpenSSOCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR,
-				"mail"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.FIRST_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR,
-				"givenname"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LAST_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR,
-				"sn"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGIN_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL,
-				"http://openssohost.example.com:8080/opensso/UI/Login?goto=" +
-					"http://portalhost.example.com:8080/c/portal/login"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-			_prefsProps.getString(
-				companyId,
-				LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGOUT_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL,
-				"http://openssohost.example.com:8080/opensso/UI/Logout?goto=" +
-					"http://portalhost.example.com:8080/web/guest/home"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.SCREEN_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR,
-				"uid"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.SERVICE_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL,
-				"http://openssohost.example.com:8080/opensso"));
+		String emailAddressAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR);
+
+		if (emailAddressAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR, emailAddressAttr);
+		}
+
+		String enabled = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(OpenSSOConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String firstNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR);
+
+		if (firstNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.FIRST_NAME_ATTR, firstNameAttr);
+		}
+
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String lastNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR);
+
+		if (lastNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.LAST_NAME_ATTR, lastNameAttr);
+		}
+
+		String loginURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL);
+
+		if (loginURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.LOGIN_URL, loginURL);
+		}
+
+		String logoutOnSessionExpiration = _prefsProps.getString(
+			companyId,
+			LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION);
+
+		if (logoutOnSessionExpiration != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
+				logoutOnSessionExpiration);
+		}
+
+		String logoutURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL);
+
+		if (logoutURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.LOGOUT_URL, logoutURL);
+		}
+
+		String screenNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR);
+
+		if (screenNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.SCREEN_NAME_ATTR, screenNameAttr);
+		}
+
+		String serviceURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL);
+
+		if (serviceURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.SERVICE_URL, serviceURL);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConfigurationKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConstants;
@@ -59,33 +58,35 @@ public class ShibbolethCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		boolean shibbolethEnabled = _prefsProps.getBoolean(
+		String enabled = _prefsProps.getString(
 			companyId, LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED);
 
-		if (!shibbolethEnabled) {
-			return dictionary;
+		if (enabled != null) {
+			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
 		}
 
-		dictionary.put(
-			TokenConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.LOGOUT_REDIRECT_URL,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL,
-				"/Shibboleth.sso/Logout"));
-		dictionary.put(
-			TokenConfigurationKeys.USER_HEADER,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER,
-				"SHIBBOLETH_USER_EMAIL"));
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String logoutRedirectURL = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL);
+
+		if (logoutRedirectURL != null) {
+			dictionary.put(
+				TokenConfigurationKeys.LOGOUT_REDIRECT_URL, logoutRedirectURL);
+		}
+
+		String userTokenName = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER);
+
+		if (userTokenName != null) {
+			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConfigurationKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConstants;
@@ -59,28 +58,27 @@ public class SiteMinderCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		boolean siteMinderEnabled = _prefsProps.getBoolean(
+		String enabled = _prefsProps.getString(
 			companyId, LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED);
 
-		if (!siteMinderEnabled) {
-			return dictionary;
+		if (enabled != null) {
+			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
 		}
 
-		dictionary.put(
-			TokenConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.USER_HEADER,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_USER_HEADER,
-				"SM_USER"));
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String userTokenName = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SITEMINDER_USER_HEADER);
+
+		if (userTokenName != null) {
+			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(


### PR DESCRIPTION
Hi Hugo,

The PR extends from https://github.com/mhan810/liferay-portal/pull/1369#issuecomment-325367974

Based on the requirement, I remove the default value and judge every property existed. Because this class is used for transferring opsnSSO configuration when upgrade from 6.2 to 7.0 (**So the default value is not necessary**). For low version portal (6.2), if it didn't save opensso configuration (related property didn't exist portalpreferences table in 6.2), we may treat dictionary as empty when upgrade from 6.2 to 7.0. **Otherwise**, when export the opensso system setting configuration from one DXP bundle to another bundle (empty database), for instance setting, it will use default value (portletpreferences table will use the default value) because dictionary still used default value.

Related code logic: you may refer to https://github.com/hhuijser/liferay-portal/pull/2980#issue-252554348

Regards,
Hai

