### PR TITLE
[TS] LPS-74231

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.exportimport.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.cas.constants.CASConfigurationKeys;
 import com.liferay.portal.security.sso.cas.constants.CASConstants;
 import com.liferay.portal.security.sso.cas.constants.LegacyCASPropsKeys;
@@ -59,51 +58,73 @@ public class CASCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			CASConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.LOGIN_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGIN_URL,
-				"https://localhost:8443/cas-web/login"));
-		dictionary.put(
-			CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION,
-				StringPool.FALSE));
-		dictionary.put(
-			CASConfigurationKeys.LOGOUT_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_LOGOUT_URL,
-				"https://localhost:8443/cas-web/logout"));
-		dictionary.put(
-			CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL,
-				"http://localhost:8080"));
-		dictionary.put(
-			CASConfigurationKeys.SERVER_NAME,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVER_NAME,
-				"https://localhost:8080"));
-		dictionary.put(
-			CASConfigurationKeys.SERVER_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVER_URL,
-				"https://localhost:8443/cas-web/"));
-		dictionary.put(
-			CASConfigurationKeys.SERVICE_URL,
-			_prefsProps.getString(
-				companyId, LegacyCASPropsKeys.CAS_SERVICE_URL,
-				"https://localhost:8080"));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(CASConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				CASConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String loginURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGIN_URL);
+
+		if (loginURL != null) {
+			dictionary.put(CASConfigurationKeys.LOGIN_URL, loginURL);
+		}
+
+		String logoutOnSessionExpiration = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION);
+
+		if (logoutOnSessionExpiration != null) {
+			dictionary.put(
+				CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
+				logoutOnSessionExpiration);
+		}
+
+		String logoutURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_LOGOUT_URL);
+
+		if (logoutURL != null) {
+			dictionary.put(CASConfigurationKeys.LOGOUT_URL, logoutURL);
+		}
+
+		String noSuchUserRedirectURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL);
+
+		if (noSuchUserRedirectURL != null) {
+			dictionary.put(
+				CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL,
+				noSuchUserRedirectURL);
+		}
+
+		String serverName = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVER_NAME);
+
+		if (serverName != null) {
+			dictionary.put(CASConfigurationKeys.SERVER_NAME, serverName);
+		}
+
+		String serverURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVER_URL);
+
+		if (serverURL != null) {
+			dictionary.put(CASConfigurationKeys.SERVER_URL, serverURL);
+		}
+
+		String serviceURL = _prefsProps.getString(
+			companyId, LegacyCASPropsKeys.CAS_SERVICE_URL);
+
+		if (serviceURL != null) {
+			dictionary.put(CASConfigurationKeys.SERVICE_URL, serviceURL);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.cas.constants.CASConfigurationKeys;
@@ -27,7 +26,6 @@ import com.liferay.portal.security.sso.cas.constants.LegacyCASPropsKeys;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -55,84 +53,44 @@ public class CASCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(CASConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String importFromLDAP = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP);
-
-		if (importFromLDAP != null) {
-			dictionary.put(
-				CASConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
-		}
-
-		String loginURL = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_LOGIN_URL);
-
-		if (loginURL != null) {
-			dictionary.put(CASConfigurationKeys.LOGIN_URL, loginURL);
-		}
-
-		String logoutOnSessionExpiration = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION);
-
-		if (logoutOnSessionExpiration != null) {
-			dictionary.put(
-				CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-				logoutOnSessionExpiration);
-		}
-
-		String logoutURL = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_LOGOUT_URL);
-
-		if (logoutURL != null) {
-			dictionary.put(CASConfigurationKeys.LOGOUT_URL, logoutURL);
-		}
-
-		String noSuchUserRedirectURL = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL);
-
-		if (noSuchUserRedirectURL != null) {
-			dictionary.put(
-				CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL,
-				noSuchUserRedirectURL);
-		}
-
-		String serverName = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_SERVER_NAME);
-
-		if (serverName != null) {
-			dictionary.put(CASConfigurationKeys.SERVER_NAME, serverName);
-		}
-
-		String serverURL = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_SERVER_URL);
-
-		if (serverURL != null) {
-			dictionary.put(CASConfigurationKeys.SERVER_URL, serverURL);
-		}
-
-		String serviceURL = _prefsProps.getString(
-			companyId, LegacyCASPropsKeys.CAS_SERVICE_URL);
-
-		if (serviceURL != null) {
-			dictionary.put(CASConfigurationKeys.SERVICE_URL, serviceURL);
-		}
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Adding CAS configuration for company " + companyId +
-					" with properties: " + dictionary);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyCASPropsKeys.CAS_AUTH_ENABLED,
+				CASConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_IMPORT_FROM_LDAP,
+				CASConfigurationKeys.IMPORT_FROM_LDAP
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_LOGIN_URL, CASConfigurationKeys.LOGIN_URL
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_LOGOUT_ON_SESSION_EXPIRATION,
+				CASConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_LOGOUT_URL,
+				CASConfigurationKeys.LOGOUT_URL
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_NO_SUCH_USER_REDIRECT_URL,
+				CASConfigurationKeys.NO_SUCH_USER_REDIRECT_URL
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_SERVER_NAME,
+				CASConfigurationKeys.SERVER_NAME
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_SERVER_URL,
+				CASConfigurationKeys.SERVER_URL
+			},
+			new String[] {
+				LegacyCASPropsKeys.CAS_SERVICE_URL,
+				CASConfigurationKeys.SERVICE_URL
+			}
+		};
 	}
 
 	@Override
@@ -152,6 +110,10 @@ public class CASCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -16,7 +16,6 @@ package com.liferay.portal.security.sso.facebook.connect.internal.verify;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -56,46 +55,8 @@ public class FacebookConnectCompanySettingsVerifyProcess
 
 	@Override
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String appId = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.APP_ID);
-
-		if (appId != null) {
-			dictionary.put(FacebookConnectConfigurationKeys.APP_ID, appId);
-		}
-
-		String appSecret = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.APP_SECRET);
-
-		if (appSecret != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.APP_SECRET, appSecret);
-		}
-
-		String graphURL = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.GRAPH_URL);
-
-		if (graphURL != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.GRAPH_URL, graphURL);
-		}
-
-		String oauthAuthURL = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL);
-
-		if (oauthAuthURL != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.OAUTH_AUTH_URL, oauthAuthURL);
-		}
+		Dictionary<String, String> dictionary = super.getPropertyValues(
+			companyId);
 
 		String oauthRedirectURL = _prefsProps.getString(
 			companyId, LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL);
@@ -106,26 +67,41 @@ public class FacebookConnectCompanySettingsVerifyProcess
 				upgradeLegacyRedirectURI(oauthRedirectURL));
 		}
 
-		String oauthTokenURL = _prefsProps.getString(
-			companyId, LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL);
-
-		if (oauthTokenURL != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
-				oauthTokenURL);
-		}
-
-		String verifiedAccountRequired = _prefsProps.getString(
-			companyId,
-			LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED);
-
-		if (verifiedAccountRequired != null) {
-			dictionary.put(
-				FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED,
-				verifiedAccountRequired);
-		}
-
 		return dictionary;
+	}
+
+	@Override
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyFacebookConnectPropsKeys.AUTH_ENABLED,
+				FacebookConnectConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.APP_ID,
+				FacebookConnectConfigurationKeys.APP_ID
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.APP_SECRET,
+				FacebookConnectConfigurationKeys.APP_SECRET
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.GRAPH_URL,
+				FacebookConnectConfigurationKeys.GRAPH_URL
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL,
+				FacebookConnectConfigurationKeys.OAUTH_AUTH_URL
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL,
+				FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL
+			},
+			new String[] {
+				LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED,
+				FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED
+			}
+		};
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -103,7 +103,7 @@ public class FacebookConnectCompanySettingsVerifyProcess
 		if (oauthRedirectURL != null) {
 			dictionary.put(
 				FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
-				oauthRedirectURL);
+				upgradeLegacyRedirectURI(oauthRedirectURL));
 		}
 
 		String oauthTokenURL = _prefsProps.getString(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConfigurationKeys;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants;
@@ -59,49 +58,72 @@ public class FacebookConnectCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			FacebookConnectConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.APP_ID,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.APP_ID,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.APP_SECRET,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.APP_SECRET,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.GRAPH_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.GRAPH_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_AUTH_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
-			upgradeLegacyRedirectURI(
-				_prefsProps.getString(
-					companyId,
-					LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL,
-					StringPool.BLANK)));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
-			_prefsProps.getString(
-				companyId, LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL,
-				StringPool.BLANK));
-		dictionary.put(
-			FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED,
-			_prefsProps.getString(
-				companyId,
-				LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED,
-				StringPool.FALSE));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String appId = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.APP_ID);
+
+		if (appId != null) {
+			dictionary.put(FacebookConnectConfigurationKeys.APP_ID, appId);
+		}
+
+		String appSecret = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.APP_SECRET);
+
+		if (appSecret != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.APP_SECRET, appSecret);
+		}
+
+		String graphURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.GRAPH_URL);
+
+		if (graphURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.GRAPH_URL, graphURL);
+		}
+
+		String oauthAuthURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_AUTH_URL);
+
+		if (oauthAuthURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_AUTH_URL, oauthAuthURL);
+		}
+
+		String oauthRedirectURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_REDIRECT_URL);
+
+		if (oauthRedirectURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_REDIRECT_URL,
+				oauthRedirectURL);
+		}
+
+		String oauthTokenURL = _prefsProps.getString(
+			companyId, LegacyFacebookConnectPropsKeys.OAUTH_TOKEN_URL);
+
+		if (oauthTokenURL != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.OAUTH_TOKEN_URL,
+				oauthTokenURL);
+		}
+
+		String verifiedAccountRequired = _prefsProps.getString(
+			companyId,
+			LegacyFacebookConnectPropsKeys.VERIFIED_ACCOUNT_REQUIRED);
+
+		if (verifiedAccountRequired != null) {
+			dictionary.put(
+				FacebookConnectConfigurationKeys.VERIFIED_ACCOUNT_REQUIRED,
+				verifiedAccountRequired);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-google/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-google/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	provided group: "com.google.guava", name: "guava-jdk5", version: "17.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-codec", name: "commons-codec", version: "1.3"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
@@ -16,7 +16,6 @@ package com.liferay.portal.security.sso.google.internal.verify;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.google.constants.GoogleAuthorizationConfigurationKeys;
@@ -25,7 +24,6 @@ import com.liferay.portal.security.sso.google.constants.LegacyGoogleLoginPropsKe
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,35 +51,21 @@ public class GoogleLoginCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(
-				GoogleAuthorizationConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String clientId = _prefsProps.getString(
-			companyId, LegacyGoogleLoginPropsKeys.CLIENT_ID);
-
-		if (clientId != null) {
-			dictionary.put(
-				GoogleAuthorizationConfigurationKeys.CLIENT_ID, clientId);
-		}
-
-		String clientSecret = _prefsProps.getString(
-			companyId, LegacyGoogleLoginPropsKeys.CLIENT_SECRET);
-
-		if (clientSecret != null) {
-			dictionary.put(
-				GoogleAuthorizationConfigurationKeys.CLIENT_SECRET,
-				clientSecret);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyGoogleLoginPropsKeys.AUTH_ENABLED,
+				GoogleAuthorizationConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyGoogleLoginPropsKeys.CLIENT_ID,
+				GoogleAuthorizationConfigurationKeys.CLIENT_ID
+			},
+			new String[] {
+				LegacyGoogleLoginPropsKeys.CLIENT_SECRET,
+				GoogleAuthorizationConfigurationKeys.CLIENT_SECRET
+			}
+		};
 	}
 
 	@Override
@@ -97,6 +81,10 @@ public class GoogleLoginCompanySettingsVerifyProcess
 	@Reference
 	private CompanyLocalService _companyLocalService;
 
+	/**
+	 * @deprecated As of 2.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference
 	private PrefsProps _prefsProps;
 

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-google/src/main/java/com/liferay/portal/security/sso/google/internal/verify/GoogleLoginCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.google.constants.GoogleAuthorizationConfigurationKeys;
 import com.liferay.portal.security.sso.google.constants.GoogleConstants;
 import com.liferay.portal.security.sso.google.constants.LegacyGoogleLoginPropsKeys;
@@ -57,21 +56,30 @@ public class GoogleLoginCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.CLIENT_ID,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.CLIENT_ID,
-				StringPool.BLANK));
-		dictionary.put(
-			GoogleAuthorizationConfigurationKeys.CLIENT_SECRET,
-			_prefsProps.getString(
-				companyId, LegacyGoogleLoginPropsKeys.CLIENT_SECRET,
-				StringPool.BLANK));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String clientId = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.CLIENT_ID);
+
+		if (clientId != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.CLIENT_ID, clientId);
+		}
+
+		String clientSecret = _prefsProps.getString(
+			companyId, LegacyGoogleLoginPropsKeys.CLIENT_SECRET);
+
+		if (clientSecret != null) {
+			dictionary.put(
+				GoogleAuthorizationConfigurationKeys.CLIENT_SECRET,
+				clientSecret);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.instances.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.exportimport.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.ntlm.constants.LegacyNtlmPropsKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConfigurationKeys;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConstants;
@@ -57,40 +56,60 @@ public class NtlmCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN, "EXAMPLE"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER,
-				"127.0.0.1"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME,
-				"EXAMPLE"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS,
-				"0x600FFFFF"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT,
-				"LIFERAY$@EXAMPLE.COM"));
-		dictionary.put(
-			NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD,
-			_prefsProps.getString(
-				companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD,
-				"test"));
+		String domain = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN);
+
+		if (domain != null) {
+			dictionary.put(NtlmConfigurationKeys.AUTH_DOMAIN, domain);
+		}
+
+		String domainController = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER);
+
+		if (domainController != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER, domainController);
+		}
+
+		String domainControllerName = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME);
+
+		if (domainControllerName != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME,
+				domainControllerName);
+		}
+
+		String enabled = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(NtlmConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String negotiateFlags = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS);
+
+		if (negotiateFlags != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS, negotiateFlags);
+		}
+
+		String serviceAccount = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT);
+
+		if (serviceAccount != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT, serviceAccount);
+		}
+
+		String servicePassword = _prefsProps.getString(
+			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD);
+
+		if (servicePassword != null) {
+			dictionary.put(
+				NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD, servicePassword);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-ntlm/src/main/java/com/liferay/portal/security/sso/ntlm/internal/verify/NtlmCompanySettingsVerifyProcess.java
@@ -16,7 +16,6 @@ package com.liferay.portal.security.sso.ntlm.internal.verify;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.ntlm.constants.LegacyNtlmPropsKeys;
@@ -25,7 +24,6 @@ import com.liferay.portal.security.sso.ntlm.constants.NtlmConstants;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,65 +51,37 @@ public class NtlmCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String domain = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN);
-
-		if (domain != null) {
-			dictionary.put(NtlmConfigurationKeys.AUTH_DOMAIN, domain);
-		}
-
-		String domainController = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER);
-
-		if (domainController != null) {
-			dictionary.put(
-				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER, domainController);
-		}
-
-		String domainControllerName = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME);
-
-		if (domainControllerName != null) {
-			dictionary.put(
-				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME,
-				domainControllerName);
-		}
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(NtlmConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String negotiateFlags = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS);
-
-		if (negotiateFlags != null) {
-			dictionary.put(
-				NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS, negotiateFlags);
-		}
-
-		String serviceAccount = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT);
-
-		if (serviceAccount != null) {
-			dictionary.put(
-				NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT, serviceAccount);
-		}
-
-		String servicePassword = _prefsProps.getString(
-			companyId, LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD);
-
-		if (servicePassword != null) {
-			dictionary.put(
-				NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD, servicePassword);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN,
+				NtlmConfigurationKeys.AUTH_DOMAIN
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER,
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_DOMAIN_CONTROLLER_NAME,
+				NtlmConfigurationKeys.AUTH_DOMAIN_CONTROLLER_NAME
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_ENABLED,
+				NtlmConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_NEGOTIATE_FLAGS,
+				NtlmConfigurationKeys.AUTH_NEGOTIATE_FLAGS
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_ACCOUNT,
+				NtlmConfigurationKeys.AUTH_SERVICE_ACCOUNT
+			},
+			new String[] {
+				LegacyNtlmPropsKeys.NTLM_AUTH_SERVICE_PASSWORD,
+				NtlmConfigurationKeys.AUTH_SERVICE_PASSWORD
+			}
+		};
 	}
 
 	@Override
@@ -131,6 +101,10 @@ public class NtlmCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.openid.constants.LegacyOpenIdPropsKeys;
 import com.liferay.portal.security.sso.openid.constants.OpenIdConfigurationKeys;
 import com.liferay.portal.security.sso.openid.constants.OpenIdConstants;
@@ -57,11 +56,12 @@ public class OpenIdCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			OpenIdConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED,
-				StringPool.FALSE));
+		String enabled = _prefsProps.getString(
+			companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(OpenIdConfigurationKeys.AUTH_ENABLED, enabled);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid/src/main/java/com/liferay/portal/security/sso/openid/internal/verify/OpenIdCompanySettingsVerifyProcess.java
@@ -16,7 +16,6 @@ package com.liferay.portal.security.sso.openid.internal.verify;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.openid.constants.LegacyOpenIdPropsKeys;
@@ -25,7 +24,6 @@ import com.liferay.portal.security.sso.openid.constants.OpenIdConstants;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,17 +51,13 @@ public class OpenIdCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(OpenIdConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyOpenIdPropsKeys.OPENID_AUTH_ENABLED,
+				OpenIdConfigurationKeys.AUTH_ENABLED
+			}
+		};
 	}
 
 	@Override
@@ -83,6 +77,10 @@ public class OpenIdCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.exportimport.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
@@ -16,7 +16,6 @@ package com.liferay.portal.security.sso.opensso.internal.verify;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.opensso.constants.LegacyOpenSSOPropsKeys;
@@ -25,7 +24,6 @@ import com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,88 +51,49 @@ public class OpenSSOCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String emailAddressAttr = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR);
-
-		if (emailAddressAttr != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR, emailAddressAttr);
-		}
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(OpenSSOConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String firstNameAttr = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR);
-
-		if (firstNameAttr != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.FIRST_NAME_ATTR, firstNameAttr);
-		}
-
-		String importFromLDAP = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP);
-
-		if (importFromLDAP != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
-		}
-
-		String lastNameAttr = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR);
-
-		if (lastNameAttr != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.LAST_NAME_ATTR, lastNameAttr);
-		}
-
-		String loginURL = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL);
-
-		if (loginURL != null) {
-			dictionary.put(OpenSSOConfigurationKeys.LOGIN_URL, loginURL);
-		}
-
-		String logoutOnSessionExpiration = _prefsProps.getString(
-			companyId,
-			LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION);
-
-		if (logoutOnSessionExpiration != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-				logoutOnSessionExpiration);
-		}
-
-		String logoutURL = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL);
-
-		if (logoutURL != null) {
-			dictionary.put(OpenSSOConfigurationKeys.LOGOUT_URL, logoutURL);
-		}
-
-		String screenNameAttr = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR);
-
-		if (screenNameAttr != null) {
-			dictionary.put(
-				OpenSSOConfigurationKeys.SCREEN_NAME_ATTR, screenNameAttr);
-		}
-
-		String serviceURL = _prefsProps.getString(
-			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL);
-
-		if (serviceURL != null) {
-			dictionary.put(OpenSSOConfigurationKeys.SERVICE_URL, serviceURL);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR,
+				OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED,
+				OpenSSOConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR,
+				OpenSSOConfigurationKeys.FIRST_NAME_ATTR
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP,
+				OpenSSOConfigurationKeys.IMPORT_FROM_LDAP
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR,
+				OpenSSOConfigurationKeys.LAST_NAME_ATTR
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL,
+				OpenSSOConfigurationKeys.LOGIN_URL
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION,
+				OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL,
+				OpenSSOConfigurationKeys.LOGOUT_URL
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR,
+				OpenSSOConfigurationKeys.SCREEN_NAME_ATTR
+			},
+			new String[] {
+				LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL,
+				OpenSSOConfigurationKeys.SERVICE_URL
+			}
+		};
 	}
 
 	@Override
@@ -154,6 +113,10 @@ public class OpenSSOCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-opensso/src/main/java/com/liferay/portal/security/sso/opensso/internal/verify/OpenSSOCompanySettingsVerifyProcess.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.opensso.constants.LegacyOpenSSOPropsKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConfigurationKeys;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants;
@@ -57,59 +56,83 @@ public class OpenSSOCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		dictionary.put(
-			OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR,
-				"mail"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.FIRST_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR,
-				"givenname"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LAST_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR,
-				"sn"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGIN_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL,
-				"http://openssohost.example.com:8080/opensso/UI/Login?goto=" +
-					"http://portalhost.example.com:8080/c/portal/login"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
-			_prefsProps.getString(
-				companyId,
-				LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION,
-				StringPool.FALSE));
-		dictionary.put(
-			OpenSSOConfigurationKeys.LOGOUT_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL,
-				"http://openssohost.example.com:8080/opensso/UI/Logout?goto=" +
-					"http://portalhost.example.com:8080/web/guest/home"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.SCREEN_NAME_ATTR,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR,
-				"uid"));
-		dictionary.put(
-			OpenSSOConfigurationKeys.SERVICE_URL,
-			_prefsProps.getString(
-				companyId, LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL,
-				"http://openssohost.example.com:8080/opensso"));
+		String emailAddressAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_EMAIL_ADDRESS_ATTR);
+
+		if (emailAddressAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.EMAIL_ADDRESS_ATTR, emailAddressAttr);
+		}
+
+		String enabled = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_AUTH_ENABLED);
+
+		if (enabled != null) {
+			dictionary.put(OpenSSOConfigurationKeys.AUTH_ENABLED, enabled);
+		}
+
+		String firstNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_FIRST_NAME_ATTR);
+
+		if (firstNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.FIRST_NAME_ATTR, firstNameAttr);
+		}
+
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String lastNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LAST_NAME_ATTR);
+
+		if (lastNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.LAST_NAME_ATTR, lastNameAttr);
+		}
+
+		String loginURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGIN_URL);
+
+		if (loginURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.LOGIN_URL, loginURL);
+		}
+
+		String logoutOnSessionExpiration = _prefsProps.getString(
+			companyId,
+			LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_ON_SESSION_EXPIRATION);
+
+		if (logoutOnSessionExpiration != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.LOGOUT_ON_SESSION_EXPIRATION,
+				logoutOnSessionExpiration);
+		}
+
+		String logoutURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_LOGOUT_URL);
+
+		if (logoutURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.LOGOUT_URL, logoutURL);
+		}
+
+		String screenNameAttr = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SCREEN_NAME_ATTR);
+
+		if (screenNameAttr != null) {
+			dictionary.put(
+				OpenSSOConfigurationKeys.SCREEN_NAME_ATTR, screenNameAttr);
+		}
+
+		String serviceURL = _prefsProps.getString(
+			companyId, LegacyOpenSSOPropsKeys.OPENSSO_SERVICE_URL);
+
+		if (serviceURL != null) {
+			dictionary.put(OpenSSOConfigurationKeys.SERVICE_URL, serviceURL);
+		}
 
 		return dictionary;
 	}

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/build.gradle
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.exportimport.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
@@ -27,7 +26,6 @@ import com.liferay.portal.security.sso.token.constants.TokenConstants;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -55,46 +53,25 @@ public class ShibbolethCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String importFromLDAP = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP);
-
-		if (importFromLDAP != null) {
-			dictionary.put(
-				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
-		}
-
-		String logoutRedirectURL = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL);
-
-		if (logoutRedirectURL != null) {
-			dictionary.put(
-				TokenConfigurationKeys.LOGOUT_REDIRECT_URL, logoutRedirectURL);
-		}
-
-		String userTokenName = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER);
-
-		if (userTokenName != null) {
-			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
-		}
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Adding Shibboleth token configuration for company " +
-					companyId + " with properties: " + dictionary);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED,
+				TokenConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP,
+				TokenConfigurationKeys.IMPORT_FROM_LDAP
+			},
+			new String[] {
+				LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL,
+				TokenConfigurationKeys.LOGOUT_REDIRECT_URL
+			},
+			new String[] {
+				LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER,
+				TokenConfigurationKeys.USER_HEADER
+			}
+		};
 	}
 
 	@Override
@@ -114,6 +91,10 @@ public class ShibbolethCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/ShibbolethCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConfigurationKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConstants;
@@ -59,33 +58,35 @@ public class ShibbolethCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		boolean shibbolethEnabled = _prefsProps.getBoolean(
+		String enabled = _prefsProps.getString(
 			companyId, LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED);
 
-		if (!shibbolethEnabled) {
-			return dictionary;
+		if (enabled != null) {
+			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
 		}
 
-		dictionary.put(
-			TokenConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.LOGOUT_REDIRECT_URL,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL,
-				"/Shibboleth.sso/Logout"));
-		dictionary.put(
-			TokenConfigurationKeys.USER_HEADER,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER,
-				"SHIBBOLETH_USER_EMAIL"));
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String logoutRedirectURL = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_LOGOUT_URL);
+
+		if (logoutRedirectURL != null) {
+			dictionary.put(
+				TokenConfigurationKeys.LOGOUT_REDIRECT_URL, logoutRedirectURL);
+		}
+
+		String userTokenName = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SHIBBOLETH_USER_HEADER);
+
+		if (userTokenName != null) {
+			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConfigurationKeys;
 import com.liferay.portal.security.sso.token.constants.TokenConstants;
@@ -59,28 +58,27 @@ public class SiteMinderCompanySettingsVerifyProcess
 	protected Dictionary<String, String> getPropertyValues(long companyId) {
 		Dictionary<String, String> dictionary = new HashMapDictionary<>();
 
-		boolean siteMinderEnabled = _prefsProps.getBoolean(
+		String enabled = _prefsProps.getString(
 			companyId, LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED);
 
-		if (!siteMinderEnabled) {
-			return dictionary;
+		if (enabled != null) {
+			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
 		}
 
-		dictionary.put(
-			TokenConfigurationKeys.AUTH_ENABLED,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.IMPORT_FROM_LDAP,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP,
-				StringPool.FALSE));
-		dictionary.put(
-			TokenConfigurationKeys.USER_HEADER,
-			_prefsProps.getString(
-				companyId, LegacyTokenPropsKeys.SITEMINDER_USER_HEADER,
-				"SM_USER"));
+		String importFromLDAP = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP);
+
+		if (importFromLDAP != null) {
+			dictionary.put(
+				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
+		}
+
+		String userTokenName = _prefsProps.getString(
+			companyId, LegacyTokenPropsKeys.SITEMINDER_USER_HEADER);
+
+		if (userTokenName != null) {
+			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
+		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token/src/main/java/com/liferay/portal/security/sso/token/internal/verify/SiteMinderCompanySettingsVerifyProcess.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.sso.token.constants.LegacyTokenPropsKeys;
@@ -27,7 +26,6 @@ import com.liferay.portal.security.sso.token.constants.TokenConstants;
 import com.liferay.portal.verify.BaseCompanySettingsVerifyProcess;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.Dictionary;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -55,38 +53,21 @@ public class SiteMinderCompanySettingsVerifyProcess
 	}
 
 	@Override
-	protected Dictionary<String, String> getPropertyValues(long companyId) {
-		Dictionary<String, String> dictionary = new HashMapDictionary<>();
-
-		String enabled = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED);
-
-		if (enabled != null) {
-			dictionary.put(TokenConfigurationKeys.AUTH_ENABLED, enabled);
-		}
-
-		String importFromLDAP = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP);
-
-		if (importFromLDAP != null) {
-			dictionary.put(
-				TokenConfigurationKeys.IMPORT_FROM_LDAP, importFromLDAP);
-		}
-
-		String userTokenName = _prefsProps.getString(
-			companyId, LegacyTokenPropsKeys.SITEMINDER_USER_HEADER);
-
-		if (userTokenName != null) {
-			dictionary.put(TokenConfigurationKeys.USER_HEADER, userTokenName);
-		}
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Adding SiteMinder token configuration for company " +
-					companyId + " with properties: " + dictionary);
-		}
-
-		return dictionary;
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[][] {
+			new String[] {
+				LegacyTokenPropsKeys.SITEMINDER_AUTH_ENABLED,
+				TokenConfigurationKeys.AUTH_ENABLED
+			},
+			new String[] {
+				LegacyTokenPropsKeys.SITEMINDER_IMPORT_FROM_LDAP,
+				TokenConfigurationKeys.IMPORT_FROM_LDAP
+			},
+			new String[] {
+				LegacyTokenPropsKeys.SITEMINDER_USER_HEADER,
+				TokenConfigurationKeys.USER_HEADER
+			}
+		};
 	}
 
 	@Override
@@ -106,6 +87,10 @@ public class SiteMinderCompanySettingsVerifyProcess
 		_companyLocalService = companyLocalService;
 	}
 
+	/**
+	 * @deprecated As of 3.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Reference(unbind = "-")
 	protected void setPrefsProps(PrefsProps prefsProps) {
 		_prefsProps = prefsProps;

--- a/portal-impl/src/com/liferay/portal/verify/BaseCompanySettingsVerifyProcess.java
+++ b/portal-impl/src/com/liferay/portal/verify/BaseCompanySettingsVerifyProcess.java
@@ -24,7 +24,9 @@ import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsDescriptor;
 import com.liferay.portal.kernel.settings.SettingsException;
 import com.liferay.portal.kernel.settings.SettingsFactory;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
 
 import java.io.IOException;
 
@@ -48,8 +50,29 @@ public abstract class BaseCompanySettingsVerifyProcess extends VerifyProcess {
 
 	protected abstract Set<String> getLegacyPropertyKeys();
 
-	protected abstract Dictionary<String, String> getPropertyValues(
-		long companyId);
+	protected Dictionary<String, String> getPropertyValues(long companyId) {
+		Dictionary<String, String> dictionary = new HashMapDictionary<>();
+
+		String[][] renamePropertykeysArray = getRenamePropertyKeysArray();
+
+		for (String[] renamePropertykeys : renamePropertykeysArray) {
+			String oldPropertyKey = renamePropertykeys[0];
+			String newPropertyKey = renamePropertykeys[1];
+
+			String oldPropertyValue = PrefsPropsUtil.getString(
+				companyId, oldPropertyKey);
+
+			if (oldPropertyValue != null) {
+				dictionary.put(newPropertyKey, oldPropertyValue);
+			}
+		}
+
+		return dictionary;
+	}
+
+	protected String[][] getRenamePropertyKeysArray() {
+		return new String[0][0];
+	}
 
 	protected abstract SettingsFactory getSettingsFactory();
 


### PR DESCRIPTION
Hi Hugo,

The PR extends from https://github.com/hhuijser/liferay-portal/pull/2992.

Based on your guidance, I finish the fix. Please refer to the below explanation from https://github.com/hhuijser/liferay-portal/pull/2992:

> The fix extends from https://github.com/mhan810/liferay-portal/pull/1369#issuecomment-325367974
> 
> Based on the requirement, I remove the default value and judge every property existed. Because this class is used for transferring opsnSSO configuration when upgrade from 6.2 to 7.0 (**So the default value is not necessary**). For low version portal (6.2), if it didn't save opensso configuration (related property didn't exist portalpreferences table in 6.2), we may treat dictionary as empty when upgrade from 6.2 to 7.0. **Otherwise**, when export the opensso system setting configuration from one DXP bundle to another bundle (empty database), for instance setting, it will use default value (portletpreferences table will use the default value) because dictionary still used default value.
> 
> Related code logic: you may refer to https://github.com/hhuijser/liferay-portal/pull/2980#issue-252554348
> 
> For third commit: Sorry, this is caused by I made the previous commit (test failed PR: https://github.com/hhuijser/liferay-portal/pull/2990). I did wrong type. 

**For the rewrite logic to BaseCompanySettingsVerifyProcess.class:**
I remove the related debug info, for example, https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java#L108-L112. Only CASCompanySettingsVerifyProcess.class, SiteMinderCompanySettingsVerifyProcess.class and ShibbolethCompanySettingsVerifyProcess.class own the debug log. 

In addition, for https://github.com/yuhai/liferay-portal/blob/a61ca9a87d967c571d4dba3a475df11a70a005f3/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/src/main/java/com/liferay/portal/security/sso/cas/internal/verify/CASCompanySettingsVerifyProcess.java#L113-L116. I thought I should use the module version "3.0.14(https://github.com/yuhai/liferay-portal/blob/a61ca9a87d967c571d4dba3a475df11a70a005f3/modules/apps/foundation/portal-security-sso/portal-security-sso-cas/bnd.bnd#L3)" as "@deprecated As of 3.0.14, with no direct replacement". However, after source-format, this is changed from 3.0.14 to 3.0.0. It seems it used the major version.

Please let me know if there is anything else I need to do.

Regards,
Hai