### PR TITLE
LPS-62965 "Permission Checker" and "Random Namespace" tooltips word wrap just one letter

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
@@ -566,7 +566,7 @@ private String _getPaletteItemTitle(HttpServletRequest request, String label, Cl
 	sb.append("<br />");
 	sb.append(LanguageUtil.get(request, label));
 	sb.append(StringPool.COLON);
-	sb.append("&nbsp;");
+	sb.append(StringPool.SPACE);
 
 	String javadocURL = null;
 
@@ -615,7 +615,7 @@ private String _getPaletteItemTitle(HttpServletRequest request, ResourceBundle r
 	if (!Objects.equals(templateVariableDefinition.getDataType(), "service-locator")) {
 		sb.append(LanguageUtil.get(request, "variable"));
 		sb.append(StringPool.COLON);
-		sb.append("&nbsp;");
+		sb.append(StringPool.SPACE);
 		sb.append(templateVariableDefinition.getName());
 	}
 


### PR DESCRIPTION
fix: We can set larger max-width of tooltip to fix this bug.
But if we change English to other language, it will run into the same problem.
Solving this problem is setting wordwrap of "Variable: xxxxxx" and "Class: xxxxxx" when it's displayed out of border.