### PR TITLE
[TS] LPS-74827

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -84,6 +84,14 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 		try {
 			long groupId = GetterUtil.getLong(document.get(Field.GROUP_ID));
 
+			if (groupId > 0) {
+				Group group = _groupLocalService.getGroup(groupId);
+
+				if (group.isStagingGroup()) {
+					groupId = group.getLiveGroupId();
+				}
+			}
+
 			String className = document.get(Field.ENTRY_CLASS_NAME);
 			String classPK = document.get(Field.ENTRY_CLASS_PK);
 

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java
@@ -196,6 +196,13 @@ public class SearchPermissionCheckerImpl implements SearchPermissionChecker {
 			roles = _resourcePermissionLocalService.getRoles(
 				companyId, className, ResourceConstants.SCOPE_INDIVIDUAL,
 				classPK, viewActionId);
+
+			roles.addAll(
+				_resourcePermissionLocalService.getRoles(
+					companyId, className,
+					ResourceConstants.SCOPE_GROUP_TEMPLATE,
+					String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID),
+					viewActionId));
 		}
 
 		if (roles.isEmpty()) {


### PR DESCRIPTION
Hi Hugo,

The root issue is that own site role users can't see other created models because the the index field "groupRoleId" used staging groupId (10002(stagingSite groupId)-20126(siteMember)) and search query use live groupId({"terms" : {"groupRoleId" : [ "10001-20126"]}).

The first commit:  From logic seen, When add index field "groupRoleId", if the document groupId is staging groupId, we should save live groupId because local staging site is not real site and we can't assign users to staging Site on UI.

The second commit: if remove SiteMember view permission from the detailed mode(for example, one web content), and the user own one siteRole (siteRole own view permission). The use also can't view this model in asset publisher portlet. So the second commit added this role to "groupRoleId" index field. Please refer to the below related logic:

Define siteRole permisison, https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java#L399-L404.
After save these permission for siteRole, its scope is 3 in resourcepermission table.

Why regular role can work?
Please refer to https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java#L415-L427

When compose search query, if regular role owns view permission, the query({"terms" : {"groupRoleId" : [ "10001-20126"]}) won't add into query. However, we can't do siteRole (as regular role) in search query because siteRole needs to use with group together.

Regards,
Hai