### PR TITLE
LPS-74240 Site facet shows group id in site facet while site has been deleted

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -891,12 +891,14 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 				long[] userId = getUserPrimaryKeys(group.getGroupId());
 
-				TransactionCommitCallbackUtil.registerCallback(
-					() -> {
-						reindex(group.getCompanyId(), userId);
+				if (userId.length != 0) {
+					TransactionCommitCallbackUtil.registerCallback(
+						() -> {
+							reindex(group.getCompanyId(), userId);
 
-						return null;
-					});
+							return null;
+						});
+				}
 
 				groupPersistence.remove(group);
 			}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -889,6 +889,15 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					}
 				}
 
+				long[] userId = getUserPrimaryKeys(group.getGroupId());
+
+				TransactionCommitCallbackUtil.registerCallback(
+					() -> {
+						reindex(group.getCompanyId(), userId);
+
+						return null;
+					});
+
 				groupPersistence.remove(group);
 			}
 


### PR DESCRIPTION
@hhuijser 
About fix:
1. I grab `userIds` before `registerCallback`, because callback function runs after TXN commits.
2. Without `if (userId.length != 0)`, integration auto-tests run failed.
