### PR TITLE
LPS-75088 - Contents order in Asset Publisher is incorrect when using Solr

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
@@ -541,6 +541,7 @@
 		<field indexed="true" multiValued="true" name="parentCategoryIds" stored="true" type="string" />
 		<field indexed="true" name="path" stored="true" type="string" />
 		<field indexed="true" name="portletId" stored="true" type="string" />
+		<field docValues="true" indexed="true" name="priority" stored="true" type="double" />
 		<field docValues="true" indexed="true" name="publishDate" stored="true" type="string" />
 		<field indexed="true" name="readCount" stored="true" type="string" />
 		<field indexed="true" name="recordSetId" stored="true" type="string" />


### PR DESCRIPTION
the root cause of the issue is that the index will use "*_sortable" by default. the order type is the STRING instead of DOUBLE.

`<dynamicField docValues="true" indexed="true" multiValued="false" name="*_sortable" stored="true" type="string" />`

