### PR TITLE
[TS] LPS-75088 

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
@@ -541,6 +541,8 @@
 		<field indexed="true" multiValued="true" name="parentCategoryIds" stored="true" type="string" />
 		<field indexed="true" name="path" stored="true" type="string" />
 		<field indexed="true" name="portletId" stored="true" type="string" />
+		<field docValues="true" indexed="true" name="priority" stored="true" type="string" />
+		<field docValues="true" indexed="true" name="priority_sortable" stored="true" type="double" />
 		<field docValues="true" indexed="true" name="publishDate" stored="true" type="string" />
 		<field indexed="true" name="readCount" stored="true" type="string" />
 		<field indexed="true" name="recordSetId" stored="true" type="string" />


### PR DESCRIPTION
Hi Hugo,

The root issue is: 
We can use "priority_sortable" field to order. When using solr, it will match with <dynamicField docValues="true" name="*String_sortable" type="string" .. /> field (https://github.com/yuhai/liferay-portal/blob/fbec394a96115e6b5bc4726e4e19ebb636b0150a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml#L580), and this will order by string. However, priority should be number (1.0,2.0...) and it should order by number. Some resources for you reference:

Index field: 
https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/document/AssetEntryDocumentContributor.java#L82

search query: sort=priority_sortable+asc. Asset publisher portlet can set priority to order.

In addition. 
1. When create "priority_sortable" index field, we also create "priority" field, so the fix also adds <field docValues="true" name="priority" type="string" ../>
2. The fix also refers to the EXISTED field "modified_sortable", https://github.com/yuhai/liferay-portal/blob/fbec394a96115e6b5bc4726e4e19ebb636b0150a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml#L534-L535

Regards,
Hai