### PR TITLE
LPS-75437 Line breaks in web content folder description are ignored in Asset Publisher

### DIFF
--- a/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/abstract.jsp
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/abstract.jsp
@@ -23,4 +23,4 @@ int abstractLength = GetterUtil.getInteger(request.getAttribute(WebKeys.ASSET_EN
 String summary = StringUtil.shorten(assetRenderer.getSummary(renderRequest, renderResponse), abstractLength);
 %>
 
-<%= HtmlUtil.escape(summary) %>
+<%= HtmlUtil.replaceNewLine(HtmlUtil.escape(summary)) %>


### PR DESCRIPTION
fix: Replace newlines.