### PR TITLE
LPS-75490 --- Fix from LPS-30229 causes a problem for staging

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -482,9 +482,10 @@ public class DLFileEntryLocalServiceImpl
 		boolean manualCheckinRequired = GetterUtil.getBoolean(
 			serviceContext.getAttribute(DL.MANUAL_CHECK_IN_REQUIRED));
 
-		dlFileEntry.setManualCheckInRequired(manualCheckinRequired);
-
-		dlFileEntryPersistence.update(dlFileEntry);
+		if (dlFileEntry.getManualCheckInRequired() ^ manualCheckinRequired) {
+			dlFileEntry.setManualCheckInRequired(manualCheckinRequired);
+			dlFileEntryPersistence.update(dlFileEntry);
+		}
 
 		String version = dlFileVersion.getVersion();
 


### PR DESCRIPTION
from https://github.com/mhan810/liferay-portal/pull/1390
Hi, and mentioning @mhan810,
https://issues.liferay.com/browse/LPS-30229 added support for manual checkin in the LiferayRepository and CMISRepository,
but it causes an issue which is:
in the method checkOutFileEntry() in DLFileEntryLocalServiceImpl.java, there is now needed to update FileEntry, no matter the manual checkin field is true or false, which will update this file entry's modified date field.
For staging, the generic logic is to publish file entries that are modifed after last publish date. See getFileEntryActionableDynamicQuery() in DLPortletDataHandler.java for query criteria.

Now consider the following senerio:
Enable staging
Upload a document on staging site, so it's v1.0
Publish to live, so both sites have v1.0
Checkout the document on staging site, so it's version of PWC
(notice in fileversion table, you will see both PWC and v1.0(staging one) point to the same file entry in fileentry table)

The problem is we are able to publish it, because the file entry's modified date is now after the last publish date, that makes it a valid file entry to be published while it should not because it's PWC, private working copy. See issue description for more reason why it should not be allowed.

The current solution I am sending to you avoids the problem when manual checkin is false. However when the use cases of LiferayRepository and CMISRepository come in and manual checkin is true, then we will still see this problem.
To my understanding of portal, I have no fast solution to fix it. It will probably introduce a big code changes.