### PR TITLE
LPS-74457

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
@@ -59,7 +59,9 @@ public class LanguageKeysCheck extends BaseFileCheck {
 		if (!isSubrepository() &&
 			!absolutePath.contains("/modules/private/apps/")) {
 
-			_checkLanguageKeys(fileName, absolutePath, content, getPatterns());
+			_checkLanguageKeys(
+				fileName, absolutePath, content, getPatterns(),
+				_portalLanguageProperties);
 		}
 
 		return content;
@@ -74,7 +76,7 @@ public class LanguageKeysCheck extends BaseFileCheck {
 
 	private void _checkLanguageKeys(
 			String fileName, String absolutePath, String content,
-			List<Pattern> patterns)
+			List<Pattern> patterns, Properties properties)
 		throws Exception {
 
 		if (fileName.endsWith(".vm")) {
@@ -82,7 +84,8 @@ public class LanguageKeysCheck extends BaseFileCheck {
 		}
 
 		for (Pattern pattern : patterns) {
-			_checkLanguageKeys(fileName, absolutePath, content, pattern);
+			_checkLanguageKeys(
+				fileName, absolutePath, content, pattern, properties);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
@@ -88,7 +88,7 @@ public class LanguageKeysCheck extends BaseFileCheck {
 
 	private void _checkLanguageKeys(
 			String fileName, String absolutePath, String content,
-			Pattern pattern)
+			Pattern pattern, Properties properties)
 		throws Exception {
 
 		Matcher matcher = pattern.matcher(content);
@@ -109,7 +109,7 @@ public class LanguageKeysCheck extends BaseFileCheck {
 					languageKey.startsWith(StringPool.OPEN_CURLY_BRACE) ||
 					languageKey.startsWith(StringPool.PERIOD) ||
 					languageKey.startsWith(StringPool.UNDERLINE) ||
-					_portalLanguageProperties.containsKey(languageKey)) {
+					properties.containsKey(languageKey)) {
 
 					continue;
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/LanguageKeysCheck.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.tools.ToolsUtil;
 import com.liferay.source.formatter.BNDSettings;
 import com.liferay.source.formatter.util.FileUtil;
 
@@ -43,6 +44,7 @@ public class LanguageKeysCheck extends BaseFileCheck {
 
 	@Override
 	public void init() throws Exception {
+		_customLanguageProperties = _getCustomLanguageProperties();
 		_portalLanguageProperties = getPortalLanguageProperties();
 	}
 
@@ -55,6 +57,12 @@ public class LanguageKeysCheck extends BaseFileCheck {
 	protected String doProcess(
 			String fileName, String absolutePath, String content)
 		throws Exception {
+
+		if (_customLanguageProperties != null) {
+			_checkLanguageKeys(
+				fileName, absolutePath, content, getPatterns(),
+				_customLanguageProperties);
+		}
 
 		if (!isSubrepository() &&
 			!absolutePath.contains("/modules/private/apps/")) {
@@ -157,6 +165,22 @@ public class LanguageKeysCheck extends BaseFileCheck {
 				putBNDSettings(bndSettings);
 			}
 		}
+	}
+
+	private Properties _getCustomLanguageProperties() throws Exception {
+		File customLanguagePropertiesFile = getFile(
+			_CUSTOM_LANGUAGE_PROPERTIES_FILE_NAME,
+			ToolsUtil.PORTAL_MAX_DIR_LEVEL);
+
+		if (customLanguagePropertiesFile == null) {
+			return null;
+		}
+
+		Properties properties = new Properties();
+
+		properties.load(new FileInputStream(customLanguagePropertiesFile));
+
+		return properties;
 	}
 
 	private String[] _getLanguageKeys(Matcher matcher) {
@@ -394,9 +418,13 @@ public class LanguageKeysCheck extends BaseFileCheck {
 		return null;
 	}
 
+	private static final String _CUSTOM_LANGUAGE_PROPERTIES_FILE_NAME =
+		"source-formatter/dependencies/Language.properties";
+
 	private final Pattern _applyLangMergerPluginPattern = Pattern.compile(
 		"^apply[ \t]+plugin[ \t]*:[ \t]+\"com.liferay.lang.merger\"$",
 		Pattern.MULTILINE);
+	private Properties _customLanguageProperties;
 	private final Pattern _mergeLangPattern = Pattern.compile(
 		"mergeLang \\{\\s*sourceDirs = \\[(.*?)\\]", Pattern.DOTALL);
 	private final Map<String, Properties> _moduleLangLanguagePropertiesMap =


### PR DESCRIPTION
Hi Hugo,

This fix allows a developer to enable the language keys check by adding this file to their subrepo:

```
[$SUBREPO$]/source-formatter/dependencies/Language.properties
```

This gives them more flexibility and control.  As an example, if they're using a released bundle they can optionally check against the keys in that bundle.  The con about this approach is if they're using 7.0.x, they'll need to manually add in new keys.