### PR TITLE
[TS] LPS-75646 Since we only can create approved shortcut, if document doe…

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
@@ -88,26 +88,33 @@ dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 						</liferay-ui:search-container-column-text>
 					</c:when>
 					<c:when test="<%= (fileEntry != null) && (fileShortcut == null) %>">
-						<liferay-ui:search-container-column-text
-							name="title"
-						>
 
-							<%
-							Map<String, Object> data = new HashMap<String, Object>();
+						<%
+						FileVersion fileVersion = fileEntry.getFileVersion();
+						%>
 
-							data.put("entryid", fileEntry.getFileEntryId());
-							data.put("entryname", fileEntry.getTitle());
-							%>
+						<c:if test="<%= fileVersion.getStatus() == WorkflowConstants.STATUS_APPROVED %>">
+							<liferay-ui:search-container-column-text
+								name="title"
+							>
 
-							<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
-								<%= HtmlUtil.escape(fileEntry.getTitle()) %>
-							</aui:a>
+								<%
+								Map<String, Object> data = new HashMap<String, Object>();
 
-							<c:if test="<%= Validator.isNotNull(fileEntry.getDescription()) %>">
-								<br />
-								<%= HtmlUtil.escape(fileEntry.getDescription()) %>
-							</c:if>
-						</liferay-ui:search-container-column-text>
+								data.put("entryid", fileEntry.getFileEntryId());
+								data.put("entryname", fileEntry.getTitle());
+								%>
+
+								<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
+									<%= HtmlUtil.escape(fileEntry.getTitle()) %>
+								</aui:a>
+
+								<c:if test="<%= Validator.isNotNull(fileEntry.getDescription()) %>">
+									<br />
+									<%= HtmlUtil.escape(fileEntry.getDescription()) %>
+								</c:if>
+							</liferay-ui:search-container-column-text>
+						</c:if>
 					</c:when>
 				</c:choose>
 			</liferay-ui:search-container-row>


### PR DESCRIPTION
Hi Hugo,

The root issue is that we can create shortcut for pending document and these documents don't have any approved version. For example, document (version:1.0, status:pending), we can create shortcut for this document. And this shortcut is approved (https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java#L79). 

If the user owns all document and media permission to access the document and media portlet, https://github.com/yuhai/liferay-portal/blob/master/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp#L167-L171,  DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts() will get the shortcut and filter the fileentry. And then fileentry will be gotten through shortcut (https://github.com/yuhai/liferay-portal/blob/master/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/cast_result.jspf#L45-L50). The exception of LPS-75646 will be thrown in https://github.com/yuhai/liferay-portal/blob/master/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp#L252 ->..->https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java#L112-L131 (return false.)

**The fix reason**: Because we only can create approved shortcut, if document doesn't have approved version. For example, document (version:1.0, status !=0), we should not allow create shortcut for the kind of document. Otherwise, we can access to the kind of documents through shortcut.

**Why do we get these document(version:1.0, status !=0) to display when select document for this shortcut?**

Please see DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(..) or DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(...) method(https://github.com/yuhai/liferay-portal/blob/master/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp#L43). We set the status for "0"in the two method.  When get dLFileEntry, it will invoke the sql from https://github.com/yuhai/liferay-portal/blob/master/portal-impl/src/custom-sql/documentlibrary.xml#L432

` (  SELECT DISTINCT DLFileEntry.folderId AS modelFolderId, DLFileEntry.createDate as createDate, DLFileEntry.modifiedDate as modifiedDate, DLFileEntry.name AS name, DLFileEntry.title AS title, DLFileEntry.size_ AS size_, DLFileEntry.readCount AS readCount, 0 AS fileShortcutId, 0 AS modelFolder FROM DLFileEntry   INNER JOIN DLFileVersion ON (DLFileEntry.fileEntryId = DLFileVersion.fileEntryId)    WHERE (DLFileEntry.groupId = ?) AND (DLFileVersion.status != ?  OR  (DLFileVersion.userId = ? AND DLFileVersion.status != ?)) AND [$FILE_ENTRY_FOLDER_ID$]  )`

For (DLFileVersion.status != ?  OR  (DLFileVersion.userId = ? AND DLFileVersion.status != ?), It will return document (version:1.0, status =1(pending)) by himself created. So the user can add shortcut for pending document.

If you have further concerns, please let me know.

Regards,
Hai 
 