### PR TITLE
[TS] LPS-75801 

### DIFF
--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -15,11 +15,10 @@
 --%>
 
 <%@ include file="/html/common/themes/init.jsp" %>
-
-<liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
-
 <%@ include file="/html/common/themes/top_meta.jspf" %>
 <%@ include file="/html/common/themes/top_meta-ext.jsp" %>
+
+<liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
 
 <link data-senna-track="temporary" href="<%= themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="Shortcut Icon" />
 


### PR DESCRIPTION
Hi Hugo,

The issue is X-UA-Compatible doesn't take effect in IE9.

Refer to https://msdn.microsoft.com/en-us/library/jj676915%28v=vs.85%29.aspx

> The X-UA-Compatible header isn't case sensitive; however, it must appear in the header of the webpage (the HEAD section) before all other elements except for the title element and other meta elements.

https://github.com/yuhai/liferay-portal/blob/master/portal-web/docroot/html/common/themes/top_head.jsp#L19 will invoke <link type="text/css"> tag.

So we should keep the rule as office document statement.

Regards,
Hai
