### PR TITLE
[TS] LPS-76038 

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
@@ -107,6 +107,14 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 			return hasPermission.booleanValue();
 		}
 
+		if (permissionChecker.hasOwnerPermission(
+				dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
+				dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
+				actionId)) {
+
+			return true;
+		}
+
 		DLFileVersion currentDLFileVersion = dlFileEntry.getFileVersion();
 
 		if (currentDLFileVersion.isPending()) {
@@ -128,14 +136,6 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 
 				return false;
 			}
-		}
-
-		if (permissionChecker.hasOwnerPermission(
-				dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
-				dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
-				actionId)) {
-
-			return true;
 		}
 
 		String className = dlFileEntry.getClassName();


### PR DESCRIPTION
Hi Hugo,

The issue was caused by LPS-72910 (0b051b82506686f0e657aa81cba720b31c9b532a). Because the user doesn't own review permission for workflow, after the code enter https://github.com/liferay/liferay-portal/blob/f8b99719ab52c608ee52352658abff4878f0f531/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java#L121-L138, for the pending document, it will return false, and then LPS-76038 happen.

The fix was added by LPS-72547 (4a797a5476cec6edd39fe9efac1f4c9a2313a487). This explicit said "When the user is trying to view a pending DLFileEntry, but is neither the owner nor a workflow reviewer, it should not be allowed".

After adding the fix,  LPS-72910 and LPS-72547 also worked.

Regards,
Hai
