### PR TITLE
[TS] LPS-76153 

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
@@ -583,7 +583,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 	protected String getSortFieldName(Sort sort, String scoreFieldName) {
 		String sortFieldName = sort.getFieldName();
 
-		if (sortFieldName.equals(Field.PRIORITY)) {
+		if ((sortFieldName != null) && sortFieldName.equals(Field.PRIORITY)) {
 			return sortFieldName;
 		}
 

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -534,7 +534,7 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 	protected String getSortFieldName(Sort sort, String scoreFieldName) {
 		String sortFieldName = sort.getFieldName();
 
-		if (sortFieldName.equals(Field.PRIORITY)) {
+		if ((sortFieldName != null) && sortFieldName.equals(Field.PRIORITY)) {
 			return sortFieldName;
 		}
 


### PR DESCRIPTION
Hi Hugo,

The issue is caused by solr(ff7b33b0e3b3ded1522b8523be797e93f2f4366d) and elasticsearch(fe9562f2e8d22e4b65a8045af164d6a23e530ae5). When search "kb" in knowledge base search portlet, NPE will happen so that search doesn't work.

In knowledge base search portlet, when orderByCol is score, the first sort's fieldName is null (refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/KBUtil.java#L168-L173), so we need to add the check.  After that, https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java#L86-L88 will handle this.

Regards,
Hai