### PR TITLE
[TS] LPS-76286  

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.internal;
 
 import com.liferay.petra.executor.PortalExecutorManager;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
@@ -108,6 +109,9 @@ public class SearchEngineInitializer implements Runnable {
 			List<FutureTask<Void>> futureTasks = new ArrayList<>();
 			Set<String> searchEngineIds = new HashSet<>();
 
+			long backgroundTaskId =
+				BackgroundTaskThreadLocal.getBackgroundTaskId();
+
 			for (Indexer<?> indexer : IndexerRegistryUtil.getIndexers()) {
 				String searchEngineId = indexer.getSearchEngineId();
 
@@ -122,6 +126,9 @@ public class SearchEngineInitializer implements Runnable {
 
 						@Override
 						public Void call() throws Exception {
+							BackgroundTaskThreadLocal.setBackgroundTaskId(
+								backgroundTaskId);
+
 							reindex(indexer);
 
 							return null;


### PR DESCRIPTION
Hi Hugo,

The issue only occurs when reindex all. The function was added by LPS-54663. When reindex all, every model will reindex, when one model reindex, we will send status to calculate the percentage of reindex all (this is added by this commit cca383c07a99467d047a9cdf0bc2530f731c9bd0).

The issue is when executing "reindex All",  reindex one model invoke async thread which doesn't set backgroundTaskThreadLocal (please refer to https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java#L124-L128) so that https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/dao/orm/IndexableActionableDynamicQuery.java#L150 won't be executed because https://github.com/yuhai/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/dao/orm/IndexableActionableDynamicQuery.java#L144-L146 return null (it will cause ReindexBackgroundTaskStatusMessageTranslator won't execute and ReindexBackgroundTaskStatusMessageTranslator is responsiblity for calculating the percentage).

For reindex one model(for example, reindex user) in UI, it works well because it use same thread to reindex (https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java#L81).

For reindex one model and reindex all, they use same entrance (https://github.com/yuhai/liferay-portal/blob/master/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java#L67-L70). backgroundTaskExecutor is different (reindex all: ReindexPortalBackgroundTaskExecutor, reindex one model:ReindexSingleIndexerBackgroundTaskExecutor).

Regards,
Hai