### PR TITLE
[TS] LPS-77193

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1927,7 +1927,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			assetEntry = assetEntryLocalService.updateEntry(
 				userId, page.getGroupId(), page.getCreateDate(),
 				page.getModifiedDate(), WikiPage.class.getName(),
-				page.getResourcePrimKey(), page.getUuid(), 0, assetCategoryIds,
+				page.getPrimaryKey(), page.getUuid(), 0, assetCategoryIds,
 				assetTagNames, true, false, null, null, publishDate, null,
 				ContentTypes.TEXT_HTML, page.getTitle(), null, null, null, null,
 				0, 0, priority);

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1774,6 +1774,8 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			summary = StringPool.BLANK;
 		}
 
+		populateServiceContext(serviceContext, page);
+
 		serviceContext.setCommand(Constants.RENAME);
 
 		WikiPageRenameContentProcessor wikiPageRenameContentProcessor =

--- a/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
+++ b/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
@@ -688,7 +688,9 @@ public class WikiPageLocalServiceTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
 			serviceContext);
 
-		WikiTestUtil.updatePage(page);
+		WikiTestUtil.updatePage(
+			page, TestPropsValues.getUserId(), StringUtil.randomString(),
+			serviceContext);
 
 		serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group.getGroupId());
@@ -729,7 +731,9 @@ public class WikiPageLocalServiceTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
 			serviceContext);
 
-		WikiTestUtil.updatePage(page);
+		WikiTestUtil.updatePage(
+			page, TestPropsValues.getUserId(), StringUtil.randomString(),
+			serviceContext);
 
 		serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group.getGroupId());


### PR DESCRIPTION
Hi Hugo,

The PR extends from https://github.com/hhuijser/liferay-portal/pull/3140#issue-289165825. And the PR solve the test failed. 

**The first commit:**
The root issue is that for draft and approved wikipage, it will use same assetEntry data.

The fix refers to https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L6435 AND https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L6456

For draft and approved wikipage, we should use different assetEntry data. After change draft for approved, deleting draft assetEntry logic also existed. Please refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java#L2069 and https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java#L2100-L2101

**The second commit:**
Use right serviceContext, otherwise 1.1 version will miss tags and categorys.  WikiTestUtil.updatePage(page) will use new serviceContext.

**The third commit:**
It solves new wikipage (new title) can keep previous wikipage's assetTags. 
For example: for one Wikipage.
1. pageId:1 Version:1.0, status:1.0, title: oldTitle, resourcePrimKey: 10
    pageId:2  Version: 1.1, status:1.1, title: oldTitle, resourcePrimKey: 10
2. When rename the wikipag (In UI, copy action can invoke rename method) for title: newTitle
Our logic will add change pageId:1 and pageId:2 title for newTitle, and then add new version:1.2 for this wikipage (resourcePrimKey: 10 ). When add new title:1.2, we need to get 1.1 wikipage's assetTags.

Regards,
Hai