### PR TITLE
[TS] LPS-77431

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,7 @@
+.dialog-iframe-popup .portlet-dynamic-data-lists .lfr-form-content {
+	position: relative;
+}
+
 .document-library-file-entry-cell-editor-hidden, .link-to-page-cell-editor-hidden {
 	display: none;
 }

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
@@ -170,73 +170,75 @@ else {
 			<aui:input name="languageId" type="hidden" value="<%= languageId %>" />
 			<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_PUBLISH %>" />
 
-			<liferay-ui:error exception="<%= DuplicateFileEntryException.class %>" message="a-file-with-that-name-already-exists" />
+			<div class="lfr-form-content">
+				<liferay-ui:error exception="<%= DuplicateFileEntryException.class %>" message="a-file-with-that-name-already-exists" />
 
-			<liferay-ui:error exception="<%= FileSizeException.class %>">
-				<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize(DLValidatorUtil.getMaxAllowableSize(), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
-			</liferay-ui:error>
+				<liferay-ui:error exception="<%= FileSizeException.class %>">
+					<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize(DLValidatorUtil.getMaxAllowableSize(), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
+				</liferay-ui:error>
 
-			<liferay-ui:error exception="<%= StorageFieldRequiredException.class %>" message="please-fill-out-all-required-fields" />
+				<liferay-ui:error exception="<%= StorageFieldRequiredException.class %>" message="please-fill-out-all-required-fields" />
 
-			<c:if test="<%= !translating && !ddlDisplayContext.isFormView() %>">
-				<aui:translation-manager
-					availableLocales="<%= availableLocales %>"
-					changeableDefaultLanguage="<%= changeableDefaultLanguage %>"
-					defaultLanguageId="<%= defaultLanguageId %>"
-					id="translationManager"
-				/>
-			</c:if>
-
-			<%
-			long classNameId = PortalUtil.getClassNameId(DDMStructure.class);
-
-			long classPK = recordSet.getDDMStructureId();
-
-			if (formDDMTemplateId > 0) {
-				classNameId = PortalUtil.getClassNameId(DDMTemplate.class);
-
-				classPK = formDDMTemplateId;
-			}
-			%>
-
-			<c:choose>
-				<c:when test="<%= ddlDisplayContext.isFormView() %>">
-					<liferay-ddm:html
-						classNameId="<%= classNameId %>"
-						classPK="<%= classPK %>"
-						ddmFormValues="<%= ddmFormValues %>"
-						repeatable="<%= translating ? false : true %>"
-						requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
+				<c:if test="<%= !translating && !ddlDisplayContext.isFormView() %>">
+					<aui:translation-manager
+						availableLocales="<%= availableLocales %>"
+						changeableDefaultLanguage="<%= changeableDefaultLanguage %>"
+						defaultLanguageId="<%= defaultLanguageId %>"
+						id="translationManager"
 					/>
-				</c:when>
-				<c:otherwise>
-					<aui:fieldset-group markupView="lexicon">
-						<aui:fieldset>
-							<liferay-ddm:html
-								classNameId="<%= classNameId %>"
-								classPK="<%= classPK %>"
-								ddmFormValues="<%= ddmFormValues %>"
-								repeatable="<%= translating ? false : true %>"
-								requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
-							/>
-						</aui:fieldset>
-					</aui:fieldset-group>
-				</c:otherwise>
-			</c:choose>
+				</c:if>
 
-			<%
-			boolean pending = false;
+				<%
+				long classNameId = PortalUtil.getClassNameId(DDMStructure.class);
 
-			if (recordVersion != null) {
-				pending = recordVersion.isPending();
-			}
-			%>
+				long classPK = recordSet.getDDMStructureId();
 
-			<c:if test="<%= pending %>">
-				<div class="alert alert-info">
-					<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
-				</div>
-			</c:if>
+				if (formDDMTemplateId > 0) {
+					classNameId = PortalUtil.getClassNameId(DDMTemplate.class);
+
+					classPK = formDDMTemplateId;
+				}
+				%>
+
+				<c:choose>
+					<c:when test="<%= ddlDisplayContext.isFormView() %>">
+						<liferay-ddm:html
+							classNameId="<%= classNameId %>"
+							classPK="<%= classPK %>"
+							ddmFormValues="<%= ddmFormValues %>"
+							repeatable="<%= translating ? false : true %>"
+							requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
+						/>
+					</c:when>
+					<c:otherwise>
+						<aui:fieldset-group markupView="lexicon">
+							<aui:fieldset>
+								<liferay-ddm:html
+									classNameId="<%= classNameId %>"
+									classPK="<%= classPK %>"
+									ddmFormValues="<%= ddmFormValues %>"
+									repeatable="<%= translating ? false : true %>"
+									requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
+								/>
+							</aui:fieldset>
+						</aui:fieldset-group>
+					</c:otherwise>
+				</c:choose>
+
+				<%
+				boolean pending = false;
+
+				if (recordVersion != null) {
+					pending = recordVersion.isPending();
+				}
+				%>
+
+				<c:if test="<%= pending %>">
+					<div class="alert alert-info">
+						<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
+					</div>
+				</c:if>
+			</div>
 
 			<aui:button-row>
 


### PR DESCRIPTION
Hi Hugo,

The issue only occured when add one record (the record include "Documents and Media" field) in the dialog, if the "Documents and Media" field repeatable=true, it will require class="lfr-form-content" element exist in this form. Please refer to the below logic.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L3176
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L3082-L3098

You may check the error in the browser. When the field repeatable=false, the issue won't occur.

**Fix Reference:**
The fix refers to LPS-67326, it add same fix in other modules(journal, kb, blogs,dl,bookmarks). I also check other module which can be added from Asset Publisher portlet in the dialog, please refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp#L289

**The second commit:**
The module is different from other modules, it exists sidenav-container {position: relative;} (https://github.com/hhuijser/liferay-portal/blob/279fa83481423c0aaf53320b91b0df12e43c4e67/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp#L114) and lfr-form-content is using {position: absolute;}, the commit will solve the display issue to override "position: absolute"(Please refer to 005c0d83106dfe39656dd61cc6cf5659b838b9ee). 

Regards,
Hai
