### PR TITLE
[TS] LPS-77040

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
@@ -8,6 +8,7 @@ AUI.add(
 		var CalendarWorkflow = Liferay.CalendarWorkflow;
 
 		var isObject = Lang.isObject;
+		var isString = Lang.isString;
 		var isValue = Lang.isValue;
 
 		var toInt = function(value) {
@@ -77,6 +78,13 @@ AUI.add(
 				EXTENDS: A.SchedulerEventRecorder,
 
 				NAME: 'scheduler-event-recorder',
+
+				ATTRS: {
+					dateFormat: {
+						validator: isString,
+						value: Liferay.Language.get('a-b-d')
+					},
+				},
 
 				prototype: {
 					initializer: function() {

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour
 a=%A
+a-b-d=%a, %B %d
 a-b-d-y=%A, %B %d, %Y
 accept=Accept
 accepted=Accepted

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ar.properties
@@ -1,5 +1,6 @@
 24-hour=على مدار 24 ساعة (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=% A، %B % d، %Y (Automatic Translation)
 accept=قبول (Automatic Translation)
 accepted=قبول (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_bg.properties
@@ -1,5 +1,6 @@
 24-hour=24 часа (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%А, %B %d, %Y (Automatic Translation)
 accept=Приемете (Automatic Translation)
 accepted=Прието (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ca.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hores
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Accepta
 accepted=Acceptat

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_cs.properties
@@ -1,5 +1,6 @@
 24-hour=24 hodin
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Přijmout
 accepted=Přijato

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_da.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour (Automatic Copy)
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accept (Automatic Copy)
 accepted=Accepted (Automatic Copy)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_de.properties
@@ -1,5 +1,6 @@
 24-hour=24 Stunden
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Annehmen
 accepted=Angenommen

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_el.properties
@@ -1,5 +1,6 @@
 24-hour=24 Ωρών (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=Α %, %B %d, %Y (Automatic Translation)
 accept=Αποδοχή (Automatic Translation)
 accepted=Αποδεκτές (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_en.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour
 a=%A
+a-b-d=%a, %B %d
 a-b-d-y=%A, %B %d, %Y
 accept=Accept
 accepted=Accepted

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_es.properties
@@ -1,5 +1,6 @@
 24-hour=24 Horas
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Aceptar
 accepted=Aceptado

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_et.properties
@@ -1,5 +1,6 @@
 24-hour=24-tunnise (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=A %%Y %B %d, (Automatic Translation)
 accept=Vastu (Automatic Translation)
 accepted=Vastu (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_eu.properties
@@ -1,5 +1,6 @@
 24-hour=24 Ordu
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Onartu
 accepted=Onartuta

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fa.properties
@@ -1,5 +1,6 @@
 24-hour=۲۴ ساعته
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=A %%B %d %Y (Automatic Translation)
 accept=پذیرش
 accepted=پذیرفته شده

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fi.properties
@@ -1,5 +1,6 @@
 24-hour=24 tuntia
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Hyväksy
 accepted=Hyväksytty

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_fr.properties
@@ -1,5 +1,6 @@
 24-hour=24 heures
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A %d %B %Y
 accept=Accepter
 accepted=Accepté(e)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_gl.properties
@@ -1,5 +1,6 @@
 24-hour=24 horas
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Aceptar
 accepted=Aceptado

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,5 +1,6 @@
 24-hour=24 घंटे (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%एक, %d, %B %Y (Automatic Translation)
 accept=स्वीकार करें (Automatic Translation)
 accepted=स्वीकार किए जाते हैं (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hr.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour (Automatic Copy)
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accept (Automatic Copy)
 accepted=Accepted (Automatic Copy)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_hu.properties
@@ -1,5 +1,6 @@
 24-hour=24 óra
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=% -A, %B %d, %Y (Automatic Translation)
 accept=Elfogad
 accepted=Elfogadva

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_in.properties
@@ -1,5 +1,6 @@
 24-hour=24 Jam
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Terima
 accepted=Diterima

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_it.properties
@@ -1,5 +1,6 @@
 24-hour=24 Ore
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %d, %B %Y (Automatic Translation)
 accept=Accetta
 accepted=Accettato

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_iw.properties
@@ -1,5 +1,6 @@
 24-hour=שעות 24
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=אשר
 accepted=אושר

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ja.properties
@@ -1,5 +1,6 @@
 24-hour=24時間
 a=%A
+a-b-d=%B%d日（%a）
 a-b-d-y=%Y年%B%d日（%A）
 accept=許可する
 accepted=許可済

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ko.properties
@@ -1,5 +1,6 @@
 24-hour=24 시간 (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B%d, %Y (Automatic Translation)
 accept=수락 (Automatic Translation)
 accepted=허용 (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_lo.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour (Automatic Copy)
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accept (Automatic Copy)
 accepted=Accepted (Automatic Copy)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_lt.properties
@@ -1,5 +1,6 @@
 24-hour=24 valandas per parą (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=A, %B %d, %Y (Automatic Translation)
 accept=Priimti (Automatic Translation)
 accepted=Priimta (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nb.properties
@@ -1,5 +1,6 @@
 24-hour=24 timer
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Godta
 accepted=Godtatt

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nl.properties
@@ -1,5 +1,6 @@
 24-hour=24 uur
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accepteren
 accepted=Geaccepteerd

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,5 +1,6 @@
 24-hour=24 uur
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accepteren
 accepted=Geaccepteerd

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pl.properties
@@ -1,5 +1,6 @@
 24-hour=24 godziny
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %d, %B %Y (Automatic Translation)
 accept=Zatwierdź
 accepted=Zatwierdzone

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,5 +1,6 @@
 24-hour=24 Horas
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %d de %B de %Y
 accept=Aceitar
 accepted=Aceito

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,5 +1,6 @@
 24-hour=24 Horas
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %d de %B de %Y
 accept=Aceitar
 accepted=Aceite

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ro.properties
@@ -1,5 +1,6 @@
 24-hour=24 de ore (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Accepta (Automatic Translation)
 accepted=Acceptate (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_ru.properties
@@ -1,5 +1,6 @@
 24-hour=24 Часа
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Принять
 accepted=Принято

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sk.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hodín
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Akceptovať
 accepted=Akceptované

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sl.properties
@@ -1,5 +1,6 @@
 24-hour=24 uur
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Accepteren
 accepted=Geaccepteerd

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,5 +1,6 @@
 24-hour=24 Часа
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Прихвати
 accepted=Прихваћено

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour (Automatic Copy)
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accept (Automatic Copy)
 accepted=Accepted (Automatic Copy)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_sv.properties
@@ -1,5 +1,6 @@
 24-hour=24 Hour (Automatic Copy)
 a=%A (Automatic Copy)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Copy)
 accept=Accept (Automatic Copy)
 accepted=Accepted (Automatic Copy)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_th.properties
@@ -1,5 +1,6 @@
 24-hour=ตลอด 24 ชั่วโมง (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %d, %B %Y (Automatic Translation)
 accept=ยอมรับ (Automatic Translation)
 accepted=การยอมรับ (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_tr.properties
@@ -1,5 +1,6 @@
 24-hour=24 Saat (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Kabul (Automatic Translation)
 accepted=Kabul (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_uk.properties
@@ -1,5 +1,6 @@
 24-hour=24-годинний (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=A %, %B %d, в %Y (Automatic Translation)
 accept=Прийняти (Automatic Translation)
 accepted=Приймаються (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_vi.properties
@@ -1,5 +1,6 @@
 24-hour=24 giờ (Automatic Translation)
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%A, %B %d, %Y (Automatic Translation)
 accept=Chấp nhận (Automatic Translation)
 accepted=Chấp nhận (Automatic Translation)

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,5 +1,6 @@
 24-hour=24小时
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%Y%b%d %A (Automatic Translation)
 accept=接受
 accepted=已接受

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,5 +1,6 @@
 24-hour=24小時
 a=%A (Automatic Translation)
+a-b-d=%a, %B %d (Automatic Copy)
 a-b-d-y=%Y%b%d %A (Automatic Translation)
 accept=接受
 accepted=已接受


### PR DESCRIPTION
Hi Hugo,

The issue belongs to the improvement for japanese display on UI.

For en, the date is : Thu, February 08.
For ja， the date should is: 2月08日（木）
(木) is the day of week (Thu)

The fix only changes japanese display for the default date format (please refer to https://alloyui.com/api/files/alloy-ui_src_aui-scheduler_js_aui-scheduler-event-recorder.js.html, dateFormat). It referred to LPS-68909 fix.  The commit order is same with LPS-68909.

Regards,
Hai


