### PR TITLE
LPS-78277 - When log off from Liferay, "ArrayIndexOutOfBoundsException" will be occurred, if "Token Based SSO" enable with using "Logout Redirect URL".

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-token-impl/src/main/java/com/liferay/portal/security/sso/token/internal/events/RedirectLogoutProcessor.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-token-impl/src/main/java/com/liferay/portal/security/sso/token/internal/events/RedirectLogoutProcessor.java
@@ -48,7 +48,7 @@ public class RedirectLogoutProcessor implements LogoutProcessor {
 			return;
 		}
 
-		String redirectURL = parameters[1];
+		String redirectURL = parameters[0];
 
 		String pathInfo = request.getPathInfo();
 


### PR DESCRIPTION
@hhuijser 
1: RedirectLogoutProcessor -> logout(,,parameters),  parameters only contain one value "logoutRedirectURL",   

2: called by TokenLogoutAction.java  -> run()， you can search the code "redirectLogoutProcessor.logout"
``` 
String logoutRedirectURL =
	tokenCompanyServiceSettings.logoutRedirectURL();

if (Validator.isNotNull(logoutRedirectURL)) {
	LogoutProcessor redirectLogoutProcessor = _logoutProcessors.get(
		LogoutProcessorType.REDIRECT);

	if (redirectLogoutProcessor != null) {
		redirectLogoutProcessor.logout(
			request, response, logoutRedirectURL);
	}
}
```
