### PR TITLE
[TS] LPS-78313

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -102,6 +102,7 @@ import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceReference;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
+import com.liferay.util.JS;
 
 import java.net.URL;
 
@@ -2801,6 +2802,8 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				String rootPortletId = PortletIdCodec.decodePortletName(
 					portletId);
 
+				rootPortletId = JS.getSafeName(rootPortletId);
+
 				while (true) {
 					String[] friendlyURLMapperRootPortletIds =
 						_friendlyURLMapperRootPortletIds.get();
@@ -2831,7 +2834,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 					String rootPortletId = PortletIdCodec.decodePortletName(
 						portletIds[i]);
 
-					rootPortletIds[i] = rootPortletId;
+					rootPortletIds[i] = JS.getSafeName(rootPortletId);
 				}
 
 				while (true) {

--- a/portal-impl/src/com/liferay/portlet/FriendlyURLMapperTrackerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/FriendlyURLMapperTrackerImpl.java
@@ -55,8 +55,9 @@ public class FriendlyURLMapperTrackerImpl implements FriendlyURLMapperTracker {
 
 		Filter filter = registry.getFilter(
 			StringBundler.concat(
-				"(&(javax.portlet.name=", portlet.getPortletId(),
-				")(objectClass=", FriendlyURLMapper.class.getName(), "))"));
+				"(&(|(javax.portlet.name=", portlet.getPortletId(),
+				")(javax.portlet.name=", portlet.getPortletName(),
+				"))(objectClass=", FriendlyURLMapper.class.getName(), "))"));
 
 		_serviceTracker = registry.trackServices(
 			filter, new FriendlyURLMapperServiceTrackerCustomizer());


### PR DESCRIPTION
Hi Hugo,

Based on SME's guidance, I finish the fix. Please refer to the explanation in the first comment in LPS-78313.

The first commit:
Since we use JS safe method to handle with portletId when deploy , for example, if javax.portlet.name = "a-b", we will handle this as portletId="ab" (https://github.com/yuhai/liferay-portal/blob/LPS-78313/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java#L132).  Refer to the below invoke logic. 
https://github.com/yuhai/liferay-portal/blob/LPS-78313/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java#L164 ->https://github.com/yuhai/liferay-portal/blob/LPS-78313/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java#L308 ...->
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/FriendlyURLMapperTrackerImpl.java#L56-L59
If we only use portletId to filter, it won't register the friendlyURL service successful. I guess this is because we set javax.portlet.name = "a-b" in registry. After adding the fix, it will work.

The second commit:
When using friendlyURL to access, we will generate the actualURL in the internal. Please refer to the logic:
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L4271-L4272 -> https://github.com/yuhai/liferay-portal/blob/LPS-78313/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L474 AND https://github.com/yuhai/liferay-portal/blob/LPS-78313/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L480
Since portletId of _friendlyURLMapperRootPortletIds and portletId of _portletsMap are different (for example, in _portletsMap, its portletId="ab", in _friendlyURLMapperRootPortletIds,  its portletId="a-b"), so the friendlyURL won't work. So the second commit will solve this.

Regards,
Hai


