### PR TITLE
[ts] LPS-78406 secureFilter property has been removed from property file, …

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
@@ -95,13 +95,6 @@ public class SecureFilter extends BasePortalFilter {
 
 		_usePermissionChecker = GetterUtil.getBoolean(
 			filterConfig.getInitParameter("use_permission_checker"));
-
-		setFilterEnabled(true);
-	}
-
-	@Override
-	public boolean isFilterEnabled() {
-		return true;
 	}
 
 	protected HttpServletRequest basicAuth(


### PR DESCRIPTION
…and basePortalFilter sets to true by default, so manually set to true in secureFilter is not neccessary and causes issues to its child types