### PR TITLE
LPS-77596

### DIFF
--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/display/context/PortletConfigurationCSSPortletDisplayContext.java
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/display/context/PortletConfigurationCSSPortletDisplayContext.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletDecorator;
 import com.liferay.portal.kernel.model.Theme;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletSetupUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -75,7 +74,7 @@ public class PortletConfigurationCSSPortletDisplayContext {
 			renderRequest, "portletResource");
 
 		PortletPreferences portletSetup =
-			PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup(
+			themeDisplay.getStrictLayoutPortletSetup(
 				themeDisplay.getLayout(), portletResource);
 
 		JSONObject portletSetupJSONObject = PortletSetupUtil.cssToJSONObject(


### PR DESCRIPTION
Hi Hugo,

The root issue is that save the configuration and display the configuration api is different. 

I want to introduce the issue background:
This commit 91d5344240ba62bc0887a9221f98802c20ba0561 let embedded portlet used the kind of portletpreferences(ownerId is groupId, plid is 0). That is to say, for all the embedded portlet, they will use same configuration in the different pages.

On 7.0.x, the issue didn't happen because the LPS-74573 didn't been backported. They are using different configuration for embedded portlet (ownerId is 0, plid is different page). 

I want to say the behavior change is not done by our fix. 
On 7.0.x, it uses same api (themeDisplay.getStrictLayoutPortletSetup(layout, portletId);) to save configuration and display configuration.
**Save configuration**: https://github.com/liferay/liferay-portal-ee/blob/7.0.x/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/PortletConfigurationCSSPortlet.java#L175
**Display configuration**: https://github.com/liferay/liferay-portal-ee/blob/7.0.x/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/PortletConfigurationCSSPortlet.java#L104

On master, it uses different api to save configuration and display configuration.
**Save configuration**: https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/PortletConfigurationCSSPortlet.java#L98
**Display configuration**: This fix is changing api.

On master, this was done by LPS-64308. The main commits are 44f951efc711bf8db22342c640ca5132c4fec309 and 09f95113f578446b147f8634f59a6234f24df3c8. After LPS-64308 commits, it seems displaying api using different with saving api.

**Summary:**
The fix mainly makes sure saving configuration and displaying configuration used same API.

cc @Seiphon

Regards,
Hai

