### PR TITLE
LPS-77819

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -34,6 +34,8 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -51,12 +53,13 @@ import com.liferay.portal.search.web.internal.util.SearchUtil;
 import com.liferay.portal.search.web.search.result.SearchResultImage;
 import com.liferay.portal.search.web.search.result.SearchResultImageContributor;
 
+import java.text.Format;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -484,14 +487,13 @@ public class SearchResultSummaryDisplayBuilder {
 	}
 
 	protected String formatDate(String dateString) {
-		SimpleDateFormat simpleDateFormatInput = new SimpleDateFormat(
-			"yyyyMMddHHmmss");
-		SimpleDateFormat simpleDateFormatOutput = new SimpleDateFormat(
-			"MMM dd yyyy, h:mm a");
-
 		try {
-			return simpleDateFormatOutput.format(
-				simpleDateFormatInput.parse(dateString));
+			Date date = DateUtil.parseDate(
+				"yyyyMMddHHmmss", dateString, _locale);
+			Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(
+				_locale, _themeDisplay.getTimeZone());
+
+			return dateFormatDateTime.format(date);
 		}
 		catch (ParseException pe) {
 			throw new RuntimeException(pe);

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.FastDateFormatConstants;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -55,11 +55,11 @@ import com.liferay.portal.search.web.search.result.SearchResultImageContributor;
 
 import java.text.Format;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -487,13 +487,16 @@ public class SearchResultSummaryDisplayBuilder {
 	}
 
 	protected String formatDate(String dateString) {
+		SimpleDateFormat simpleDateFormatInput = new SimpleDateFormat(
+			"yyyyMMddHHmmss", _locale);
+
 		try {
-			Date date = DateUtil.parseDate(
-				"yyyyMMddHHmmss", dateString, _locale);
 			Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(
+				FastDateFormatConstants.LONG, FastDateFormatConstants.SHORT,
 				_locale, _themeDisplay.getTimeZone());
 
-			return dateFormatDateTime.format(date);
+			return dateFormatDateTime.format(
+				simpleDateFormatInput.parse(dateString));
 		}
 		catch (ParseException pe) {
 			throw new RuntimeException(pe);


### PR DESCRIPTION
Hi Hugo,

The root issue is that we still use PC environment locale to display the search result. The reason is when new SimpleDateFormat(pattern) , we don't use the Constructor(SimpleDateFormat(String pattern, Locale locale)). 

If we use JDK's api (SimpleDateFormat(String pattern, Locale locale)) and it can solve the issue.  Please refer to the below test:
```
package com.test;

import java.util.Locale;
import java.text.SimpleDateFormat;

public class Test {

	 public static void main(String args[]) {
		String dateString = "20180327031056";
		Locale locale = new Locale("zh", "CN");

		SimpleDateFormat simpleDateFormatInput = new SimpleDateFormat(
			"yyyyMMddHHmmss", locale);
		SimpleDateFormat simpleDateFormatOutput = new SimpleDateFormat(
			"MMM dd yyyy, h:mm a", locale);

		try {
			String outprint = simpleDateFormatOutput.format(
				simpleDateFormatInput.parse(dateString));

			System.out.println("outprint is " + outprint);
		}
		catch (Exception e) {
		}
	 }
}
```
The outprint will be "三月 27 2018, 3:10 上午" when the locale is zh_CN. The display is not friendly. So we choose to use org.apache.commons.lang.time.FastDateFormat to format the date, its display will be right for chinese ("2018年3月27日 上午3:10").

After the first commit, the display will be "18-3-27 上午3:10" (This should be not good enough). After the second commit, the display will be "("2018年3月27日 上午3:10")."

Regards,
Hai


