### PR TITLE
[TS] LPS-79227

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -67,7 +67,7 @@ public class JSONPortletResponseUtil {
 			portletRequest);
 
 		if (BrowserSnifferUtil.isIe(request)) {
-			contentType = ContentTypes.TEXT_HTML;
+			contentType = ContentTypes.TEXT_PLAIN;
 		}
 
 		return contentType;

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -17,7 +17,6 @@ package com.liferay.portal.kernel.portlet;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.io.IOException;
@@ -68,10 +67,9 @@ public class JSONPortletResponseUtil {
 			portletRequest);
 
 		if (BrowserSnifferUtil.isIe(request)) {
-			double version = GetterUtil.getDouble(
-				BrowserSnifferUtil.getVersion(request));
+			String version = BrowserSnifferUtil.getVersion(request);
 
-			if (version < 11) {
+			if (!"11.0".equals(version)) {
 				contentType = ContentTypes.TEXT_HTML;
 			}
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -66,12 +66,9 @@ public class JSONPortletResponseUtil {
 		HttpServletRequest request = PortalUtil.getHttpServletRequest(
 			portletRequest);
 
-		if (BrowserSnifferUtil.isIe(request)) {
-			String version = BrowserSnifferUtil.getVersion(request);
-
-			if (!"11.0".equals(version)) {
-				contentType = ContentTypes.TEXT_HTML;
-			}
+		if (BrowserSnifferUtil.isIe(request) &&
+			!BrowserSnifferUtil.getVersion(request).equals("11.0")) {
+			contentType = ContentTypes.TEXT_HTML;
 		}
 
 		return contentType;

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -66,8 +66,7 @@ public class JSONPortletResponseUtil {
 		HttpServletRequest request = PortalUtil.getHttpServletRequest(
 			portletRequest);
 
-		if (BrowserSnifferUtil.isIe(request) &&
-			!BrowserSnifferUtil.getVersion(request).equals("11.0")) {
+		if (BrowserSnifferUtil.isIe(request)) {
 			contentType = ContentTypes.TEXT_HTML;
 		}
 


### PR DESCRIPTION
Hi Hugo,

The root issue is that https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js#L101 responseText is null in IE 11 browser so that the issue occured. By referring to LPS-46724 and LPS-77632 fix, we did the fix.

The fix mainly do three things:
1. Change LPS-46724's fix text/html as text/plain in the content-type (0fe77107ba19debbbb9521341a77d937479ae3aa), actually, the issue encountered similar issue with LPS-79227 (LPS-46724 added text/html as content-type).

2. Revert LPS-77632 (For JSONResponseUtil class, it was added by 5dc36a12d125f66a92d34eeef182471212ebad45, this was extract logic). LPS-77632 only let IE 11 used application/json as content-type.

3. From JSONResponseUtil class, it mainly handles with json objects (key:value). The content should not include rich text (html). So we want to use text/plain as content-type. 

After the fix, LPS-46724, LPS-77632 and LPS-79227 all work.

Regards,
Hai