### PR TITLE
[TS] LPS-79753

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/io/AutoDeleteFileInputStream.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/io/AutoDeleteFileInputStream.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.kernel.io;
 
+import com.liferay.petra.memory.DeleteFileFinalizeAction;
+import com.liferay.petra.memory.FinalizeManager;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -35,7 +38,9 @@ public class AutoDeleteFileInputStream extends FileInputStream {
 		super.close();
 
 		if (!_file.delete()) {
-			_file.deleteOnExit();
+			FinalizeManager.register(
+				_file, new DeleteFileFinalizeAction(_file.getAbsolutePath()),
+				FinalizeManager.WEAK_REFERENCE_FACTORY);
 		}
 	}
 


### PR DESCRIPTION
Hi Hugo,

The issue should be known issue from JDK.

https://bugs.openjdk.java.net/browse/JDK-4872014
https://bugs.java.com/view_bug.do?bug_id=4872014

If file.deleteOnExit() invoked frequently, it will cause memory leak. In liferay, https://issues.liferay.com/browse/LPS-22268 also introduced the issue. **The fix referred to LPS-22268**.

The issue will occur apparently when set **dl.store.impl=com.liferay.portal.store.db.DBStore** in portal-ext and then add image document in Oracle. Please refer to the below logic:
https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/portal-store/portal-store-db/src/main/java/com/liferay/portal/store/db/DBStore.java#L414-L416
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/portal-store/portal-store-db/src/main/java/com/liferay/portal/store/db/DBStore.java#L438-L441

When DLStoreUtil.getFileAsStream() exectue, it will get the inputStream as AutoDeleteFileInputStream. When AutoDeleteFileInputStream.close() execute, the issue will occur.

Regards,
Hai