### PR TITLE
[TS] LPS-79920

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -154,11 +154,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to bind to the LDAP server");
-			}
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(e, e);
+				_log.warn("Unable to bind to the LDAP server", e);
 			}
 		}
 

--- a/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -193,8 +193,8 @@ public class LDAPAuth implements Authenticator {
 				ldapAuthResult.setResponseControl(responseControls);
 			}
 			catch (Exception e) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
+				if (_log.isWarnEnabled()) {
+					_log.warn(
 						StringBundler.concat(
 							"Failed to bind to the LDAP server with userDN ",
 							userDN, " and password ", password),

--- a/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/foundation/portal-security/portal-security-ldap-impl/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.portal.security.ldap.internal.DefaultPortalLDAP">
+		<priority value="WARN" />
+	</category>
+
+	<category name="com.liferay.portal.security.ldap.internal.authenticator.LDAPAuth">
+		<priority value="WARN" />
+	</category>
+</log4j:configuration>

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -472,10 +472,6 @@
 		<priority value="ERROR" />
 	</category>
 
-	<category name="com.liferay.portal.security.auth.LDAPAuth">
-		<priority value="WARN" />
-	</category>
-
 	<category name="com.liferay.portal.security.auth.PrincipalThreadLocal">
 		<priority value="ERROR" />
 	</category>
@@ -494,14 +490,6 @@
 
 	<category name="com.liferay.portal.security.lang.PortalSecurityManager">
 		<priority value="INFO" />
-	</category>
-
-	<category name="com.liferay.portal.security.ldap">
-		<priority value="ERROR" />
-	</category>
-
-	<category name="com.liferay.portal.security.ldap.PortalLDAPUtil">
-		<priority value="ERROR" />
 	</category>
 
 	<category name="com.liferay.portal.security.pacl.BasePACLPolicy">


### PR DESCRIPTION
Hi Hugo,

The issue belongs to one improvement issue from user experience. When constructs an initial LDAP context, if it fails, the user hope can see the detailed cause reasons so that the user can check the issue better. 

In this fix, I change the DefaultPortalLDAP log level for warn. For LDAPAuth class, its original log level was warn. And I change related debug info for warn in LDAPAuth class so that the root exception can be printed by default.

For the second commit, I refer to https://dev.liferay.com/fr/develop/tutorials/-/knowledge_base/7-0/adjusting-module-logging.

> Configure Log4j for multiple modules in a [anyModule]/src/main/resources/META-INF/module-log4j.xml file.

You may search module-log4j.xml in liferay-portal project, you will see other files.

Regards,
Hai
