### PR TITLE
[ts] LPS-80557

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
@@ -17,7 +17,6 @@ package com.liferay.portal.servlet.filters.header;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -47,7 +46,7 @@ import javax.servlet.http.HttpSession;
 public class HeaderFilter extends BasePortalFilter {
 
 	protected long getLastModified(HttpServletRequest request) {
-		String value = HttpUtil.getParameter(request.getQueryString(), "t");
+		String value = request.getParameter("t");
 
 		if (Validator.isNull(value)) {
 			return -1;


### PR DESCRIPTION
 request.getQuery() returns a string without leading question mark, but the getParameter() is expecting a question to separate the query part.