### PR TITLE
[TS] LPS-80684 

### DIFF
--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
@@ -124,7 +124,7 @@ public class FacebookConnectAction extends BaseStrutsAction {
 
 		HttpSession session = request.getSession();
 
-		String redirect = ParamUtil.getString(request, "redirect");
+		String redirect = ParamUtil.getString(request, "state");
 
 		redirect = _portal.escapeRedirect(redirect);
 

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
@@ -25,11 +25,10 @@ String facebookAuthRedirectURL = (String)request.getAttribute(FacebookConnectWeb
 String facebookAuthURL = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_AUTH_URL);
 String facebookAppId = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_APP_ID);
 
-facebookAuthRedirectURL = HttpUtil.addParameter(facebookAuthRedirectURL, "redirect", loginRedirectURL);
-
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "client_id", facebookAppId);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "redirect_uri", facebookAuthRedirectURL);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "scope", "email");
+facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "state", loginRedirectURL);
 
 String taglibOpenFacebookConnectLoginWindow = "javascript:var facebookConnectLoginWindow = window.open('" + URLCodec.encodeURL(facebookAuthURL) + "', 'facebook', 'align=center,directories=no,height=560,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no,width=1000'); void(''); facebookConnectLoginWindow.focus();";
 %>

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
@@ -71,11 +71,7 @@ public class FacebookConnectImpl implements FacebookConnect {
 		url = _http.addParameter(
 			url, "redirect_uri", facebookConnectRedirectURL);
 
-		facebookConnectRedirectURL = _http.addParameter(
-			facebookConnectRedirectURL, "redirect", redirect);
-
-		url = _http.addParameter(
-			url, "redirect_uri", facebookConnectRedirectURL);
+		url = _http.addParameter(url, "state", redirect);
 
 		url = _http.addParameter(
 			url, "client_secret", facebookConnectConfiguration.appSecret());


### PR DESCRIPTION
Hi Hugo,

The issue is caused by Facebook changed. Please refer to the below document.
https://developers.facebook.com/blog/post/2017/12/18/strict-uri-matching/

After Facebook enforce "Strict URI Matching" for true, it will require "Parameter "redirect_uri" must exactly match one of "Valid OAuth redirect URIs". Since our redirect_uri includes redirectURL. The facebook will fail connection due to we generate the redirect_uri can't match  "Valid OAuth redirect URIs" which is set in Facebook side. 

The fix refers to 
https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/#logindialog
and some comments on https://developers.facebook.com/blog/post/2017/12/18/strict-uri-matching/

The fix transfters the redirectURL from redirect_uri to the state param which facebook will keep it after back to liferay.

Regards,
Hai