### PR TITLE
[TS] LPS-80684

### DIFF
--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
@@ -125,11 +125,20 @@ public class FacebookConnectAction extends BaseStrutsAction {
 
 		HttpSession session = request.getSession();
 
+		String nonce = (String)session.getAttribute("nonce");
+
 		String state = ParamUtil.getString(request, "state");
 
 		JSONObject stateJSONObject = JSONFactoryUtil.createJSONObject(state);
 
 		String redirect = stateJSONObject.getString("redirect");
+
+		String stateNonce = stateJSONObject.getString("stateNonce");
+
+		if (!stateNonce.equals(nonce)) {
+			throw new PrincipalException.MustBeAuthenticated(
+				_portal.getUserId(request));
+		}
 
 		redirect = _portal.escapeRedirect(redirect);
 

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectAction.java
@@ -16,6 +16,7 @@ package com.liferay.login.authentication.facebook.connect.web.internal.portlet.a
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.facebook.FacebookConnect;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.User;
@@ -124,7 +125,11 @@ public class FacebookConnectAction extends BaseStrutsAction {
 
 		HttpSession session = request.getSession();
 
-		String redirect = ParamUtil.getString(request, "redirect");
+		String state = ParamUtil.getString(request, "state");
+
+		JSONObject stateJSONObject = JSONFactoryUtil.createJSONObject(state);
+
+		String redirect = stateJSONObject.getString("redirect");
 
 		redirect = _portal.escapeRedirect(redirect);
 

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
@@ -25,10 +25,13 @@ String facebookAuthRedirectURL = (String)request.getAttribute(FacebookConnectWeb
 String facebookAuthURL = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_AUTH_URL);
 String facebookAppId = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_APP_ID);
 
-facebookAuthRedirectURL = HttpUtil.addParameter(facebookAuthRedirectURL, "redirect", loginRedirectURL);
+JSONObject stateJSONObject = JSONFactoryUtil.createJSONObject();
+
+stateJSONObject.put("redirect", loginRedirectURL);
 
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "client_id", facebookAppId);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "redirect_uri", facebookAuthRedirectURL);
+facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "state", stateJSONObject.toString());
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "scope", "email");
 
 String taglibOpenFacebookConnectLoginWindow = "javascript:var facebookConnectLoginWindow = window.open('" + URLCodec.encodeURL(facebookAuthURL) + "', 'facebook', 'align=center,directories=no,height=560,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no,width=1000'); void(''); facebookConnectLoginWindow.focus();";

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/facebook.jsp
@@ -25,9 +25,16 @@ String facebookAuthRedirectURL = (String)request.getAttribute(FacebookConnectWeb
 String facebookAuthURL = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_AUTH_URL);
 String facebookAppId = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_APP_ID);
 
+HttpSession portalSession = PortalSessionThreadLocal.getHttpSession();
+
+String nonce = PwdGenerator.getPassword(GetterUtil.getInteger(PropsUtil.get(PropsKeys.AUTH_TOKEN_LENGTH)));
+
+portalSession.setAttribute("nonce", nonce);
+
 JSONObject stateJSONObject = JSONFactoryUtil.createJSONObject();
 
 stateJSONObject.put("redirect", loginRedirectURL);
+stateJSONObject.put("stateNonce", nonce);
 
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "client_id", facebookAppId);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "redirect_uri", facebookAuthRedirectURL);

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -21,6 +21,11 @@
 <%@ page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.servlet.PortalSessionThreadLocal" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
+page import="com.liferay.portal.kernel.util.PropsKeys" %><%@
+page import="com.liferay.portal.kernel.util.PropsUtil" %><%@
+page import="com.liferay.portal.kernel.util.PwdGenerator" %><%@
 page import="com.liferay.portal.kernel.util.URLCodec" %><%@
 page import="com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectWebKeys" %>

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -18,7 +18,9 @@
 
 <%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+<%@ page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
+page import="com.liferay.portal.kernel.json.JSONObject" %><%@
+page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
 page import="com.liferay.portal.kernel.util.URLCodec" %><%@
 page import="com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectWebKeys" %>

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
@@ -68,14 +68,14 @@ public class FacebookConnectImpl implements FacebookConnect {
 		String facebookConnectRedirectURL =
 			facebookConnectConfiguration.oauthRedirectURL();
 
-		url = _http.addParameter(
-			url, "redirect_uri", facebookConnectRedirectURL);
+		JSONObject stateJSONObject = JSONFactoryUtil.createJSONObject();
 
-		facebookConnectRedirectURL = _http.addParameter(
-			facebookConnectRedirectURL, "redirect", redirect);
+		stateJSONObject.put("redirect", redirect);
 
 		url = _http.addParameter(
 			url, "redirect_uri", facebookConnectRedirectURL);
+
+		url = _http.addParameter(url, "state", stateJSONObject.toString());
 
 		url = _http.addParameter(
 			url, "client_secret", facebookConnectConfiguration.appSecret());


### PR DESCRIPTION
Hi Hugo,

The issue is caused by Facebook changed. Please refer to the below document.
https://developers.facebook.com/blog/post/2017/12/18/strict-uri-matching/

After Facebook enforce "Strict URI Matching" for true, it will require "Parameter "redirect_uri" must exactly match one of "Valid OAuth redirect URIs". Since our redirect_uri includes redirectURL. The facebook will fail connection due to we generate the redirect_uri can't match "Valid OAuth redirect URIs" which is set in Facebook side.

Based on SME's guidance, I finish the fix. Please refer to the internal link from https://issues.liferay.com/browse/LPS-80684?focusedCommentId=1329845&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1329845

The official document reference:
https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/#logindialog

> state. A string value created by your app to maintain state between the request and callback. This parameter should be used for preventing Cross-site Request Forgery and will be passed back to you, unchanged, in your redirect URI.

For FacebookConnectImpl.getAccessToken() method, I think we needn't check the crsf at here. Refer to the part "Exchanging Code for an Access Token" from https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/#logindialog

For the param nonce in facebook.jsp, I refer to our crsf generated from https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java#L290-L291 

Thanks,
Hai

