### PR TITLE
[TS] LPS-82422 

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -144,6 +144,7 @@ page import="com.liferay.portal.kernel.service.ServiceContext" %><%@
 page import="com.liferay.portal.kernel.service.TicketLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.UserLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %><%@
 page import="com.liferay.portal.kernel.theme.ThemeDisplay" %><%@
 page import="com.liferay.portal.kernel.upload.LiferayFileItemException" %><%@
 page import="com.liferay.portal.kernel.upload.UploadRequestSizeException" %><%@

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -90,7 +90,14 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 	}
 
 	<c:if test="<%= thread.getRootMessageId() != message.getMessageId() %>">
-		document.getElementById('<portlet:namespace />message_' + <%= message.getMessageId() %>).scrollIntoView(true);
+		var submessageIdNode = document.getElementById('<portlet:namespace />message_' + <%= message.getMessageId() %>);
+
+		if (<%= BrowserSnifferUtil.isIe(request) %>) {
+			window.scrollBy(0, submessageIdNode.offsetTop);
+		}
+		else {
+			submessageIdNode.scrollIntoView(true);
+		}
 	</c:if>
 </aui:script>
 


### PR DESCRIPTION
Hi Hugo,

The issue is that message content area will shift the left if submessage content width exceed message content area when access the specific submessage in IE browser. Please refer to https://issues.liferay.com/secure/attachment/267868/IE11_NOT_work.png

The root issue is that scrollIntoView() method caused the issue in IE. If I remove the function (https://github.com/liferay/liferay-portal/blob/master/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp#L92-L94). The issue won't occur in IE.

Please refer to the known issue reported.

1. https://social.technet.microsoft.com/Forums/ie/en-US/b8458796-8360-4512-b88a-62190f421ef7/issues-with-scrollintoview-javascript-method-in-ie10?forum=ieitprocurrentver
2. https://social.msdn.microsoft.com/Forums/en-US/c4bf1d68-8bd1-47e8-bd31-e2a4be6e6868/scrollintoview-method-causing-issues-in-ie10
3. https://www.npmjs.com/package/ie11-scroll-into-view

The fix reference:
window.scrollBy： https://www.w3schools.com/jsref/prop_win_pagexoffset.asp
offsetTop:         https://www.w3schools.com/jsref/prop_element_offsettop.asp

The purpose also navigate to specific submessage when access the submessage.

Regards,
Hai

