### PR TITLE
LPS-82482 Do not use ResourceBundleUtil with classloader

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-document-library/src/main/java/com/liferay/dynamic/data/mapping/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-document-library/src/main/java/com/liferay/dynamic/data/mapping/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -28,18 +28,16 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -47,6 +45,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pedro Queiroz
@@ -156,7 +157,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 
 		Map<String, String> stringsMap = new HashMap<>();
 
-		ResourceBundle resourceBundle = getResourceBundle(
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
 			ddmFormFieldRenderingContext.getLocale());
 
 		stringsMap.put("select", LanguageUtil.get(resourceBundle, "select"));
@@ -183,18 +184,22 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		}
 	}
 
-	protected ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
+	@Reference(
+		cardinality = ReferenceCardinality.MANDATORY,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(&(bundle.symbolic.name=com.liferay.dynamic.data.mapping.type.document.library)(resource.bundle.base.name=content.Language))"
+	)
+	protected void setResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
 
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(locale);
+		this.resourceBundleLoader = new AggregateResourceBundleLoader(
+			resourceBundleLoader,
+			ResourceBundleLoaderUtil.getPortalResourceBundleLoader());
+	}
 
-		ResourceBundle portletResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			portletResourceBundle, portalResourceBundle);
+	protected void unsetResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
 	}
 
 	@Reference
@@ -205,6 +210,8 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 
 	@Reference
 	protected JSONFactory jsonFactory;
+
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DocumentLibraryDDMFormFieldTemplateContextContributor.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-document-library/src/main/java/com/liferay/dynamic/data/mapping/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-document-library/src/main/java/com/liferay/dynamic/data/mapping/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -28,7 +28,10 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.Html;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.URLCodec;
@@ -181,10 +184,17 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		Class<?> clazz = getClass();
+		ResourceBundleLoader portalResourceBundleLoader =
+			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
 
-		return ResourceBundleUtil.getBundle(
-			"content.Language", locale, clazz.getClassLoader());
+		ResourceBundle portalResourceBundle =
+			portalResourceBundleLoader.loadResourceBundle(locale);
+
+		ResourceBundle portletResourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", locale, getClass());
+
+		return new AggregateResourceBundle(
+			portletResourceBundle, portalResourceBundle);
 	}
 
 	@Reference

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/ControlPanelWorkflowPortlet.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/ControlPanelWorkflowPortlet.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.workflow.web.internal.portlet;
 
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.workflow.constants.WorkflowWebKeys;
 import com.liferay.portal.workflow.web.internal.constants.WorkflowPortletKeys;
 import com.liferay.portal.workflow.web.internal.display.context.WorkflowNavigationDisplayContext;
@@ -86,7 +88,9 @@ public class ControlPanelWorkflowPortlet extends BaseWorkflowPortlet {
 	protected void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
-		this.resourceBundleLoader = resourceBundleLoader;
+		this.resourceBundleLoader = new AggregateResourceBundleLoader(
+			resourceBundleLoader,
+			ResourceBundleLoaderUtil.getPortalResourceBundleLoader());
 	}
 
 	protected ResourceBundleLoader resourceBundleLoader;

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/configuration/icon/DuplicateDefinitionPortletConfigurationIcon.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/configuration/icon/DuplicateDefinitionPortletConfigurationIcon.java
@@ -17,8 +17,10 @@ package com.liferay.portal.workflow.web.internal.portlet.configuration.icon;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.workflow.web.internal.constants.WorkflowPortletKeys;
@@ -93,7 +95,9 @@ public class DuplicateDefinitionPortletConfigurationIcon
 	protected void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
-		_resourceBundleLoader = resourceBundleLoader;
+		_resourceBundleLoader = new AggregateResourceBundleLoader(
+			resourceBundleLoader,
+			ResourceBundleLoaderUtil.getPortalResourceBundleLoader());
 	}
 
 	@Reference

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/configuration/icon/UnpublishDefinitionPortletConfigurationIcon.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/configuration/icon/UnpublishDefinitionPortletConfigurationIcon.java
@@ -17,9 +17,11 @@ package com.liferay.portal.workflow.web.internal.portlet.configuration.icon;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.workflow.web.internal.constants.WorkflowPortletKeys;
@@ -107,7 +109,9 @@ public class UnpublishDefinitionPortletConfigurationIcon
 	protected void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
-		_resourceBundleLoader = resourceBundleLoader;
+		_resourceBundleLoader = new AggregateResourceBundleLoader(
+			resourceBundleLoader,
+			ResourceBundleLoaderUtil.getPortalResourceBundleLoader());
 	}
 
 	@Reference


### PR DESCRIPTION
Hi @hhuijser,
we should not load the language files directly from the classloader and prefer to use the language extender that allows for property extension and replacement. 

I think I have had into account all what we discussed and the binding/unbinding combination is a safe one and also should comply with our performance requirements. I would personally use static binding, since there should be not many updates on the language keys, but we aren't allowing that as far as I remember. 

I did not know how I could test this thoroughly. If you find any problems please let me know so I can help. 

I hope this helps. 