### PR TITLE
Language extender adds portal resources by default

### DIFF
--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
@@ -15,10 +15,12 @@
 package com.liferay.portal.language.extender.internal;
 
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.CacheResourceBundleLoader;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
@@ -109,7 +111,10 @@ public class LanguageExtension implements Extension {
 			}
 			else if (baseName instanceof String) {
 				resourceBundleLoader = processBaseName(
-					bundleWiring.getClassLoader(), (String)baseName);
+					bundleWiring.getClassLoader(), (String)baseName,
+					GetterUtil.getBoolean(
+						attributes.getOrDefault(
+							"exclude.portal.resources", "false")));
 			}
 
 			if (resourceBundleLoader != null) {
@@ -165,10 +170,22 @@ public class LanguageExtension implements Extension {
 	}
 
 	protected ResourceBundleLoader processBaseName(
-		ClassLoader classLoader, String baseName) {
+		ClassLoader classLoader, String baseName,
+		boolean excludePortalResource) {
 
-		return new CacheResourceBundleLoader(
-			ResourceBundleUtil.getResourceBundleLoader(baseName, classLoader));
+		CacheResourceBundleLoader cacheResourceBundleLoader =
+			new CacheResourceBundleLoader(
+				ResourceBundleUtil.getResourceBundleLoader(
+					baseName, classLoader));
+
+		if (excludePortalResource) {
+			return cacheResourceBundleLoader;
+		}
+		else {
+			return new AggregateResourceBundleLoader(
+				cacheResourceBundleLoader,
+				ResourceBundleLoaderUtil.getPortalResourceBundleLoader());
+		}
 	}
 
 	protected void registerResourceBundleLoader(


### PR DESCRIPTION
@hhuijser as we discussed this would make the language extender add the portal resources to every resource bundle as a default. 
Any module that would want to opt out from this should use this capability (for example):

```Provide-Capability:\
   liferay.resource.bundle;\
       bundle.symbolic.name="bundle.symbolic.name";\
       exclude.portal.resources="true";\
       resource.bundle.base.name="content.Language"
```

if no `exclude.portal.resources="true"` is present then the portal resources will be added to the module resources