### PR TITLE
[TS] LPS-82911

### DIFF
--- a/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/portlet/CommentPortlet.java
+++ b/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/portlet/CommentPortlet.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	immediate = true,
 	property = {
+		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.icon=/icons/comment.png",
 		"javax.portlet.display-name=Comments",


### PR DESCRIPTION
Hi Hugo,

Please refer to @ling-alan-huang detailed explanation from https://issues.liferay.com/browse/LPS-82911?focusedCommentId=1391022&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1391022.

For https://github.com/yuhai/liferay-portal/blob/master/definitions/liferay-portlet-app_7_1_0.dtd#L801-L803. At the beginning, I thought the fix is conflict with the document. After check other portlets which can't directly add to page, I find they can be set the property for true. Please refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/portlet/AssetBrowserPortlet.java#L43. This portlet is related with related Assets (when adding one model, for example, adding blog, you can choose other Related Assets (web content, blogs, documents)). When you select Related Assets, the AssetBrowserPortlet will be invoked.

So the fix is good for me.

Thanks,
Hai