### PR TITLE
LPS-83223 

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/controller/test/PortletImportControllerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/controller/test/PortletImportControllerTest.java
@@ -74,8 +74,7 @@ public class PortletImportControllerTest extends BaseExportImportTestCase {
 			group, lastPublishDate, null);
 
 		Assert.assertEquals(
-			PortletKeys.PREFS_OWNER_ID_DEFAULT,
-			portletPreferencesImpl.getOwnerId());
+			group.getGroupId(), portletPreferencesImpl.getOwnerId());
 		Assert.assertEquals(
 			PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
 			portletPreferencesImpl.getOwnerType());

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -740,10 +740,12 @@ public class PortletPreferencesFactoryImpl
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			companyId, portletId);
 
+		boolean uniquePerCompany = false;
 		boolean uniquePerLayout = false;
 		boolean uniquePerGroup = false;
 
 		if (portlet.isPreferencesCompanyWide()) {
+			uniquePerCompany = true;
 			portletId = PortletIdCodec.decodePortletName(portletId);
 		}
 		else {
@@ -775,23 +777,38 @@ public class PortletPreferencesFactoryImpl
 			ownerId = PortletIdCodec.decodeUserId(originalPortletId);
 			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
 		}
-		else if (!uniquePerLayout) {
-			plid = PortletKeys.PREFS_PLID_SHARED;
-
-			if (uniquePerGroup) {
+		else if (uniquePerLayout) {
+			if (plid == 0) {
 				if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
 					ownerId = siteGroupId;
 				}
 				else {
 					ownerId = layoutGroupId;
 				}
+			}
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+		}
+		else if (uniquePerGroup) {
+			plid = PortletKeys.PREFS_PLID_SHARED;
 
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
+			if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
+				ownerId = siteGroupId;
 			}
 			else {
-				ownerId = companyId;
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
+				ownerId = layoutGroupId;
 			}
+
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
+
+		}
+		else if (uniquePerCompany) {
+			plid = PortletKeys.PREFS_PLID_SHARED;
+
+			ownerId = companyId;
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
+		}
+		else {
+			//should be some kind of exception;
 		}
 
 		if (strictMode) {


### PR DESCRIPTION
unqiue per layout portlets that are also not deployed to page will not have a plid, and they will not fall into elseif condition so they will be using ownerId = 0, ownerType = 3, plid = 0 for querying agaisnt DB. Since we use fetchBy_O_O_P_P(ownerId, ownerType, plid, portletId), designed to be able to differentiate prefence entry, as a result querying from diferent sites or even different companies will result in the same entry. Specifically, the calling method getStrictPortletSetup(long companyId, long groupId, String portletId) sets siteGroupId and plid to zero. This change will make sure these kind portlets have per group preferences with ownerType of 3