### PR TITLE
[TS] LPS-83222

### DIFF
--- a/modules/apps/static/portal-target-platform-indexer/portal-target-platform-indexer-impl/src/main/java/com/liferay/portal/target/platform/indexer/internal/TargetPlatformIndexer.java
+++ b/modules/apps/static/portal-target-platform-indexer/portal-target-platform-indexer-impl/src/main/java/com/liferay/portal/target/platform/indexer/internal/TargetPlatformIndexer.java
@@ -20,6 +20,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.resource.CapabilityBuilder;
 
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.target.platform.indexer.Indexer;
 
 import java.io.ByteArrayOutputStream;
@@ -181,7 +182,10 @@ public class TargetPlatformIndexer implements Indexer {
 			return;
 		}
 
-		Path tempJarPath = tempPath.resolve(jarPath.getFileName());
+		String jarPathFileName = String.valueOf(jarPath.getFileName());
+
+		Path tempJarPath = tempPath.resolve(
+			URLCodec.encodeURL(jarPathFileName));
 
 		Files.copy(
 			jarPath, tempJarPath, StandardCopyOption.COPY_ATTRIBUTES,


### PR DESCRIPTION
Hi Hugo,

The root issue is module name includes space character (unencode character), the issue will happen. Please refer to LPS-83222 description.

Actually, in our tool, the module name will be Bundle-SymbolicName + Bundle-Version.jar. For example,
Bundle-Name:Test
SymbolicName: com.liferay
Bundle-Version: 1.0.0
After deploy, the module name is com.liferay-1.0.0.jar

When generate the jar, our tool won't generate the case jar. However, for jar name, we may add space character (the jar may generate by other tools, or rename it). So the module name "module.test -1.0.0.jar" is right.

Please refer to the stack from LPS-83222 description. We may encode the filename to solve the issue. **As far as I see, it won't affect other places. Please refer to the below logic.**

https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java#L342
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGIndexValidator.java#L232
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGIndexValidator.java#L347-L348
->
future.get() will get outputStream from https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-target-platform-indexer/portal-target-platform-indexer-impl/src/main/java/com/liferay/portal/target/platform/indexer/internal/TargetPlatformIndexer.java#L141-L143, and putBytes to https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/BytesURLProtocolSupport.java#L63
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGIndexValidator.java#L240

The final purpose will check Integrity. Please refer to https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGIndexValidator.java#L394
->
https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/BytesURLProtocolSupport.java#L86
->
 https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGIndexValidator.java#L151-L159

If checkIntegrity is true, we won't validate again. 

Thanks,
Hai

