### PR TITLE
LPS-85263 When initialize the bundle, set the title type of workflow as xml rather than string

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.workflow.kaleo.runtime.internal.manager;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
 import com.liferay.portal.kernel.workflow.comparator.WorkflowComparatorFactory;
@@ -136,6 +138,15 @@ public class DefaultPortalKaleoManager
 
 			serviceContext.setCompanyId(companyId);
 
+			Locale defaultLocale = LocaleUtil.getDefault();
+
+			String languageId = LocaleUtil.toLanguageId(defaultLocale);
+
+			String localizedTitle = StringPool.BLANK;
+
+			localizedTitle = LocalizationUtil.updateLocalization(
+				localizedTitle, "Title", definitionName, languageId);
+
 			int kaleoDefinitionsCount =
 				kaleoDefinitionLocalService.getKaleoDefinitionsCount(
 					definitionName, serviceContext);
@@ -165,7 +176,7 @@ public class DefaultPortalKaleoManager
 
 			_workflowDefinitionManager.deployWorkflowDefinition(
 				serviceContext.getCompanyId(), defaultUser.getUserId(),
-				definitionName, definitionName, FileUtil.getBytes(inputStream));
+				localizedTitle, definitionName, FileUtil.getBytes(inputStream));
 		}
 	}
 


### PR DESCRIPTION
Hi @hhuijser 

This issue happens because when deploying default definitions of workflow, the value of title stored in database as String type. But when we add a new workflow, the value of title stored in database as xml type.
My solution is change the type of title from string to xml when initialize the bundle. So these values can keep a same type then they can be compared.

Thanks,
Seiphon