### PR TITLE
[TS] LPS-86545 doAsUserId parameter removed from URL when links to pages belonging to other sites of the portal

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -272,6 +273,11 @@ public class FriendlyURLServlet extends HttpServlet {
 		String actualURL = portal.getActualURL(
 			group.getGroupId(), _private, Portal.PATH_MAIN, friendlyURL, params,
 			requestContext);
+
+		if (actualURL.startsWith(PortalUtil.getPortalURL(request))) {
+			actualURL = StringUtil.removeSubstring(
+				actualURL, PortalUtil.getPortalURL(request));
+		}
 
 		return new Redirect(actualURL);
 	}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -21,6 +21,7 @@ import com.liferay.expando.kernel.exception.ValueDataException;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.layouts.admin.kernel.model.LayoutTypePortletConstants;
 import com.liferay.petra.encryptor.Encryptor;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
@@ -3301,7 +3302,16 @@ public class PortalImpl implements Portal {
 		}
 
 		if (layout.isTypeURL()) {
-			return getLayoutActualURL(layout);
+			String portalURL = getPortalURL(layout, themeDisplay);
+
+			String url = layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.URL);
+
+			if (!url.startsWith(StringPool.SLASH) &&
+				!url.startsWith(portalURL)) {
+
+				return getLayoutActualURL(layout);
+			}
 		}
 
 		String layoutFriendlyURL = getLayoutFriendlyURL(layout, themeDisplay);


### PR DESCRIPTION
Hi Hugo,

My second comment is a fix to change the action from _redirect_ to _forward_ If a URL starts with portalURL like http://localhost:8008/web/guest, so that we can preserve the doAsUserId in request when we click it.

Please have a look at this portion of code:
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java#L149-L167


Thanks,
Alan
