### PR TITLE
[TS] LPS-87113 Table 'Audit_AuditEvent' already exists error is reported during the upgrade process(6.2->7.1)

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/bnd.bnd
@@ -1,3 +1,4 @@
+Bundle-Activator: com.liferay.portal.security.audit.storage.internal.activator.AuditStorageServiceBundleActivator
 Bundle-Name: Liferay Portal Security Audit Storage Service
 Bundle-SymbolicName: com.liferay.portal.security.audit.storage.service
 Bundle-Version: 4.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/build.gradle
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/build.gradle
@@ -6,6 +6,7 @@ buildService {
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-api")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-storage-api")
 	compileOnly project(":apps:portal:portal-spring-extender-api")

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/activator/AuditStorageServiceBundleActivator.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/activator/AuditStorageServiceBundleActivator.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.audit.storage.internal.activator;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.upgrade.release.BaseUpgradeServiceModuleRelease;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Alan Huang
+ */
+public class AuditStorageServiceBundleActivator implements BundleActivator {
+
+	@Override
+	public void start(BundleContext bundleContext) throws Exception {
+		Filter filter = bundleContext.createFilter(
+			StringBundler.concat(
+				"(&(objectClass=", ModuleServiceLifecycle.class.getName() + ")",
+				ModuleServiceLifecycle.DATABASE_INITIALIZED + ")"));
+
+		_serviceTracker = new ServiceTracker<Object, Object>(
+			bundleContext, filter, null) {
+
+			@Override
+			public Object addingService(ServiceReference<Object> reference) {
+				try {
+					BaseUpgradeServiceModuleRelease
+						upgradeServiceModuleRelease =
+							new BaseUpgradeServiceModuleRelease() {
+
+								@Override
+								protected String getNamespace() {
+									return "Audit";
+								}
+
+								@Override
+								protected String getNewBundleSymbolicName() {
+									return "com.liferay.portal.security.audit.storage.service";
+								}
+
+								@Override
+								protected String getOldBundleSymbolicName() {
+									return "audit-portle";
+								}
+
+							};
+
+					upgradeServiceModuleRelease.upgrade();
+
+					return null;
+				}
+				catch (UpgradeException ue) {
+					throw new RuntimeException(ue);
+				}
+			}
+
+		};
+
+		_serviceTracker.open();
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		_serviceTracker.close();
+	}
+
+	private ServiceTracker<Object, Object> _serviceTracker;
+
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/upgrade/AuditStorageServiceUpgrade.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/upgrade/AuditStorageServiceUpgrade.java
@@ -15,9 +15,7 @@
 package com.liferay.portal.security.audit.storage.internal.upgrade;
 
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeServiceModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -29,34 +27,6 @@ public class AuditStorageServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		try {
-			BaseUpgradeServiceModuleRelease upgradeServiceModuleRelease =
-				new BaseUpgradeServiceModuleRelease() {
-
-					@Override
-					protected String getNamespace() {
-						return "Audit";
-					}
-
-					@Override
-					protected String getNewBundleSymbolicName() {
-						return
-							"com.liferay.portal.security.audit.storage.service";
-					}
-
-					@Override
-					protected String getOldBundleSymbolicName() {
-						return "audit-portlet";
-					}
-
-				};
-
-			upgradeServiceModuleRelease.upgrade();
-		}
-		catch (UpgradeException ue) {
-			throw new RuntimeException(ue);
-		}
-
 		registry.register(
 			"com.liferay.portal.security.audit.storage.service", "0.0.1",
 			"1.0.0", new DummyUpgradeStep());

--- a/modules/apps/portal-security-audit/source-formatter.properties
+++ b/modules/apps/portal-security-audit/source-formatter.properties
@@ -1,0 +1,9 @@
+##
+## Exclusions
+##
+## See https://github.com/liferay/liferay-portal/blob/master/source-formatter.properties
+## for available properties.
+##
+
+    line.length.excludes=\
+        modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/activator/AuditStorageServiceBundleActivator.java@57


### PR DESCRIPTION
Hi Hugo,

https://issues.liferay.com/browse/LPS-87113

The fix is the same as the fix on LPS-76193: https://github.com/brianchandotcom/liferay-portal/pull/53376

Thanks,
Alan