### PR TITLE
LPS-84119 Add BundleActivator check

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BNDBundleInformationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BNDBundleInformationCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.checks;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.checks.util.BNDSourceUtil;
 
@@ -36,6 +37,8 @@ public class BNDBundleInformationCheck extends BaseFileCheck {
 			!absolutePath.contains("/testIntegration/") &&
 			!absolutePath.contains("/third-party/")) {
 
+			_checkBundleActivator(fileName, content);
+
 			_checkBundleName(fileName, absolutePath, content);
 
 			String bundleVersion = BNDSourceUtil.getDefinitionValue(
@@ -49,6 +52,49 @@ public class BNDBundleInformationCheck extends BaseFileCheck {
 		}
 
 		return content;
+	}
+
+	private void _checkBundleActivator(String fileName, String content) {
+		String bundleActivator = BNDSourceUtil.getDefinitionValue(
+			content, "Bundle-Activator");
+
+		if (bundleActivator == null) {
+			return;
+		}
+
+		if (!bundleActivator.endsWith("BundleActivator")) {
+			addMessage(
+				fileName,
+				"Incorrect Bundle-Activator, it should end with " +
+					"'BundleActivator'");
+
+			return;
+		}
+
+		int startPos = bundleActivator.lastIndexOf(StringPool.PERIOD);
+		int endPos = bundleActivator.lastIndexOf("BundleActivator");
+
+		String strippedBundleActivator = bundleActivator.substring(
+			startPos + 1, endPos);
+
+		String bundleSymbolicName = BNDSourceUtil.getDefinitionValue(
+			content, "Bundle-SymbolicName");
+
+		if ((strippedBundleActivator != null) && (bundleSymbolicName != null)) {
+			String strippedBundleSymbolicName = StringUtil.replace(
+				bundleSymbolicName, CharPool.PERIOD, StringPool.BLANK);
+
+			if (StringUtil.endsWith(
+					strippedBundleSymbolicName, strippedBundleActivator)) {
+
+				return;
+			}
+		}
+
+		addMessage(
+			fileName,
+			"Incorrect Bundle-Activator, it should match " +
+				"'Bundle-SymbolicName'");
 	}
 
 	private void _checkBundleName(

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/BNDSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/BNDSourceProcessorTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter;
+
+import org.junit.Test;
+
+/**
+ * @author Alan Huang
+ */
+public class BNDSourceProcessorTest extends BaseSourceProcessorTestCase {
+
+	@Test
+	public void testIncorrectBundleActivator() throws Exception {
+		test(
+			"IncorrectBundleActivator1.testbnd",
+			"Incorrect Bundle-Activator, it should match " +
+				"'Bundle-SymbolicName'");
+
+		test(
+			"IncorrectBundleActivator2.testbnd",
+			"Incorrect Bundle-Activator, it should end with 'BundleActivator'");
+
+		test(
+			"IncorrectBundleActivator3.testbnd",
+			"Incorrect Bundle-Activator, it should end with 'BundleActivator'");
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator1.testbnd
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator1.testbnd
@@ -1,0 +1,4 @@
+Bundle-Activator: com.liferay.portal.configuration.persistence.internal.activator.ConfigurationPersistenceBundleActivator
+Bundle-Name: Liferay Portal Configuration Persistence Implementation
+Bundle-SymbolicName: com.liferay.portal.configuration.persistence.impl
+Bundle-Version: 2.0.0

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator2.testbnd
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator2.testbnd
@@ -1,0 +1,4 @@
+Bundle-Activator: com.liferay.portal.social.activity.extender.internal.SocialActivityExtender
+Bundle-Name: Liferay Portal Social Activity Extender
+Bundle-SymbolicName: com.liferay.portal.social.activity.extender
+Bundle-Version: 2.0.0

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator3.testbnd
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectBundleActivator3.testbnd
@@ -1,0 +1,10 @@
+Bundle-Activator: com.liferay.frontend.editor.taglib.internal.activator.EditorRendererBundleActivator
+Bundle-Name: Liferay Frontend Editor Taglib
+Bundle-SymbolicName: com.liferay.frontend.editor.taglib
+Bundle-Version: 2.0.0
+Provide-Capability:\
+	osgi.extender;\
+		osgi.extender="jsp.taglib";\
+		uri="http://liferay.com/tld/editor";\
+		version:Version="${Bundle-Version}"
+Web-ContextPath: /frontend-editor-taglib


### PR DESCRIPTION
Hi @hhuijser,

There is something wrong in this pull.
I tested it in _SFDebug_ project, it works ok.

But if I test in portal, it failed.
It seems that the test didn't call _BNDBundleInformationCheck_. 
Could you please have a look at it?
```
com.liferay.source.formatter.BNDSourceProcessorTest > testIncorrectBundleActivator STARTED

com.liferay.source.formatter.BNDSourceProcessorTest > testIncorrectBundleActivator FAILED
    java.lang.AssertionError: [] expected:<1> but was:<0>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at com.liferay.source.formatter.BaseSourceProcessorTestCase.test(BaseSourceProcessorTestCase.java:158)
        at com.liferay.source.formatter.BaseSourceProcessorTestCase.test(BaseSourceProcessorTestCase.java:101)
        at com.liferay.source.formatter.BaseSourceProcessorTestCase.test(BaseSourceProcessorTestCase.java:86)
        at com.liferay.source.formatter.BNDSourceProcessorTest.testIncorrectBundleActivator(BNDSourceProcessorTest.java:26)

```
It seems that it relates these code: SourceChecksUtil.java
```
private static List<SourceCheck> _getSourceChecks(
...
...
if ((!portalSource && !subrepository &&
  sourceCheck.isPortalCheck()) ||
  (!includeModuleChecks && sourceCheck.isModulesCheck())) {

    continue;
  }

```
In _SFDebug_ project, it doesn't go into if.
In protal test, it goes into if, and go _continnue_

Thanks.

