### PR TITLE
LPS-90380 Create SourceFormatter Task to enforce liferay-npm-scripts usage

### DIFF
--- a/modules/sdk/source-formatter-suppressions.xml
+++ b/modules/sdk/source-formatter-suppressions.xml
@@ -28,6 +28,7 @@
 		<suppress checks="JavaXMLSecurityCheck" files="modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/util/XMLUtil\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/internal/util/XMLUtil\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="modules/sdk/gradle-plugins-tlddoc-builder/src/main/java/com/liferay/gradle/plugins/tlddoc/builder/internal/util/TLDUtil\.java" />
+		<suppress checks="JSONPackageUsageCheck" files="modules/sdk/project-templates/.*" />
 		<suppress checks="JSONValidationCheck" files="modules/sdk/project-templates/.*" />
 		<suppress checks="XMLBuildFileCheck" files="modules/sdk/gradle-plugins-workspace/src/gradleTest/distBundleZip/plugins-sdk/layouttpl/qux-layouttpl/build.xml" />
 	</source-check>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageUsageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageUsageCheck.java
@@ -14,6 +14,7 @@
 
 package com.liferay.source.formatter.checks;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.HashMap;
@@ -79,7 +80,7 @@ public class JSONPackageUsageCheck extends BaseFileCheck {
 						scriptsDependenciesJSONObject.getString(
 							packageEnforceScript);
 
-					if (!scriptValue.startsWith(packageName)) {
+					if (!scriptValue.startsWith(packageName + CharPool.SPACE)) {
 						addMessage(fileName, message);
 					}
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageUsageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageUsageCheck.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checks;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * @author Alan Huang
+ */
+public class JSONPackageUsageCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		if (!absolutePath.endsWith("/package.json")) {
+			return content;
+		}
+
+		try {
+			JSONObject jsonObject = new JSONObject(content);
+
+			if (jsonObject.isNull("devDependencies")) {
+				return content;
+			}
+
+			JSONObject devDependenciesJSONObject = jsonObject.getJSONObject(
+				"devDependencies");
+
+			for (String packageName : _DEV_DEPENDENCIES_PACKAGE_NAMES) {
+				if (devDependenciesJSONObject.isNull(packageName)) {
+					continue;
+				}
+
+				String[] packageEnforceScripts = _packageEnforceScriptsMap.get(
+					packageName);
+
+				for (String packageEnforceScript : packageEnforceScripts) {
+					String message = StringBundler.concat(
+						"For Using '" + packageName + "', '",
+						packageEnforceScript, "' should be enforced");
+
+					if (jsonObject.isNull("scripts")) {
+						addMessage(fileName, message);
+
+						continue;
+					}
+
+					JSONObject scriptsDependenciesJSONObject =
+						jsonObject.getJSONObject("scripts");
+
+					if (scriptsDependenciesJSONObject.isNull(
+							packageEnforceScript)) {
+
+						addMessage(fileName, message);
+
+						continue;
+					}
+
+					String scriptValue =
+						scriptsDependenciesJSONObject.getString(
+							packageEnforceScript);
+
+					if (!scriptValue.startsWith(packageName)) {
+						addMessage(fileName, message);
+					}
+				}
+			}
+		}
+		catch (JSONException jsone) {
+			addMessage(fileName, jsone.getMessage());
+		}
+
+		return content;
+	}
+
+	private static final String[] _DEV_DEPENDENCIES_PACKAGE_NAMES = {
+		"liferay-npm-scripts"
+	};
+
+	private static final Map<String, String[]> _packageEnforceScriptsMap =
+		new HashMap<String, String[]>() {
+			{
+				put("liferay-npm-scripts", new String[] {"csf", "format"});
+			}
+		};
+
+}

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -300,6 +300,9 @@
 		<check name="JSONLineBreakCheck">
 			<property name="enabled" value="false" />
 		</check>
+		<check name="JSONPackageUsageCheck">
+			<property name="enabled" value="false" />
+		</check>
 		<check name="JSONPropertyOrderCheck" />
 		<check name="JSONValidationCheck" />
 		<check name="JSONWhitespaceCheck">

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSONSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSONSourceProcessorTest.java
@@ -33,4 +33,34 @@ public class JSONSourceProcessorTest extends BaseSourceProcessorTestCase {
 			new Integer[] {4, 5});
 	}
 
+	@Test
+	public void testJSONPackageUsageCheck() throws Exception {
+		test(
+			"JSONPackageUsageCheck1/package.testjson",
+			new String[] {
+				"For Using 'liferay-npm-scripts', 'csf' should be enforced",
+				"For Using 'liferay-npm-scripts', 'format' should be enforced"
+			});
+
+		test(
+			"JSONPackageUsageCheck2/package.testjson",
+			new String[] {
+				"For Using 'liferay-npm-scripts', 'csf' should be enforced",
+				"For Using 'liferay-npm-scripts', 'format' should be enforced"
+			});
+
+		test(
+			"JSONPackageUsageCheck3/package.testjson",
+			new String[] {
+				"For Using 'liferay-npm-scripts', 'csf' should be enforced",
+				"For Using 'liferay-npm-scripts', 'format' should be enforced"
+			});
+
+		test(
+			"JSONPackageUsageCheck4/package.testjson",
+			new String[] {
+				"For Using 'liferay-npm-scripts', 'format' should be enforced"
+			});
+	}
+
 }

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck1/package.testjson
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck1/package.testjson
@@ -1,0 +1,10 @@
+{
+	"dependencies": {
+		"metal-tooltip": "^2.0.3"
+	},
+	"devDependencies": {
+		"liferay-npm-scripts": "1.2.0"
+	},
+	"name": "adaptive-media-web",
+	"version": "3.0.0"
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck2/package.testjson
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck2/package.testjson
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"metal-tooltip": "^2.0.3"
+	},
+	"devDependencies": {
+		"liferay-npm-scripts": "1.2.0"
+	},
+	"name": "adaptive-media-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build --soy --bundler",
+	},
+	"version": "3.0.0"
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck3/package.testjson
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck3/package.testjson
@@ -1,0 +1,15 @@
+{
+	"dependencies": {
+		"metal-tooltip": "^2.0.3"
+	},
+	"devDependencies": {
+		"liferay-npm-scripts": "1.2.0"
+	},
+	"name": "adaptive-media-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build --soy --bundler",
+		"csf": "liferay-npm-scripts-incorrect lint",
+		"format": "liferay-npm-scripts-incorrect format"
+	},
+	"version": "3.0.0"
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck4/package.testjson
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/JSONPackageUsageCheck4/package.testjson
@@ -1,0 +1,14 @@
+{
+	"dependencies": {
+		"metal-tooltip": "^2.0.3"
+	},
+	"devDependencies": {
+		"liferay-npm-scripts": "1.2.0"
+	},
+	"name": "adaptive-media-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build --soy --bundler",
+		"csf": "liferay-npm-scripts lint"
+	},
+	"version": "3.0.0"
+}

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -191,5 +191,6 @@
 		<suppress checks="JSONDeprecatedPackagesCheck" files="modules/apps/portal-search/portal-search-web/package\.json" />
 		<suppress checks="JSONDeprecatedPackagesCheck" files="modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/package\.json" />
 		<suppress checks="JSONDeprecatedPackagesCheck" files="modules/sdk/project-templates/project-templates-soy-portlet/src/main/resources/archetype-resources/package\.json" />
+		<suppress checks="JSONPackageUsageCheck" files="modules/apps/hello-soy/hello-soy-web/package\.json" />
 	</source-check>
 </suppressions>

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -352,6 +352,8 @@
 
     source.check.json.line.break.check.enabled=true
 
+    source.check.json.package.usage.check.enabled=true
+
     source.check.properties.build.include.dirs.check.enabled=true
 
     source.check.properties.language.keys.check.allowedLanguageKeys=\


### PR DESCRIPTION
@hhuijser,

I added suppression here: https://github.com/hhuijser/liferay-portal/pull/3472/commits/f41f5bd7ea8737d8612aa82f3cf69af876455b2c#diff-573f0f9e8e7c40f70ab0f5695268e4e2R31

because some of json files will complain when `new JSONObject(content)`:
https://github.com/liferay/liferay-portal/blob/master/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/package.json#L19