### PR TITLE
LPS-84119 Preserve empty lines because allowLeadingSpaces is true for YMLWhitespaceCheck

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -3,6 +3,9 @@ components:
         DataDefinition:
             description: https://www.schema.org/DataDefinition
             properties:
+                contentSpaceId:
+                    format: int64
+                    type: integer
                 dataDefinitionFields:
                     items:
                         $ref: '#/components/schemas/DataDefinitionField'
@@ -17,9 +20,6 @@ components:
                     items:
                         $ref: '#/components/schemas/LocalizedValue'
                     type: array
-                contentSpaceId:
-                    format: int64
-                    type: integer
                 id:
                     format: int64
                     type: integer
@@ -65,13 +65,13 @@ components:
                 dataDefinitionId:
                     format: int64
                     type: integer
-                id:
-                    format: int64
-                    type: integer
                 description:
                     items:
                         $ref: '#/components/schemas/LocalizedValue'
                     type: array
+                id:
+                    format: int64
+                    type: integer
                 name:
                     items:
                         $ref: '#/components/schemas/LocalizedValue'

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/util/YMLSourceUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/util/YMLSourceUtil.java
@@ -36,7 +36,13 @@ public class YMLSourceUtil {
 		StringBundler sb = new StringBundler();
 
 		for (String line : lines) {
-			if (Validator.isNull(line) || !line.startsWith(indent)) {
+			if (Validator.isNull(line)) {
+				sb.append("\n");
+
+				continue;
+			}
+
+			if (!line.startsWith(indent)) {
 				continue;
 			}
 


### PR DESCRIPTION
@hhuijser,
See: https://github.com/liferay/liferay-portal/commit/ce517504a17b6d78b97d68a5413bdc69e7366ab7#diff-f98d937a110f0972054d9ea8296620a7R79

The empty line is added, and `allowLeadingSpaces` is true for YMLWhitespaceCheck.
so the related content block  is not replaced with newContent.

I had a look at *.yml, I think `allowLeadingSpaces` was set to true only for *.yml, but I am thinking we shouldn't apply this for *.yaml, I mean we should remove the empty lines for *.yaml.