### PR TITLE
LPS-84119 Fix regex, don't match the file path if the directory contains dot

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -96,7 +96,7 @@ public class SourceFormatter {
 				ExcludeSyntax.REGEX,
 				"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),
 			new ExcludeSyntaxPattern(
-				ExcludeSyntax.REGEX, ".*/\\w+\\..*\\.properties")
+				ExcludeSyntax.REGEX, ".*/\\w+\\.\\w+\\.properties")
 		};
 
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi @hhuijser,

See this issue here: https://github.com/hhuijser/liferay-portal-ee/pull/2900#issuecomment-501201647

I analysed `ExcludeSyntaxPattern(ExcludeSyntax.REGEX, ".*/\\w+\\..*\\.properties")`, I think it want to exclude the file name which contains **two DOTs**, like `app.server.properties` or `portal-legacy-4.4.properties` 