### PR TITLE
LPS-84119 Fix regex, more accurately match *.*.properties, avoid to match the file path which the directory contains dot

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -96,7 +96,7 @@ public class SourceFormatter {
 				ExcludeSyntax.REGEX,
 				"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),
 			new ExcludeSyntaxPattern(
-				ExcludeSyntax.REGEX, ".*/\\w+\\..*\\.properties")
+				ExcludeSyntax.REGEX, ".*/\\w+\\.\\w+\\.properties")
 		};
 
 	public static void main(String[] args) throws Exception {

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/com.liferay.oauth2.provider.scope.sample.qa.jar/content/Language.properties
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/com.liferay.oauth2.provider.scope.sample.qa.jar/content/Language.properties
@@ -1,3 +1,3 @@
+oauth2.application.description.liferay-oauth2-scope-sample-qa-app=Sample QA app
 oauth2.scope.example-scope-1=Example scope 1
 oauth2.scope.example-scope-2=Example scope 2
-oauth2.application.description.liferay-oauth2-scope-sample-qa-app=Sample QA app


### PR DESCRIPTION
Hi @hhuijser,

See the issue: https://github.com/hhuijser/liferay-portal-ee/pull/2900#issuecomment-501201647

I analysed `ExcludeSyntaxPattern(ExcludeSyntax.REGEX, ".*/\\w+\\..*\\.properties")`, I think it want to exclude the file name which contains two DOTs, like `app.server.properties` or` portal-legacy-4.4.properties`

My second commit `Auto SF` doesn't break SF rule here: https://github.com/liferay/liferay-portal/commit/4c0d4e54675f38dc17278bd8da58733ef59d9f3f