### PR TITLE
LPS-84119 Fix regex, match the property file which the filename contains two or more dots

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -96,7 +96,7 @@ public class SourceFormatter {
 				ExcludeSyntax.REGEX,
 				"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),
 			new ExcludeSyntaxPattern(
-				ExcludeSyntax.REGEX, ".*/\\w+\\.\\w+\\.properties")
+				ExcludeSyntax.REGEX, ".*/(\\w+\\.){2,}properties")
 		};
 
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
**Issues**: https://testray.liferay.com/reports/production/logs/test-1-1/1561014164034/test-portal-acceptance-upstream(7.2.x)/316/source-format-jdk8/0/jenkins-console.txt.gz

```
     [java] java.lang.Exception: Found 2 formatting issues:
     [java] 1: ./test.case.method.names.properties expected:<.../a>
     [java] KEEP_BUNDLE=true[]> but was:<.../a>
     [java] KEEP_BUNDLE=true[
     [java] ]>
     [java] 2: ./test.cloud-10-0-19-122.lax.liferay.com.properties expected:<[                ##
     [java] ## Blade Sample
     [java] ##

```
I didn't find those two property files on 7.2.x.

My previous fix https://github.com/hhuijser/liferay-portal/pull/3590/files caused this SF issue.
I changed the regex to match the property file which the filename contains two or more dots. 