### PR TITLE
LPS-84119 Enforce compatible minor version for frontend-js-web

### DIFF
--- a/modules/source-formatter.properties
+++ b/modules/source-formatter.properties
@@ -30,3 +30,6 @@
     source.check.gradle.dependency.artifacts.check.renameArtifacts=\
         org.apache.felix:org.apache.felix.configadmin->com.liferay:org.apache.felix.configadmin,\
         org.osgi:org.osgi.core->org.osgi:osgi.core
+
+    source.check.json.package.json.check.enforceCompatibleVersionArtifacts=\
+        frontend-js-web:^

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageJSONCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSONPackageJSONCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.checks;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.source.formatter.util.FileUtil;
@@ -23,6 +24,7 @@ import java.io.IOException;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONObject;
@@ -51,7 +53,8 @@ public class JSONPackageJSONCheck extends BaseFileCheck {
 
 		JSONObject jsonObject = new JSONObject(content);
 
-		content = _fixDependencyVersions(absolutePath, content, jsonObject);
+		content = _fixDependencyVersions(
+			fileName, absolutePath, content, jsonObject);
 
 		String dirName = absolutePath.substring(0, absolutePath.length() - 12);
 
@@ -123,7 +126,8 @@ public class JSONPackageJSONCheck extends BaseFileCheck {
 	}
 
 	private String _fixDependencyVersions(
-			String absolutePath, String content, JSONObject jsonObject)
+			String fileName, String absolutePath, String content,
+			JSONObject jsonObject)
 		throws IOException {
 
 		if (jsonObject.isNull("dependencies")) {
@@ -155,6 +159,24 @@ public class JSONPackageJSONCheck extends BaseFileCheck {
 						"\"", dependencyName, "\": \"", actualVersion, "\""),
 					StringBundler.concat(
 						"\"", dependencyName, "\": \"", expectedVersion, "\""));
+			}
+
+			List<String> enforceCompatibleVersionArtifacts = getAttributeValues(
+				_ENFORCE_COMPATIBLE_VERSION_ARTIFACTS_KEY, absolutePath);
+
+			for (String artifact : enforceCompatibleVersionArtifacts) {
+				String[] artifactParts = StringUtil.split(
+					artifact, StringPool.COLON);
+
+				if (dependencyName.equals(artifactParts[0]) &&
+					!actualVersion.startsWith(artifactParts[1])) {
+
+					addMessage(
+						fileName,
+						StringBundler.concat(
+							"Version for '", dependencyName,
+							"' should start with '", artifactParts[1], "'"));
+				}
 			}
 		}
 
@@ -219,6 +241,9 @@ public class JSONPackageJSONCheck extends BaseFileCheck {
 
 		return _expectedDependencyVersionsMap;
 	}
+
+	private static final String _ENFORCE_COMPATIBLE_VERSION_ARTIFACTS_KEY =
+		"enforceCompatibleVersionArtifacts";
 
 	private Map<String, String> _expectedDependencyVersionsMap;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterCheckUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterCheckUtil.java
@@ -283,7 +283,10 @@ public class SourceFormatterCheckUtil {
 					cacheValues = false;
 				}
 
-				if (!absolutePath.startsWith(fileLocation)) {
+				if (!absolutePath.startsWith(fileLocation) &&
+					!absolutePath.contains(
+						SourceFormatterUtil.SOURCE_FORMATTER_TEST_PATH)) {
+
 					continue;
 				}
 			}

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSONSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSONSourceProcessorTest.java
@@ -61,6 +61,13 @@ public class JSONSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testJSONDependencyVersions() throws Exception {
+		test(
+			"modules/apps/SFTest/package.testjson",
+			"Version for 'frontend-js-web' should start with '^'");
+	}
+
+	@Test
 	public void testJSONDeprecatedPackagesCheck() throws Exception {
 		test(
 			"JSONDeprecatedPackages/package.testjson",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/modules/apps/SFTest/package.testjson
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/modules/apps/SFTest/package.testjson
@@ -1,0 +1,17 @@
+{
+	"dependencies": {
+		"frontend-js-web": "4.0.0",
+		"metal": "2.16.8",
+		"metal-component": "2.16.8",
+		"metal-dom": "2.16.8",
+		"metal-events": "2.16.8",
+		"metal-soy": "2.16.8"
+	},
+	"name": "adaptive-media-web",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "4.0.0"
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -272,6 +272,8 @@
         com.liferay.xstream.configurator.XStreamConfiguratorRegistryUtil,\
         org.eclipse.core.runtime.FileLocator
 
+    source.check.json.package.json.check.enforceCompatibleVersionArtifacts=
+
     source.check.properties.language.keys.check.allowedLanguageKeys=\
         a-fragment-collection-with-the-key-x-already-exists,\
         a-fragment-entry-with-the-key-x-already-exists,\


### PR DESCRIPTION
Hi @hhuijser,

I enforce this rule by message instead of auto change, because the version `4.0.0` may start with `^`, `~`, `>`, ..., so we cannot just add `^` behind `4.0.0`.

Output message:
`Version for 'frontend-js-web' should start with '^': /home/alan/liferay_code/master/liferay-portal/modules/apps/adaptive-media/adaptive-media-web/package.json (SourceCheck:JSONPackageJSONCheck)`