### PR TITLE
LPS-89415 Sort parameters

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -345,6 +345,12 @@ paths:
         get:
             operationId: getCollectionEntriesPage
             parameters:
+                - in: path
+                  name: collectionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
                 - explode: true
                   in: query
                   name: changeTypesFilter
@@ -363,6 +369,13 @@ paths:
                           type: string
                       type: array
                   style: form
+                - in: query
+                  name: collision
+                  required: false
+                  schema:
+                      default: false
+                      type: boolean
+                  style: form
                 - explode: true
                   in: query
                   name: groupIdsFilter
@@ -372,6 +385,12 @@ paths:
                           type: string
                       type: array
                   style: form
+                - in: query
+                  name: status
+                  required: false
+                  schema:
+                      default: 2
+                      type: integer
                 - explode: true
                   in: query
                   name: userIdsFilter
@@ -380,19 +399,6 @@ paths:
                       items:
                           type: string
                       type: array
-                  style: form
-                - in: path
-                  name: collectionId
-                  required: true
-                  schema:
-                      format: int64
-                      type: integer
-                - in: query
-                  name: collision
-                  required: false
-                  schema:
-                      default: false
-                      type: boolean
                   style: form
                 - in: query
                   name: page
@@ -409,12 +415,6 @@ paths:
                   required: false
                   schema:
                       type: string
-                - in: query
-                  name: status
-                  required: false
-                  schema:
-                      default: 2
-                      type: integer
             responses:
                 200:
                     content:


### PR DESCRIPTION
Hi Hugo, the `YMLDefinitionOrderCheck` is formatting the file in this pull incorrectly.

Can the logic be updated to follow the rules below:

```
1. path (by order of appearance, left to right)
2. query (alphbetized)
3. special query (filter, pagination, sort)
```

Please cc me on the fix that's sent to Brian. There's a commit in the `portal-tools-rest-builder` that should be reverted after SF is updated