### PR TITLE
LPS-84119 Add MissingGenericCheck

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ChildSitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ChildSitesItemSelectorViewDisplayContext.java
@@ -86,7 +86,7 @@ public class ChildSitesItemSelectorViewDisplayContext
 	private List<Group> _filterGroups(
 		List<Group> groups, PermissionChecker permissionChecker) {
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (permissionChecker.isGroupAdmin(group.getGroupId())) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/LayoutScopesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/LayoutScopesItemSelectorViewDisplayContext.java
@@ -92,7 +92,7 @@ public class LayoutScopesItemSelectorViewDisplayContext
 			return groups;
 		}
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (!group.isLayout()) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ParentSitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ParentSitesItemSelectorViewDisplayContext.java
@@ -73,7 +73,7 @@ public class ParentSitesItemSelectorViewDisplayContext
 	}
 
 	private List<Group> _filterParentSitesGroups(List<Group> groups) {
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (SitesUtil.isContentSharingWithChildrenEnabled(group)) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/SitesThatIAdministerItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/SitesThatIAdministerItemSelectorViewDisplayContext.java
@@ -86,7 +86,7 @@ public class SitesThatIAdministerItemSelectorViewDisplayContext
 	private List<Group> _filterGroups(
 		List<Group> groups, PermissionChecker permissionChecker) {
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (permissionChecker.isGroupAdmin(group.getGroupId())) {

--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
@@ -119,7 +119,7 @@ public class AssetTagsDisplayContext {
 		long[] mergeTagIds = StringUtil.split(
 			ParamUtil.getString(_renderRequest, "mergeTagIds"), 0L);
 
-		List<String> mergeTagNames = new ArrayList();
+		List<String> mergeTagNames = new ArrayList<>();
 
 		for (long mergeTagId : mergeTagIds) {
 			AssetTag tag = AssetTagLocalServiceUtil.fetchAssetTag(mergeTagId);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ValidationFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ValidationFieldType.java
@@ -64,7 +64,7 @@ public class ValidationFieldType extends BaseFieldType {
 	private Map<String, String> _getValue(
 		SPIDataDefinitionField spiDataDefinitionField) {
 
-		Map<String, String> value = new HashMap();
+		Map<String, String> value = new HashMap<>();
 
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/rest/DDMRESTDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/rest/DDMRESTDataProviderTest.java
@@ -598,7 +598,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			ddmDataProviderResponse.getOutputOptional(
 				"list output", List.class);
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("5", "Rio de Janeiro"));
 				add(new KeyValuePair("6", "São Paulo"));
@@ -664,7 +664,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			ddmDataProviderResponse.getOutputOptional(
 				"list output", List.class);
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("1", "Pernambuco"));
 				add(new KeyValuePair("2", "Paraiba"));
@@ -822,7 +822,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			name.capture(), value.capture()
 		);
 
-		List<String> names = new ArrayList() {
+		List<String> names = new ArrayList<>() {
 			{
 				add("country");
 				add("start");
@@ -832,7 +832,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 
 		Assert.assertEquals(names, name.getAllValues());
 
-		List<String> values = new ArrayList() {
+		List<String> values = new ArrayList<>() {
 			{
 				add("brazil");
 				add("1");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstanceOutputParametersDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstanceOutputParametersDataProviderTest.java
@@ -189,7 +189,7 @@ public class DDMDataProviderInstanceOutputParametersDataProviderTest
 
 		Assert.assertTrue(outputParameterNamesOptional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("Country Id", "Country Id"));
 				add(new KeyValuePair("Country Name", "Country Name"));
@@ -306,7 +306,7 @@ public class DDMDataProviderInstanceOutputParametersDataProviderTest
 
 		Assert.assertTrue(outputParameterNamesOptional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList();
+		List<KeyValuePair> keyValuePairs = new ArrayList<>();
 
 		Assert.assertEquals(
 			keyValuePairs.toString(), keyValuePairs,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstancesDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstancesDataProviderTest.java
@@ -101,7 +101,7 @@ public class DDMDataProviderInstancesDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("1", "Data Provider Instance 1"));
 				add(new KeyValuePair("2", "Data Provider Instance 2"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMStorageTypesDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMStorageTypesDataProviderTest.java
@@ -57,7 +57,7 @@ public class DDMStorageTypesDataProviderTest extends PowerMockito {
 
 	@Test
 	public void testMultipleStorageAdapter() throws Exception {
-		Set<String> expectedSet = new TreeSet() {
+		Set<String> expectedSet = new TreeSet<>() {
 			{
 				add("json");
 				add("txt");
@@ -70,7 +70,7 @@ public class DDMStorageTypesDataProviderTest extends PowerMockito {
 
 	@Test
 	public void testSingleStorageAdapter() throws Exception {
-		Set<String> expectedSet = new TreeSet() {
+		Set<String> expectedSet = new TreeSet<>() {
 			{
 				add("json");
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProviderTest.java
@@ -106,7 +106,7 @@ public class WorkflowDefinitionsDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("no-workflow", "No Workflow"));
 				add(new KeyValuePair("definition1@1", "Definition 1"));
@@ -137,7 +137,7 @@ public class WorkflowDefinitionsDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("no-workflow", "No Workflow"));
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
@@ -130,7 +130,7 @@ public class DDMExpressionImplTest extends PowerMockito {
 		DDMExpressionImpl<BigDecimal> ddmExpression = createDDMExpression(
 			"a - b");
 
-		Set<String> variables = new HashSet() {
+		Set<String> variables = new HashSet<>() {
 			{
 				add("a");
 				add("b");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/SetOptionsFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/SetOptionsFunctionTest.java
@@ -111,7 +111,7 @@ public class SetOptionsFunctionTest extends PowerMockito {
 
 		Assert.assertTrue(properties.containsKey("options"));
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<>() {
 			{
 				add(new KeyValuePair("value1", "label1"));
 				add(new KeyValuePair("value2", "label2"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
@@ -34,7 +34,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 	@Test
 	public void testWrite() throws Exception {
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
@@ -43,9 +43,9 @@ public class DDMFormInstanceRecordCSVWriterTest {
 			}
 		};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<>() {
 					{
 						put("field1", "2");
 						put("field2", "esta é uma 'string'");
@@ -56,7 +56,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<>() {
 					{
 						put("field1", "1");
 						put("field2", "esta é uma 'string'");
@@ -98,9 +98,9 @@ public class DDMFormInstanceRecordCSVWriterTest {
 		DDMFormInstanceRecordCSVWriter ddmFormInstanceRecordCSVWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<>() {
 					{
 						put("field1", "value1");
 						put("field2", "false");
@@ -110,7 +110,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<>() {
 					{
 						put("field1", "");
 						put("field2", "true");
@@ -138,7 +138,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 		DDMFormInstanceRecordCSVWriter ddmFormInstanceRecordCSVWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		List<String> values = new ArrayList() {
+		List<String> values = new ArrayList<>() {
 			{
 				add("value1");
 				add("2");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
@@ -676,7 +676,8 @@ public class DDMFormInstanceRecordExporterImplTest extends PowerMockito {
 		ddmFormInstanceRecordExporter.ddmFormInstanceVersionLocalService =
 			_ddmFormInstanceVersionLocalService;
 
-		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList<>();
+		List<DDMFormInstanceVersion> ddmFormInstanceVersions =
+			new ArrayList<>();
 
 		DDMFormInstanceVersion ddmFormInstanceVersion = mock(
 			DDMFormInstanceVersion.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
@@ -676,7 +676,7 @@ public class DDMFormInstanceRecordExporterImplTest extends PowerMockito {
 		ddmFormInstanceRecordExporter.ddmFormInstanceVersionLocalService =
 			_ddmFormInstanceVersionLocalService;
 
-		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList();
+		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList<>();
 
 		DDMFormInstanceVersion ddmFormInstanceVersion = mock(
 			DDMFormInstanceVersion.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
@@ -40,9 +40,9 @@ public class DDMFormInstanceRecordJSONWriterTest {
 
 		ddmFormInstanceRecordJSONWriter.jsonFactory = new JSONFactoryImpl();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<>() {
 					{
 						put("field1", "2");
 						put("field2", "false");
@@ -52,7 +52,7 @@ public class DDMFormInstanceRecordJSONWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<>() {
 					{
 						put("field1", "1");
 						put("field2", "");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordWriterTrackerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordWriterTrackerImplTest.java
@@ -108,7 +108,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<>() {
 			{
 				put("ddm.form.instance.record.writer.type", "csv");
 				put("ddm.form.instance.record.writer.extension", "csv");
@@ -132,7 +132,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<>() {
 			{
 				put("ddm.form.instance.record.writer.type", "csv");
 				put("ddm.form.instance.record.writer.extension", "csv");
@@ -150,7 +150,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordJSONWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<>() {
 			{
 				put("ddm.form.instance.record.writer.type", "json");
 				put("ddm.form.instance.record.writer.extension", "json");
@@ -168,7 +168,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordXMLWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<>() {
 			{
 				put("ddm.form.instance.record.writer.type", "xml");
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
@@ -197,9 +197,9 @@ public class DDMFormInstanceRecordXLSWriterTest extends PowerMockito {
 	public void testWrite() throws Exception {
 		Map<String, String> ddmFormFieldsLabel = Collections.emptyMap();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<>() {
 					{
 						put("field1", "2");
 					}
@@ -207,7 +207,7 @@ public class DDMFormInstanceRecordXLSWriterTest extends PowerMockito {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<>() {
 					{
 						put("field1", "1");
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
@@ -124,14 +124,14 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 
 		Element element = mock(Element.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
 			}
 		};
 
-		Map<String, String> ddmFormFieldsValue = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsValue = new LinkedHashMap<>() {
 			{
 				put("field1", "Value 1");
 				put("field2", "Value 2");
@@ -176,7 +176,7 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 		DDMFormInstanceRecordXMLWriter ddmFormInstanceRecordXMLWriter = mock(
 			DDMFormInstanceRecordXMLWriter.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
@@ -185,9 +185,9 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 			}
 		};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<>() {
 					{
 						put("field1", "2");
 						put("field2", "esta é uma 'string'");
@@ -198,7 +198,7 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<>() {
 					{
 						put("field1", "1");
 						put("field2", "esta é uma 'string'");

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportProcessCallbackUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportProcessCallbackUtil.java
@@ -110,6 +110,6 @@ public class ExportImportProcessCallbackUtil {
 		ExportImportProcessCallbackUtil.class);
 
 	private static final Map<String, List<List<Callable<?>>>>
-		_callbackListListMap = new ConcurrentHashMap();
+		_callbackListListMap = new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -477,7 +477,7 @@ public class FragmentEntryLinkExportImportContentProcessor
 
 		Iterator<String> editableKeysIterator = editableJSONObject.keys();
 
-		Set<String> editableKeys = new HashSet();
+		Set<String> editableKeys = new HashSet<>();
 
 		editableKeysIterator.forEachRemaining(editableKeys::add);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownActionsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownActionsTag.java
@@ -54,7 +54,7 @@ public class DropdownActionsTag extends BaseClayTag {
 		Map<String, Object> context = getContext();
 
 		if (Validator.isNotNull(context.get("buttonLabel"))) {
-			Map<String, String> button = new HashMap();
+			Map<String, String> button = new HashMap<>();
 
 			button.put("label", (String)context.get("buttonLabel"));
 			button.put("style", (String)context.get("buttonStyle"));

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownMenuTag.java
@@ -54,7 +54,7 @@ public class DropdownMenuTag extends BaseClayTag {
 		Map<String, Object> context = getContext();
 
 		if (Validator.isNotNull(context.get("buttonLabel"))) {
-			Map<String, String> button = new HashMap();
+			Map<String, String> button = new HashMap<>();
 
 			button.put("label", (String)context.get("buttonLabel"));
 			button.put("style", (String)context.get("buttonStyle"));

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/context/Context.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/context/Context.java
@@ -65,6 +65,6 @@ public class Context {
 		_map.put(key, value);
 	}
 
-	private final Map<String, Serializable> _map = new HashMap();
+	private final Map<String, Serializable> _map = new HashMap<>();
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/Criteria.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/Criteria.java
@@ -225,7 +225,7 @@ public final class Criteria implements Serializable {
 		return sb.toString();
 	}
 
-	private Map<String, Criterion> _criteria = new HashMap();
-	private Map<String, String> _filterStrings = new HashMap();
+	private Map<String, Criterion> _criteria = new HashMap<>();
+	private Map<String, String> _filterStrings = new HashMap<>();
 
 }

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest.java
@@ -118,6 +118,6 @@ public class UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest {
 	private ScreenNameValidator _screenNameValidator;
 
 	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList();
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingGenericCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingGenericCheck.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checkstyle.checks;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * @author Alan Huang
+ */
+public class MissingGenericCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.VARIABLE_DEF};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		DetailAST typeDetailAST = detailAST.findFirstToken(TokenTypes.TYPE);
+
+		if (typeDetailAST == null) {
+			return;
+		}
+
+		DetailAST typeArgumentDetailAST = typeDetailAST.findFirstToken(
+			TokenTypes.TYPE_ARGUMENTS);
+
+		if (typeArgumentDetailAST == null) {
+			return;
+		}
+
+		DetailAST assignDetailAST = detailAST.findFirstToken(TokenTypes.ASSIGN);
+
+		if (assignDetailAST == null) {
+			return;
+		}
+
+		DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
+			return;
+		}
+
+		firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.LITERAL_NEW) {
+			return;
+		}
+
+		DetailAST identDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (!(identDetailAST.getType() == TokenTypes.IDENT) ||
+			!ArrayUtil.contains(_GENERIC_CLASSES, identDetailAST.getText())) {
+
+			return;
+		}
+
+		DetailAST siblingDetailAST = identDetailAST.getNextSibling();
+
+		if (siblingDetailAST.getType() == TokenTypes.LPAREN) {
+			siblingDetailAST = siblingDetailAST.getNextSibling();
+
+			if ((siblingDetailAST.getType() == TokenTypes.ELIST) &&
+				(siblingDetailAST.getChildCount() == 0)) {
+
+				log(detailAST, _MSG_MISSING_MODIFIER, identDetailAST.getText());
+			}
+		}
+	}
+
+	private static final String[] _GENERIC_CLASSES = {
+		"ArrayList", "ConcurrentHashMap", "ConcurrentSkipListMap",
+		"ConcurrentSkipListSet", "CopyOnWriteArraySet", "HashMap", "HashSet",
+		"Hashtable", "IdentityHashMap", "LinkedHashMap", "LinkedHashSet",
+		"LinkedList", "Stack", "TreeMap", "TreeSet", "Vector"
+	};
+
+	private static final String _MSG_MISSING_MODIFIER = "generic.missing";
+
+}

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -233,6 +233,9 @@
 		<module name="com.liferay.source.formatter.checkstyle.checks.MissingModifierCheck">
 			<message key="modifier.missing" value="Missing modifier for ''{0}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.checks.MissingGenericCheck">
+			<message key="generic.missing" value="Missing generic for ''{0}''" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.checks.MissingOverrideCheck">
 			<property name="enabled" value="false" />
 			<message key="override.missing" value="Missing @Override" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
@@ -298,6 +298,32 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testMissingGeneric() throws Exception {
+		test("MissingGeneric.testjava",
+			new String[] {
+				"Missing generic for 'ArrayList'",
+				"Missing generic for 'ConcurrentHashMap'",
+				"Missing generic for 'ConcurrentSkipListMap'",
+				"Missing generic for 'ConcurrentSkipListSet'",
+				"Missing generic for 'CopyOnWriteArraySet'",
+				"Missing generic for 'HashMap'",
+				"Missing generic for 'HashSet'",
+				"Missing generic for 'Hashtable'",
+				"Missing generic for 'IdentityHashMap'",
+				"Missing generic for 'LinkedHashMap'",
+				"Missing generic for 'LinkedHashSet'",
+				"Missing generic for 'LinkedList'",
+				"Missing generic for 'Stack'",
+				"Missing generic for 'TreeMap'",
+				"Missing generic for 'TreeSet'",
+				"Missing generic for 'Vector'"
+			},
+			new Integer[] {
+				44, 46, 48, 50, 52, 54, 56, 58, 60, 63, 65, 67, 69, 71, 73, 75
+			});
+	}
+
+	@Test
 	public void testMissingSerialVersionUID() throws Exception {
 		test(
 			"MissingSerialVersionUID.testjava",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingGeneric.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingGeneric.testjava
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * @author Alan Huang
+ */
+public class MissingGeneric {
+
+	public void method() {
+		List<String> arrayList = new ArrayList();
+
+		Map<String, String> concurrentHashMap = new ConcurrentHashMap();
+
+		Map<String, String> concurrentSkipListMap = new ConcurrentSkipListMap();
+
+		Set<String> concurrentSkipListSet = new ConcurrentSkipListSet();
+
+		Set<String> copyOnWriteArraySet = new CopyOnWriteArraySet();
+
+		Map<String, String> hashMap = new HashMap();
+
+		Set<String> hashSet = new HashSet();
+
+		Dictionary<String, Object> hashtable = new Hashtable();
+
+		Map<Object, Map<String, Object>> identityHashMap =
+			new IdentityHashMap();
+
+		Map<String, String> linkedHashMap = new LinkedHashMap();
+
+		Set<String> linkedHashSet = new LinkedHashSet();
+
+		List<String> linkedList = new LinkedList();
+
+		Stack<String> stack = new Stack();
+
+		Map<String, String> treeMap = new TreeMap();
+
+		Set<String> treeSet = new TreeSet();
+
+		Vector<String> vector = new Vector();
+
+		System.out.println(arrayList.size());
+		System.out.println(concurrentHashMap.size());
+		System.out.println(concurrentSkipListMap.size());
+		System.out.println(concurrentSkipListSet.size());
+		System.out.println(copyOnWriteArraySet.size());
+		System.out.println(hashMap.size());
+		System.out.println(hashSet.size());
+		System.out.println(hashtable.size());
+		System.out.println(identityHashMap.size());
+		System.out.println(linkedHashMap.size());
+		System.out.println(linkedHashSet.size());
+		System.out.println(linkedList.size());
+		System.out.println(stack.size());
+		System.out.println(treeMap.size());
+		System.out.println(treeSet.size());
+		System.out.println(vector.size());
+	}
+
+}


### PR DESCRIPTION
Hi @hhuijser,

The issue: https://github.com/liferay/liferay-portal/commit/a4c335d74c7d18103c066ca7c659de09194b9cb1

I removed `EnumMap` from [private static final String[] _GENERIC_CLASSES](https://github.com/hhuijser/liferay-portal/compare/master...ling-alan-huang:LPS-84119_MissingGenericCheck_20190719_01?expand=1#diff-82fc5733e2b4956258c7d609449747a8R86) ,
Reason: https://github.com/ling-alan-huang/liferay-portal/pull/84#issuecomment-512756713
```
     [exec] /opt/dev/projects/github/liferay-portal/modules/apps/frontend-taglib/frontend-taglib-util/src/main/java/com/liferay/frontend/taglib/util/TagResourceHandler.java:180: error: cannot infer type arguments for EnumMap<K,V>
     [exec] 		new EnumMap<>(Position.class) \{
     [exec] 		           ^
     [exec]   reason: cannot use '<>' with anonymous inner classes
     [exec]   where K,V are type-variables:
     [exec]     K extends Enum<K> declared in class EnumMap
     [exec]     V extends Object declared in class EnumMap
     [exec] 1 error

```

So the rule is only for non-parameter in `Constructor`. 