### PR TITLE
LPS-98817 Add MissingDiamondOperatorCheck

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ChildSitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ChildSitesItemSelectorViewDisplayContext.java
@@ -86,7 +86,7 @@ public class ChildSitesItemSelectorViewDisplayContext
 	private List<Group> _filterGroups(
 		List<Group> groups, PermissionChecker permissionChecker) {
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (permissionChecker.isGroupAdmin(group.getGroupId())) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/LayoutScopesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/LayoutScopesItemSelectorViewDisplayContext.java
@@ -92,7 +92,7 @@ public class LayoutScopesItemSelectorViewDisplayContext
 			return groups;
 		}
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (!group.isLayout()) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ParentSitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/ParentSitesItemSelectorViewDisplayContext.java
@@ -73,7 +73,7 @@ public class ParentSitesItemSelectorViewDisplayContext
 	}
 
 	private List<Group> _filterParentSitesGroups(List<Group> groups) {
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (SitesUtil.isContentSharingWithChildrenEnabled(group)) {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/SitesThatIAdministerItemSelectorViewDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/SitesThatIAdministerItemSelectorViewDisplayContext.java
@@ -86,7 +86,7 @@ public class SitesThatIAdministerItemSelectorViewDisplayContext
 	private List<Group> _filterGroups(
 		List<Group> groups, PermissionChecker permissionChecker) {
 
-		List<Group> filteredGroups = new ArrayList();
+		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (permissionChecker.isGroupAdmin(group.getGroupId())) {

--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContext.java
@@ -119,7 +119,7 @@ public class AssetTagsDisplayContext {
 		long[] mergeTagIds = StringUtil.split(
 			ParamUtil.getString(_renderRequest, "mergeTagIds"), 0L);
 
-		List<String> mergeTagNames = new ArrayList();
+		List<String> mergeTagNames = new ArrayList<>();
 
 		for (long mergeTagId : mergeTagIds) {
 			AssetTag tag = AssetTagLocalServiceUtil.fetchAssetTag(mergeTagId);

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategorySectionDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategorySectionDisplay.java
@@ -57,7 +57,7 @@ public class ConfigurationCategorySectionDisplay {
 	}
 
 	private Set<ConfigurationCategoryDisplay> _configurationCategoryDisplays =
-		new TreeSet(new ConfigurationCategoryDisplayComparator());
+		new TreeSet<>(new ConfigurationCategoryDisplayComparator());
 	private final String _configurationCategorySection;
 
 	private static class ConfigurationCategoryDisplayComparator

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationEntryRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationEntryRetrieverImpl.java
@@ -129,7 +129,7 @@ public class ConfigurationEntryRetrieverImpl
 		}
 
 		Set<ConfigurationCategorySectionDisplay> configurationCategorySections =
-			new TreeSet(new ConfigurationCategorySectionDisplayComparator());
+			new TreeSet<>(new ConfigurationCategorySectionDisplayComparator());
 
 		configurationCategorySections.addAll(
 			configurationCategorySectionDisplaysMap.values());
@@ -142,7 +142,7 @@ public class ConfigurationEntryRetrieverImpl
 		String configurationCategory, String languageId,
 		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
 
-		Set<ConfigurationEntry> configurationEntries = new TreeSet(
+		Set<ConfigurationEntry> configurationEntries = new TreeSet<>(
 			getConfigurationEntryComparator());
 
 		Locale locale = LocaleUtil.fromLanguageId(languageId);

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ValidationFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ValidationFieldType.java
@@ -64,7 +64,7 @@ public class ValidationFieldType extends BaseFieldType {
 	private Map<String, String> _getValue(
 		SPIDataDefinitionField spiDataDefinitionField) {
 
-		Map<String, String> value = new HashMap();
+		Map<String, String> value = new HashMap<>();
 
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/rest/DDMRESTDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/rest/DDMRESTDataProviderTest.java
@@ -598,7 +598,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			ddmDataProviderResponse.getOutputOptional(
 				"list output", List.class);
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("5", "Rio de Janeiro"));
 				add(new KeyValuePair("6", "São Paulo"));
@@ -664,7 +664,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			ddmDataProviderResponse.getOutputOptional(
 				"list output", List.class);
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("1", "Pernambuco"));
 				add(new KeyValuePair("2", "Paraiba"));
@@ -822,7 +822,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 			name.capture(), value.capture()
 		);
 
-		List<String> names = new ArrayList() {
+		List<String> names = new ArrayList<String>() {
 			{
 				add("country");
 				add("start");
@@ -832,7 +832,7 @@ public class DDMRESTDataProviderTest extends PowerMockito {
 
 		Assert.assertEquals(names, name.getAllValues());
 
-		List<String> values = new ArrayList() {
+		List<String> values = new ArrayList<String>() {
 			{
 				add("brazil");
 				add("1");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstanceOutputParametersDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstanceOutputParametersDataProviderTest.java
@@ -189,7 +189,7 @@ public class DDMDataProviderInstanceOutputParametersDataProviderTest
 
 		Assert.assertTrue(outputParameterNamesOptional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("Country Id", "Country Id"));
 				add(new KeyValuePair("Country Name", "Country Name"));
@@ -306,7 +306,7 @@ public class DDMDataProviderInstanceOutputParametersDataProviderTest
 
 		Assert.assertTrue(outputParameterNamesOptional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList();
+		List<KeyValuePair> keyValuePairs = new ArrayList<>();
 
 		Assert.assertEquals(
 			keyValuePairs.toString(), keyValuePairs,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstancesDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMDataProviderInstancesDataProviderTest.java
@@ -101,7 +101,7 @@ public class DDMDataProviderInstancesDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("1", "Data Provider Instance 1"));
 				add(new KeyValuePair("2", "Data Provider Instance 2"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMStorageTypesDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/DDMStorageTypesDataProviderTest.java
@@ -57,7 +57,7 @@ public class DDMStorageTypesDataProviderTest extends PowerMockito {
 
 	@Test
 	public void testMultipleStorageAdapter() throws Exception {
-		Set<String> expectedSet = new TreeSet() {
+		Set<String> expectedSet = new TreeSet<String>() {
 			{
 				add("json");
 				add("txt");
@@ -70,7 +70,7 @@ public class DDMStorageTypesDataProviderTest extends PowerMockito {
 
 	@Test
 	public void testSingleStorageAdapter() throws Exception {
-		Set<String> expectedSet = new TreeSet() {
+		Set<String> expectedSet = new TreeSet<String>() {
 			{
 				add("json");
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProviderTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/test/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProviderTest.java
@@ -106,7 +106,7 @@ public class WorkflowDefinitionsDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("no-workflow", "No Workflow"));
 				add(new KeyValuePair("definition1@1", "Definition 1"));
@@ -137,7 +137,7 @@ public class WorkflowDefinitionsDataProviderTest extends PowerMockito {
 
 		Assert.assertTrue(optional.isPresent());
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("no-workflow", "No Workflow"));
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
@@ -130,7 +130,7 @@ public class DDMExpressionImplTest extends PowerMockito {
 		DDMExpressionImpl<BigDecimal> ddmExpression = createDDMExpression(
 			"a - b");
 
-		Set<String> variables = new HashSet() {
+		Set<String> variables = new HashSet<String>() {
 			{
 				add("a");
 				add("b");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/SetOptionsFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/SetOptionsFunctionTest.java
@@ -111,7 +111,7 @@ public class SetOptionsFunctionTest extends PowerMockito {
 
 		Assert.assertTrue(properties.containsKey("options"));
 
-		List<KeyValuePair> keyValuePairs = new ArrayList() {
+		List<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>() {
 			{
 				add(new KeyValuePair("value1", "label1"));
 				add(new KeyValuePair("value2", "label2"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
@@ -34,7 +34,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 	@Test
 	public void testWrite() throws Exception {
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
@@ -43,9 +43,9 @@ public class DDMFormInstanceRecordCSVWriterTest {
 			}
 		};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<String, String>() {
 					{
 						put("field1", "2");
 						put("field2", "esta é uma 'string'");
@@ -56,7 +56,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<String, String>() {
 					{
 						put("field1", "1");
 						put("field2", "esta é uma 'string'");
@@ -98,9 +98,9 @@ public class DDMFormInstanceRecordCSVWriterTest {
 		DDMFormInstanceRecordCSVWriter ddmFormInstanceRecordCSVWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<String, String>() {
 					{
 						put("field1", "value1");
 						put("field2", "false");
@@ -110,7 +110,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<String, String>() {
 					{
 						put("field1", "");
 						put("field2", "true");
@@ -138,7 +138,7 @@ public class DDMFormInstanceRecordCSVWriterTest {
 		DDMFormInstanceRecordCSVWriter ddmFormInstanceRecordCSVWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		List<String> values = new ArrayList() {
+		List<String> values = new ArrayList<String>() {
 			{
 				add("value1");
 				add("2");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordCSVWriterTest.java
@@ -34,40 +34,42 @@ public class DDMFormInstanceRecordCSVWriterTest {
 
 	@Test
 	public void testWrite() throws Exception {
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
-			{
-				put("field1", "Field 1");
-				put("field2", "Field 2");
-				put("field3", "Field 3");
-				put("field4", "Field 4");
-			}
-		};
+		Map<String, String> ddmFormFieldsLabel =
+			new LinkedHashMap<String, String>() {
+				{
+					put("field1", "Field 1");
+					put("field2", "Field 2");
+					put("field3", "Field 3");
+					put("field4", "Field 4");
+				}
+			};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
-			{
-				Map<String, String> map1 = new HashMap<String, String>() {
-					{
-						put("field1", "2");
-						put("field2", "esta é uma 'string'");
-						put("field3", "false");
-						put("field4", "11.7");
-					}
-				};
+		List<Map<String, String>> ddmFormFieldValues =
+			new ArrayList<Map<String, String>>() {
+				{
+					Map<String, String> map1 = new HashMap<String, String>() {
+						{
+							put("field1", "2");
+							put("field2", "esta é uma 'string'");
+							put("field3", "false");
+							put("field4", "11.7");
+						}
+					};
 
-				add(map1);
+					add(map1);
 
-				Map<String, String> map2 = new HashMap<String, String>() {
-					{
-						put("field1", "1");
-						put("field2", "esta é uma 'string'");
-						put("field3", "");
-						put("field4", "10");
-					}
-				};
+					Map<String, String> map2 = new HashMap<String, String>() {
+						{
+							put("field1", "1");
+							put("field2", "esta é uma 'string'");
+							put("field3", "");
+							put("field4", "10");
+						}
+					};
 
-				add(map2);
-			}
-		};
+					add(map2);
+				}
+			};
 
 		DDMFormInstanceRecordWriterRequest.Builder builder =
 			DDMFormInstanceRecordWriterRequest.Builder.newBuilder(
@@ -98,29 +100,30 @@ public class DDMFormInstanceRecordCSVWriterTest {
 		DDMFormInstanceRecordCSVWriter ddmFormInstanceRecordCSVWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
-			{
-				Map<String, String> map1 = new HashMap<String, String>() {
-					{
-						put("field1", "value1");
-						put("field2", "false");
-						put("field3", "134.5");
-					}
-				};
+		List<Map<String, String>> ddmFormFieldValues =
+			new ArrayList<Map<String, String>>() {
+				{
+					Map<String, String> map1 = new HashMap<String, String>() {
+						{
+							put("field1", "value1");
+							put("field2", "false");
+							put("field3", "134.5");
+						}
+					};
 
-				add(map1);
+					add(map1);
 
-				Map<String, String> map2 = new HashMap<String, String>() {
-					{
-						put("field1", "");
-						put("field2", "true");
-						put("field3", "45");
-					}
-				};
+					Map<String, String> map2 = new HashMap<String, String>() {
+						{
+							put("field1", "");
+							put("field2", "true");
+							put("field3", "45");
+						}
+					};
 
-				add(map2);
-			}
-		};
+					add(map2);
+				}
+			};
 
 		StringBundler sb = new StringBundler(2);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
@@ -676,7 +676,8 @@ public class DDMFormInstanceRecordExporterImplTest extends PowerMockito {
 		ddmFormInstanceRecordExporter.ddmFormInstanceVersionLocalService =
 			_ddmFormInstanceVersionLocalService;
 
-		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList<>();
+		List<DDMFormInstanceVersion> ddmFormInstanceVersions =
+			new ArrayList<>();
 
 		DDMFormInstanceVersion ddmFormInstanceVersion = mock(
 			DDMFormInstanceVersion.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordExporterImplTest.java
@@ -676,7 +676,7 @@ public class DDMFormInstanceRecordExporterImplTest extends PowerMockito {
 		ddmFormInstanceRecordExporter.ddmFormInstanceVersionLocalService =
 			_ddmFormInstanceVersionLocalService;
 
-		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList();
+		List<DDMFormInstanceVersion> ddmFormInstanceVersions = new ArrayList<>();
 
 		DDMFormInstanceVersion ddmFormInstanceVersion = mock(
 			DDMFormInstanceVersion.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
@@ -40,29 +40,30 @@ public class DDMFormInstanceRecordJSONWriterTest {
 
 		ddmFormInstanceRecordJSONWriter.jsonFactory = new JSONFactoryImpl();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
-			{
-				Map<String, String> map1 = new HashMap<String, String>() {
-					{
-						put("field1", "2");
-						put("field2", "false");
-						put("field3", "11.7");
-					}
-				};
+		List<Map<String, String>> ddmFormFieldValues =
+			new ArrayList<Map<String, String>>() {
+				{
+					Map<String, String> map1 = new HashMap<String, String>() {
+						{
+							put("field1", "2");
+							put("field2", "false");
+							put("field3", "11.7");
+						}
+					};
 
-				add(map1);
+					add(map1);
 
-				Map<String, String> map2 = new HashMap<String, String>() {
-					{
-						put("field1", "1");
-						put("field2", "");
-						put("field3", "10");
-					}
-				};
+					Map<String, String> map2 = new HashMap<String, String>() {
+						{
+							put("field1", "1");
+							put("field2", "");
+							put("field3", "10");
+						}
+					};
 
-				add(map2);
-			}
-		};
+					add(map2);
+				}
+			};
 
 		DDMFormInstanceRecordWriterRequest.Builder builder =
 			DDMFormInstanceRecordWriterRequest.Builder.newBuilder(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordJSONWriterTest.java
@@ -40,9 +40,9 @@ public class DDMFormInstanceRecordJSONWriterTest {
 
 		ddmFormInstanceRecordJSONWriter.jsonFactory = new JSONFactoryImpl();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<String, String>() {
 					{
 						put("field1", "2");
 						put("field2", "false");
@@ -52,7 +52,7 @@ public class DDMFormInstanceRecordJSONWriterTest {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<String, String>() {
 					{
 						put("field1", "1");
 						put("field2", "");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordWriterTrackerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordWriterTrackerImplTest.java
@@ -108,7 +108,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<String, Object>() {
 			{
 				put("ddm.form.instance.record.writer.type", "csv");
 				put("ddm.form.instance.record.writer.extension", "csv");
@@ -132,7 +132,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordCSVWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<String, Object>() {
 			{
 				put("ddm.form.instance.record.writer.type", "csv");
 				put("ddm.form.instance.record.writer.extension", "csv");
@@ -150,7 +150,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordJSONWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<String, Object>() {
 			{
 				put("ddm.form.instance.record.writer.type", "json");
 				put("ddm.form.instance.record.writer.extension", "json");
@@ -168,7 +168,7 @@ public class DDMFormInstanceRecordWriterTrackerImplTest {
 		DDMFormInstanceRecordWriter ddmFormInstanceRecordWriter =
 			new DDMFormInstanceRecordXMLWriter();
 
-		Map<String, Object> properties = new HashMap() {
+		Map<String, Object> properties = new HashMap<String, Object>() {
 			{
 				put("ddm.form.instance.record.writer.type", "xml");
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
@@ -197,25 +197,26 @@ public class DDMFormInstanceRecordXLSWriterTest extends PowerMockito {
 	public void testWrite() throws Exception {
 		Map<String, String> ddmFormFieldsLabel = Collections.emptyMap();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
-			{
-				Map<String, String> map1 = new HashMap<String, String>() {
-					{
-						put("field1", "2");
-					}
-				};
+		List<Map<String, String>> ddmFormFieldValues =
+			new ArrayList<Map<String, String>>() {
+				{
+					Map<String, String> map1 = new HashMap<String, String>() {
+						{
+							put("field1", "2");
+						}
+					};
 
-				add(map1);
+					add(map1);
 
-				Map<String, String> map2 = new HashMap<String, String>() {
-					{
-						put("field1", "1");
-					}
-				};
+					Map<String, String> map2 = new HashMap<String, String>() {
+						{
+							put("field1", "1");
+						}
+					};
 
-				add(map2);
-			}
-		};
+					add(map2);
+				}
+			};
 
 		DDMFormInstanceRecordWriterRequest.Builder builder =
 			DDMFormInstanceRecordWriterRequest.Builder.newBuilder(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXLSWriterTest.java
@@ -197,9 +197,9 @@ public class DDMFormInstanceRecordXLSWriterTest extends PowerMockito {
 	public void testWrite() throws Exception {
 		Map<String, String> ddmFormFieldsLabel = Collections.emptyMap();
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<String, String>() {
 					{
 						put("field1", "2");
 					}
@@ -207,7 +207,7 @@ public class DDMFormInstanceRecordXLSWriterTest extends PowerMockito {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<String, String>() {
 					{
 						put("field1", "1");
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
@@ -124,14 +124,14 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 
 		Element element = mock(Element.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
 			}
 		};
 
-		Map<String, String> ddmFormFieldsValue = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsValue = new LinkedHashMap<String, String>() {
 			{
 				put("field1", "Value 1");
 				put("field2", "Value 2");
@@ -176,7 +176,7 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 		DDMFormInstanceRecordXMLWriter ddmFormInstanceRecordXMLWriter = mock(
 			DDMFormInstanceRecordXMLWriter.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap() {
+		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
 			{
 				put("field1", "Field 1");
 				put("field2", "Field 2");
@@ -185,9 +185,9 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 			}
 		};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
 			{
-				Map<String, String> map1 = new HashMap() {
+				Map<String, String> map1 = new HashMap<String, String>() {
 					{
 						put("field1", "2");
 						put("field2", "esta é uma 'string'");
@@ -198,7 +198,7 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 
 				add(map1);
 
-				Map<String, String> map2 = new HashMap() {
+				Map<String, String> map2 = new HashMap<String, String>() {
 					{
 						put("field1", "1");
 						put("field2", "esta é uma 'string'");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/test/java/com/liferay/dynamic/data/mapping/io/internal/exporter/DDMFormInstanceRecordXMLWriterTest.java
@@ -124,19 +124,21 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 
 		Element element = mock(Element.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
-			{
-				put("field1", "Field 1");
-				put("field2", "Field 2");
-			}
-		};
+		Map<String, String> ddmFormFieldsLabel =
+			new LinkedHashMap<String, String>() {
+				{
+					put("field1", "Field 1");
+					put("field2", "Field 2");
+				}
+			};
 
-		Map<String, String> ddmFormFieldsValue = new LinkedHashMap<String, String>() {
-			{
-				put("field1", "Value 1");
-				put("field2", "Value 2");
-			}
-		};
+		Map<String, String> ddmFormFieldsValue =
+			new LinkedHashMap<String, String>() {
+				{
+					put("field1", "Value 1");
+					put("field2", "Value 2");
+				}
+			};
 
 		Mockito.doCallRealMethod(
 		).when(
@@ -176,40 +178,42 @@ public class DDMFormInstanceRecordXMLWriterTest extends PowerMockito {
 		DDMFormInstanceRecordXMLWriter ddmFormInstanceRecordXMLWriter = mock(
 			DDMFormInstanceRecordXMLWriter.class);
 
-		Map<String, String> ddmFormFieldsLabel = new LinkedHashMap<String, String>() {
-			{
-				put("field1", "Field 1");
-				put("field2", "Field 2");
-				put("field3", "Field 3");
-				put("field4", "Field 4");
-			}
-		};
+		Map<String, String> ddmFormFieldsLabel =
+			new LinkedHashMap<String, String>() {
+				{
+					put("field1", "Field 1");
+					put("field2", "Field 2");
+					put("field3", "Field 3");
+					put("field4", "Field 4");
+				}
+			};
 
-		List<Map<String, String>> ddmFormFieldValues = new ArrayList<Map<String, String>>() {
-			{
-				Map<String, String> map1 = new HashMap<String, String>() {
-					{
-						put("field1", "2");
-						put("field2", "esta é uma 'string'");
-						put("field3", "false");
-						put("field4", "11.7");
-					}
-				};
+		List<Map<String, String>> ddmFormFieldValues =
+			new ArrayList<Map<String, String>>() {
+				{
+					Map<String, String> map1 = new HashMap<String, String>() {
+						{
+							put("field1", "2");
+							put("field2", "esta é uma 'string'");
+							put("field3", "false");
+							put("field4", "11.7");
+						}
+					};
 
-				add(map1);
+					add(map1);
 
-				Map<String, String> map2 = new HashMap<String, String>() {
-					{
-						put("field1", "1");
-						put("field2", "esta é uma 'string'");
-						put("field3", "");
-						put("field4", "10");
-					}
-				};
+					Map<String, String> map2 = new HashMap<String, String>() {
+						{
+							put("field1", "1");
+							put("field2", "esta é uma 'string'");
+							put("field3", "");
+							put("field4", "10");
+						}
+					};
 
-				add(map2);
-			}
-		};
+					add(map2);
+				}
+			};
 
 		DDMFormInstanceRecordWriterRequest.Builder builder =
 			DDMFormInstanceRecordWriterRequest.Builder.newBuilder(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportProcessCallbackUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportProcessCallbackUtil.java
@@ -110,6 +110,6 @@ public class ExportImportProcessCallbackUtil {
 		ExportImportProcessCallbackUtil.class);
 
 	private static final Map<String, List<List<Callable<?>>>>
-		_callbackListListMap = new ConcurrentHashMap();
+		_callbackListListMap = new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -497,7 +497,7 @@ public class FragmentEntryLinkExportImportContentProcessor
 
 		Iterator<String> editableKeysIterator = editableJSONObject.keys();
 
-		Set<String> editableKeys = new HashSet();
+		Set<String> editableKeys = new HashSet<>();
 
 		editableKeysIterator.forEachRemaining(editableKeys::add);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownActionsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownActionsTag.java
@@ -54,7 +54,7 @@ public class DropdownActionsTag extends BaseClayTag {
 		Map<String, Object> context = getContext();
 
 		if (Validator.isNotNull(context.get("buttonLabel"))) {
-			Map<String, String> button = new HashMap();
+			Map<String, String> button = new HashMap<>();
 
 			button.put("label", (String)context.get("buttonLabel"));
 			button.put("style", (String)context.get("buttonStyle"));

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/DropdownMenuTag.java
@@ -54,7 +54,7 @@ public class DropdownMenuTag extends BaseClayTag {
 		Map<String, Object> context = getContext();
 
 		if (Validator.isNotNull(context.get("buttonLabel"))) {
-			Map<String, String> button = new HashMap();
+			Map<String, String> button = new HashMap<>();
 
 			button.put("label", (String)context.get("buttonLabel"));
 			button.put("style", (String)context.get("buttonStyle"));

--- a/modules/apps/frontend-taglib/frontend-taglib-util/src/main/java/com/liferay/frontend/taglib/util/TagResourceHandler.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-util/src/main/java/com/liferay/frontend/taglib/util/TagResourceHandler.java
@@ -177,7 +177,7 @@ public class TagResourceHandler {
 	}
 
 	private static final EnumMap<Position, String> _webKeysEnumMap =
-		new EnumMap(Position.class) {
+		new EnumMap<Position, String>(Position.class) {
 			{
 				put(Position.BOTTOM, WebKeys.PAGE_BODY_BOTTOM);
 				put(Position.TOP, WebKeys.PAGE_TOP);

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/context/Context.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/context/Context.java
@@ -65,6 +65,6 @@ public class Context {
 		_map.put(key, value);
 	}
 
-	private final Map<String, Serializable> _map = new HashMap();
+	private final Map<String, Serializable> _map = new HashMap<>();
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/Criteria.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/Criteria.java
@@ -225,7 +225,7 @@ public final class Criteria implements Serializable {
 		return sb.toString();
 	}
 
-	private Map<String, Criterion> _criteria = new HashMap();
-	private Map<String, String> _filterStrings = new HashMap();
+	private Map<String, Criterion> _criteria = new HashMap<>();
+	private Map<String, String> _filterStrings = new HashMap<>();
 
 }

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest.java
@@ -118,6 +118,6 @@ public class UserServiceWhenAddingUserWithSpecialCharactersScreenNameTest {
 	private ScreenNameValidator _screenNameValidator;
 
 	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList();
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
@@ -14,11 +14,15 @@
 
 package com.liferay.source.formatter.checkstyle.checks;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
 
 /**
  * @author Alan Huang
@@ -33,10 +37,6 @@ public class MissingDiamondOperatorCheck extends BaseCheck {
 	@Override
 	protected void doVisitToken(DetailAST detailAST) {
 		DetailAST typeDetailAST = detailAST.findFirstToken(TokenTypes.TYPE);
-
-		if (typeDetailAST == null) {
-			return;
-		}
 
 		DetailAST typeArgumentDetailAST = typeDetailAST.findFirstToken(
 			TokenTypes.TYPE_ARGUMENTS);
@@ -73,15 +73,34 @@ public class MissingDiamondOperatorCheck extends BaseCheck {
 
 		DetailAST siblingDetailAST = identDetailAST.getNextSibling();
 
-		String types = DetailASTUtil.getTypeName(detailAST, true);
-
 		if (siblingDetailAST.getType() != TokenTypes.TYPE_ARGUMENTS) {
 			if (leteralNewDetailAST.findFirstToken(TokenTypes.OBJBLOCK) !=
 					null) {
 
+				String variableTypeName = "";
+
+				List<DetailAST> typeArgumentDetailASTList =
+					DetailASTUtil.getAllChildTokens(
+						typeArgumentDetailAST, true, DetailASTUtil.ALL_TYPES);
+
+				for (DetailAST argumentDetailAST : typeArgumentDetailASTList) {
+					if (argumentDetailAST.getChildCount() == 0) {
+						variableTypeName =
+							variableTypeName + argumentDetailAST.getText();
+
+						if (StringUtil.equals(
+								argumentDetailAST.getText(),
+								StringPool.COMMA)) {
+
+							variableTypeName =
+								variableTypeName + StringPool.SPACE;
+						}
+					}
+				}
+
 				log(
 					detailAST, _MSG_MISSING_DIAMOND_TYPES_OPERATOR,
-					types.substring(types.indexOf("<")),
+					variableTypeName.substring(variableTypeName.indexOf("<")),
 					identDetailAST.getText());
 			}
 			else {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
@@ -16,7 +16,6 @@ package com.liferay.source.formatter.checkstyle.checks;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -73,41 +72,41 @@ public class MissingDiamondOperatorCheck extends BaseCheck {
 
 		DetailAST siblingDetailAST = identDetailAST.getNextSibling();
 
-		if (siblingDetailAST.getType() != TokenTypes.TYPE_ARGUMENTS) {
-			if (leteralNewDetailAST.findFirstToken(TokenTypes.OBJBLOCK) !=
-					null) {
+		if (siblingDetailAST.getType() == TokenTypes.TYPE_ARGUMENTS) {
+			return;
+		}
 
-				String variableTypeName = "";
+		if (leteralNewDetailAST.findFirstToken(TokenTypes.OBJBLOCK) != null) {
+			String typeName = StringPool.BLANK;
+			String variableTypeName = StringPool.BLANK;
 
-				List<DetailAST> typeArgumentDetailASTList =
-					DetailASTUtil.getAllChildTokens(
-						typeArgumentDetailAST, true, DetailASTUtil.ALL_TYPES);
+			List<DetailAST> typeArgumentDetailASTList =
+				DetailASTUtil.getAllChildTokens(
+					typeArgumentDetailAST, true, DetailASTUtil.ALL_TYPES);
 
-				for (DetailAST argumentDetailAST : typeArgumentDetailASTList) {
-					if (argumentDetailAST.getChildCount() != 0) {
-						continue;
-					}
-
-					variableTypeName =
-						variableTypeName + argumentDetailAST.getText();
-
-					if (StringUtil.equals(
-							argumentDetailAST.getText(), StringPool.COMMA)) {
-
-						variableTypeName = variableTypeName + StringPool.SPACE;
-					}
+			for (DetailAST argumentDetailAST : typeArgumentDetailASTList) {
+				if (argumentDetailAST.getChildCount() != 0) {
+					continue;
 				}
 
-				log(
-					detailAST, _MSG_MISSING_DIAMOND_TYPES_OPERATOR,
-					variableTypeName.substring(variableTypeName.indexOf("<")),
-					identDetailAST.getText());
+				typeName = argumentDetailAST.getText();
+
+				if (typeName.equals(StringPool.COMMA)) {
+					typeName = typeName + StringPool.SPACE;
+				}
+
+				variableTypeName = variableTypeName + typeName;
 			}
-			else {
-				log(
-					detailAST, _MSG_MISSING_DIAMOND_OPERATOR,
-					identDetailAST.getText());
-			}
+
+			log(
+				detailAST, _MSG_MISSING_DIAMOND_TYPES_OPERATOR,
+				variableTypeName.substring(variableTypeName.indexOf("<")),
+				identDetailAST.getText());
+		}
+		else {
+			log(
+				detailAST, _MSG_MISSING_DIAMOND_OPERATOR,
+				identDetailAST.getText());
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
@@ -84,17 +84,17 @@ public class MissingDiamondOperatorCheck extends BaseCheck {
 						typeArgumentDetailAST, true, DetailASTUtil.ALL_TYPES);
 
 				for (DetailAST argumentDetailAST : typeArgumentDetailASTList) {
-					if (argumentDetailAST.getChildCount() == 0) {
-						variableTypeName =
-							variableTypeName + argumentDetailAST.getText();
+					if (argumentDetailAST.getChildCount() != 0) {
+						continue;
+					}
 
-						if (StringUtil.equals(
-								argumentDetailAST.getText(),
-								StringPool.COMMA)) {
+					variableTypeName =
+						variableTypeName + argumentDetailAST.getText();
 
-							variableTypeName =
-								variableTypeName + StringPool.SPACE;
-						}
+					if (StringUtil.equals(
+							argumentDetailAST.getText(), StringPool.COMMA)) {
+
+						variableTypeName = variableTypeName + StringPool.SPACE;
 					}
 				}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingDiamondOperatorCheck.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checkstyle.checks;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * @author Alan Huang
+ */
+public class MissingDiamondOperatorCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.VARIABLE_DEF};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		DetailAST typeDetailAST = detailAST.findFirstToken(TokenTypes.TYPE);
+
+		if (typeDetailAST == null) {
+			return;
+		}
+
+		DetailAST typeArgumentDetailAST = typeDetailAST.findFirstToken(
+			TokenTypes.TYPE_ARGUMENTS);
+
+		if (typeArgumentDetailAST == null) {
+			return;
+		}
+
+		DetailAST assignDetailAST = detailAST.findFirstToken(TokenTypes.ASSIGN);
+
+		if (assignDetailAST == null) {
+			return;
+		}
+
+		DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
+			return;
+		}
+
+		DetailAST leteralNewDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (leteralNewDetailAST.getType() != TokenTypes.LITERAL_NEW) {
+			return;
+		}
+
+		DetailAST identDetailAST = leteralNewDetailAST.getFirstChild();
+
+		if (!(identDetailAST.getType() == TokenTypes.IDENT) ||
+			!ArrayUtil.contains(_GENERIC_CLASSES, identDetailAST.getText())) {
+
+			return;
+		}
+
+		DetailAST siblingDetailAST = identDetailAST.getNextSibling();
+
+		String types = DetailASTUtil.getTypeName(detailAST, true);
+
+		if (siblingDetailAST.getType() != TokenTypes.TYPE_ARGUMENTS) {
+			if (leteralNewDetailAST.findFirstToken(TokenTypes.OBJBLOCK) !=
+					null) {
+
+				log(
+					detailAST, _MSG_MISSING_DIAMOND_TYPES_OPERATOR,
+					types.substring(types.indexOf("<")),
+					identDetailAST.getText());
+			}
+			else {
+				log(
+					detailAST, _MSG_MISSING_DIAMOND_OPERATOR,
+					identDetailAST.getText());
+			}
+		}
+	}
+
+	private static final String[] _GENERIC_CLASSES = {
+		"ArrayList", "ConcurrentHashMap", "ConcurrentSkipListMap",
+		"ConcurrentSkipListSet", "CopyOnWriteArraySet", "EnumMap", "HashMap",
+		"HashSet", "Hashtable", "IdentityHashMap", "LinkedHashMap",
+		"LinkedHashSet", "LinkedList", "Stack", "TreeMap", "TreeSet", "Vector"
+	};
+
+	private static final String _MSG_MISSING_DIAMOND_OPERATOR =
+		"diamond.operator.missing";
+
+	private static final String _MSG_MISSING_DIAMOND_TYPES_OPERATOR =
+		"diamond.operator.types.missing";
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/util/DetailASTUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/util/DetailASTUtil.java
@@ -304,7 +304,8 @@ public class DetailASTUtil {
 		sb.append(CharPool.LESS_THAN);
 
 		List<DetailAST> typeArgumentDetailASTList = getAllChildTokens(
-			typeArgumentsDetailAST, false, TokenTypes.TYPE_ARGUMENT);
+			typeArgumentsDetailAST, includeTypeArguments,
+			TokenTypes.TYPE_ARGUMENT);
 
 		for (DetailAST typeArgumentDetailAST : typeArgumentDetailASTList) {
 			FullIdent typeArgumenIdent = FullIdent.createFullIdentBelow(

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -223,6 +223,10 @@
 		<module name="com.liferay.source.formatter.checkstyle.checks.MissingAuthorCheck">
 			<message key="author.missing" value="Missing author" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.checks.MissingDiamondOperatorCheck">
+			<message key="diamond.operator.missing" value="Missing diamond operator ''&lt;&gt;'' for ''{0}''" />
+			<message key="diamond.operator.types.missing" value="Missing types ''{0}'' for using diamond operator ''&lt;&gt;'' with anonymous inner classes for ''{1}''" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.checks.MissingEmptyLineCheck">
 			<message key="empty.line.missing.after.method.call" value="There should be an empty line after line ''{0}''" />
 			<message key="empty.line.missing.after.variable.definition" value="There should be an empty line after variable definition of type ''{0}''" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
@@ -298,6 +298,36 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testMissingDiamondOperator() throws Exception {
+		test("MissingDiamondOperator.testjava",
+			new String[] {
+				"Missing diamond operator '<>' for 'ArrayList'",
+				"Missing types '<String, String>' for using diamond operator '<>' with anonymous inner classes for 'ArrayList'",
+				"Missing diamond operator '<>' for 'ConcurrentHashMap'",
+				"Missing diamond operator '<>' for 'ConcurrentSkipListMap'",
+				"Missing diamond operator '<>' for 'ConcurrentSkipListSet'",
+				"Missing diamond operator '<>' for 'CopyOnWriteArraySet'",
+				"Missing types '<Position, String>' for using diamond operator '<>' with anonymous inner classes for 'EnumMap'",
+				"Missing diamond operator '<>' for 'HashMap'",
+				"Missing types '<String, String>' for using diamond operator '<>' with anonymous inner classes for 'HashMap'",
+				"Missing diamond operator '<>' for 'HashSet'",
+				"Missing diamond operator '<>' for 'Hashtable'",
+				"Missing diamond operator '<>' for 'IdentityHashMap'",
+				"Missing diamond operator '<>' for 'LinkedHashMap'",
+				"Missing diamond operator '<>' for 'LinkedHashSet'",
+				"Missing diamond operator '<>' for 'LinkedList'",
+				"Missing diamond operator '<>' for 'Stack'",
+				"Missing diamond operator '<>' for 'TreeMap'",
+				"Missing diamond operator '<>' for 'TreeSet'",
+				"Missing diamond operator '<>' for 'Vector'"
+			},
+			new Integer[] {
+				45, 47, 53, 55, 57, 59, 61, 68, 70, 76, 78, 80, 83, 85, 87, 89,
+				91, 93, 95
+			});
+	}
+
+	@Test
 	public void testMissingSerialVersionUID() throws Exception {
 		test(
 			"MissingSerialVersionUID.testjava",

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java
@@ -302,14 +302,17 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 		test("MissingDiamondOperator.testjava",
 			new String[] {
 				"Missing diamond operator '<>' for 'ArrayList'",
-				"Missing types '<String, String>' for using diamond operator '<>' with anonymous inner classes for 'ArrayList'",
+				"Missing types '<String, String>' for using diamond operator" +
+					" '<>' with anonymous inner classes for 'ArrayList'",
 				"Missing diamond operator '<>' for 'ConcurrentHashMap'",
 				"Missing diamond operator '<>' for 'ConcurrentSkipListMap'",
 				"Missing diamond operator '<>' for 'ConcurrentSkipListSet'",
 				"Missing diamond operator '<>' for 'CopyOnWriteArraySet'",
-				"Missing types '<Position, String>' for using diamond operator '<>' with anonymous inner classes for 'EnumMap'",
+				"Missing types '<Position, String>' for using diamond " +
+					"operator '<>' with anonymous inner classes for 'EnumMap'",
 				"Missing diamond operator '<>' for 'HashMap'",
-				"Missing types '<String, String>' for using diamond operator '<>' with anonymous inner classes for 'HashMap'",
+				"Missing types '<String, String>' for using diamond operator" +
+					" '<>' with anonymous inner classes for 'HashMap'",
 				"Missing diamond operator '<>' for 'HashSet'",
 				"Missing diamond operator '<>' for 'Hashtable'",
 				"Missing diamond operator '<>' for 'IdentityHashMap'",
@@ -319,11 +322,18 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 				"Missing diamond operator '<>' for 'Stack'",
 				"Missing diamond operator '<>' for 'TreeMap'",
 				"Missing diamond operator '<>' for 'TreeSet'",
-				"Missing diamond operator '<>' for 'Vector'"
+				"Missing diamond operator '<>' for 'Vector'",
+				"Missing types '<Map<String, String>>' for using diamond " +
+					"operator '<>' with anonymous inner classes for " +
+						"'ArrayList'",
+				"Missing types '<String, String>' for using diamond operator" +
+					" '<>' with anonymous inner classes for 'HashMap'",
+				"Missing types '<String, String>' for using diamond operator" +
+					" '<>' with anonymous inner classes for 'HashMap'"
 			},
 			new Integer[] {
 				45, 47, 53, 55, 57, 59, 61, 68, 70, 76, 78, 80, 83, 85, 87, 89,
-				91, 93, 95
+				91, 93, 95, 97, 99, 110
 			});
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingDiamondOperator.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingDiamondOperator.testjava
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * @author Alan Huang
+ */
+public class MissingDiamondOperator {
+
+	public void method() {
+		List<String> arrayList1 = new ArrayList();
+
+		List<String, String> arrayList2 = new ArrayList() {
+			{
+				add("a", "b");
+			}
+		};
+
+		Map<String, String> concurrentHashMap = new ConcurrentHashMap();
+
+		Map<String, String> concurrentSkipListMap = new ConcurrentSkipListMap();
+
+		Set<String> concurrentSkipListSet = new ConcurrentSkipListSet();
+
+		Set<String> copyOnWriteArraySet = new CopyOnWriteArraySet();
+
+		EnumMap<Position, String> enumMap = new EnumMap(Position.class) {
+			{
+				put(Position.BOTTOM, "BOTTOM");
+				put(Position.TOP, "TOP");
+			}
+		};
+
+		Map<String, String> hashMap1 = new HashMap();
+
+		Map<String, String> hashMap2 = new HashMap() {
+			{
+				put("a", "b");
+			}
+		};
+
+		Set<String> hashSet = new HashSet();
+
+		Dictionary<String, Object> hashtable = new Hashtable();
+
+		Map<Object, Map<String, Object>> identityHashMap =
+			new IdentityHashMap();
+
+		Map<String, String> linkedHashMap = new LinkedHashMap();
+
+		Set<String> linkedHashSet = new LinkedHashSet();
+
+		List<String> linkedList = new LinkedList();
+
+		Stack<String> stack = new Stack();
+
+		Map<String, String> treeMap = new TreeMap();
+
+		Set<String> treeSet = new TreeSet();
+
+		Vector<String> vector = new Vector();
+
+		System.out.println(arrayList1.size());
+		System.out.println(arrayList2.size());
+		System.out.println(concurrentHashMap.size());
+		System.out.println(concurrentSkipListMap.size());
+		System.out.println(concurrentSkipListSet.size());
+		System.out.println(copyOnWriteArraySet.size());
+		System.out.println(enumMap.size());
+		System.out.println(hashMap1.size());
+		System.out.println(hashMap2.size());
+		System.out.println(hashSet.size());
+		System.out.println(hashtable.size());
+		System.out.println(identityHashMap.size());
+		System.out.println(linkedHashMap.size());
+		System.out.println(linkedHashSet.size());
+		System.out.println(linkedList.size());
+		System.out.println(stack.size());
+		System.out.println(treeMap.size());
+		System.out.println(treeSet.size());
+		System.out.println(vector.size());
+	}
+
+	public enum Position {
+
+		BOTTOM, TOP
+
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingDiamondOperator.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MissingDiamondOperator.testjava
@@ -94,6 +94,32 @@ public class MissingDiamondOperator {
 
 		Vector<String> vector = new Vector();
 
+		List<Map<String, String>> ddmFormFieldValues = new ArrayList() {
+			{
+				Map<String, String> map1 = new HashMap() {
+					{
+						put("field1", "2");
+						put("field2", "esta é uma 'string'");
+						put("field3", "false");
+						put("field4", "11.7");
+					}
+				};
+
+				add(map1);
+
+				Map<String, String> map2 = new HashMap() {
+					{
+						put("field1", "1");
+						put("field2", "esta é uma 'string'");
+						put("field3", "");
+						put("field4", "10");
+					}
+				};
+
+				add(map2);
+			}
+		};
+
 		System.out.println(arrayList1.size());
 		System.out.println(arrayList2.size());
 		System.out.println(concurrentHashMap.size());
@@ -113,6 +139,7 @@ public class MissingDiamondOperator {
 		System.out.println(treeMap.size());
 		System.out.println(treeSet.size());
 		System.out.println(vector.size());
+		System.out.println(ddmFormFieldValues.size());
 	}
 
 	public enum Position {


### PR DESCRIPTION
Hi Hugo,

This new check `MissingDiamondOperatorCheck` can print out two kind of warning messages.

1.
For `List<String> arrayList1 = new ArrayList();`
Message: `Missing diamond operator '<>' for 'ArrayList'`

-------------------------------------
2.
For
```
    private static final EnumMap<Position, String> _webKeysEnumMap =
        new EnumMap(Position.class) {
            {
                put(Position.BOTTOM, WebKeys.PAGE_BODY_BOTTOM);
                put(Position.TOP, WebKeys.PAGE_TOP);
            }
    };

```
Message `Missing types '<Position, String>' for using diamond operator '<>' with anonymous inner classes for 'EnumMap'`

-------------------------------------

But this check doesn't handle this case, because this case will cause java compile error, SF doesn't need to do for that.
```
     [exec] /opt/dev/projects/github/liferay-portal/modules/apps/frontend-taglib/frontend-taglib-util/src/main/java/com/liferay/frontend/taglib/util/TagResourceHandler.java:180: error: cannot infer type arguments for EnumMap<K,V>
     [exec] 		new EnumMap<>(Position.class) \{
     [exec] 		           ^
     [exec]   reason: cannot use '<>' with anonymous inner classes
     [exec]   where K,V are type-variables:
     [exec]     K extends Enum<K> declared in class EnumMap
     [exec]     V extends Object declared in class EnumMap
     [exec] 1 error
```
