### PR TITLE
LPS-101214

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
@@ -61,7 +61,9 @@ import ${import};
 
 <#if entity.hasRemoteService() && !stringUtil.equals(sessionTypeName, "Local")>
 	@AccessControlled
-	@JSONWebService
+	<#if entity.isJsonEnabled()>
+		@JSONWebService
+	</#if>
 </#if>
 
 <#if !dependencyInjectorDS>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101214

Given that `remote-service=true` implies `json-enabled=true`, it makes sense to me that `json-enabled=false` should also imply that the `JSONWebService` annotation gets removed.

However, I'm not 100% sure. Since the change is small, I thought a pull request would be the easiest way to open this discussion.

**Note**: Currently, only one service builder service in Liferay would be affected by this change: [OAuth2Authorization](https://github.com/liferay/liferay-portal/blob/master/modules/apps/oauth2-provider/oauth2-provider-service/service.xml#L80).