### PR TITLE
LPS-84119 Add YMLLongLinesCheck

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
@@ -39,7 +39,7 @@ public class YMLLongLinesCheck extends BaseFileCheck {
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				lineNumber++;
 
-				_checkMaxLineLength(line, fileName, lineNumber);
+				_checkMaxLineLength(line, fileName, absolutePath, lineNumber);
 			}
 		}
 
@@ -47,15 +47,23 @@ public class YMLLongLinesCheck extends BaseFileCheck {
 	}
 
 	private void _checkMaxLineLength(
-		String line, String fileName, int lineNumber) {
+		String line, String fileName, String absolutePath, int lineNumber) {
 
-		int lineLength = getLineLength(line);
+		int maxLineLength;
 
-		if (lineLength <= getMaxLineLength()) {
+		try {
+			maxLineLength = Integer.parseInt(
+				getAttributeValue(_MAX_LINE_LENGTH, absolutePath));
+		}
+		catch (Exception e) {
 			return;
 		}
 
-		addMessage(fileName, "> " + getMaxLineLength(), lineNumber);
+		if (getLineLength(line) > maxLineLength) {
+			addMessage(fileName, "> " + maxLineLength, lineNumber);
+		}
 	}
+
+	private static final String _MAX_LINE_LENGTH = "maxLineLength";
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checks;
+
+import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
+import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+
+import java.io.IOException;
+
+/**
+ * @author Alan Huang
+ */
+public class YMLLongLinesCheck extends BaseFileCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws IOException {
+
+		try (UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(new UnsyncStringReader(content))) {
+
+			int lineNumber = 0;
+
+			String line = null;
+
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				lineNumber++;
+
+				_checkMaxLineLength(line, fileName, lineNumber);
+			}
+		}
+
+		return content;
+	}
+
+	private void _checkMaxLineLength(
+		String line, String fileName, int lineNumber) {
+
+		int lineLength = getLineLength(line);
+
+		if (lineLength <= getMaxLineLength()) {
+			return;
+		}
+
+		addMessage(fileName, "> " + getMaxLineLength(), lineNumber);
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLLongLinesCheck.java
@@ -37,6 +37,10 @@ public class YMLLongLinesCheck extends BaseFileCheck {
 			String line = null;
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
+				if (line.matches(" +-")) {
+					continue;
+				}
+
 				lineNumber++;
 
 				_checkMaxLineLength(line, fileName, absolutePath, lineNumber);

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -495,7 +495,9 @@
 	<source-processor name="YMLSourceProcessor">
 		<check name="YMLDefinitionOrderCheck" />
 		<check name="YMLEmptyLinesCheck" />
-		<check name="YMLLongLinesCheck" />
+		<check name="YMLLongLinesCheck">
+			<property name="maxLineLength" value="120" />
+		</check>
 		<check name="YMLWhitespaceCheck">
 			<property name="allowLeadingSpaces" value="true" />
 		</check>

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -495,6 +495,7 @@
 	<source-processor name="YMLSourceProcessor">
 		<check name="YMLDefinitionOrderCheck" />
 		<check name="YMLEmptyLinesCheck" />
+		<check name="YMLLongLinesCheck" />
 		<check name="YMLWhitespaceCheck">
 			<property name="allowLeadingSpaces" value="true" />
 		</check>

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/YMLSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/YMLSourceProcessorTest.java
@@ -22,6 +22,11 @@ import org.junit.Test;
 public class YMLSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
+	public void testExceedMaxLineLength() throws Exception {
+		test("ExceedMaxLineLength.testyaml", "> 120", 18);
+	}
+
+	@Test
 	public void testIncorrectEmptyLines() throws Exception {
 		test("IncorrectEmptyLines.testyaml");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ExceedMaxLineLength.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ExceedMaxLineLength.testyaml
@@ -1,0 +1,21 @@
+components:
+    schemas:
+        Role:
+            description: Represents a relationship between a user and a company or site. This follows the [`Role`]
+               (https://www.schema.org/Role) specification.
+            properties:
+                creator:
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    description: The role's creator.
+                    readOnly: true
+                dateCreated:
+                    description: The role's creation date.
+                    format: date-time
+                    readOnly: true
+                    type: string
+                dateModified:
+                    description: This is a exceed MaxLineLength description, last time any of the role's fields were changed.
+                    format: date-time
+                    readOnly: true
+                    type: string

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StyleBlock.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StyleBlock.testyaml
@@ -27,11 +27,11 @@ components:
                     type: string
                 domain:
                     type: string
-                    description: "Gets a user's segments. The set of available headers are: Host (string), Accept-Language
-                        (string), User-Agent (string), X-Browser (string), X-Cookies (collection string), X-Device-Brand
-                        (string), X-Device-Model (string), X-Device-Screen-Resolution-Height (double),
-                        X-Device-Screen-Resolution-Width (double), X-Last-Sign-In-Date-Time (date time) and X-Signed-In
-                        (boolean). Local date will be always present in the request."
+                    description: "Gets a user's segments. The set of available headers are: Host (string),
+                        Accept-Language (string), User-Agent (string), X-Browser (string), X-Cookies (collection
+                        string), X-Device-Brand (string), X-Device-Model (string), X-Device-Screen-Resolution-Height
+                        (double), X-Device-Screen-Resolution-Width (double), X-Last-Sign-In-Date-Time (date time) and
+                        X-Signed-In (boolean). Local date will be always present in the request."
 info:
     version:
       ver-name: v1

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/StyleBlock.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/StyleBlock.testyaml
@@ -26,11 +26,11 @@ components:
                     readOnly: true
                     type: string
                 domain:
-                    description: "Gets a user's segments. The set of available headers are: Host (string), Accept-Language
-                        (string), User-Agent (string), X-Browser (string), X-Cookies (collection string), X-Device-Brand
-                        (string), X-Device-Model (string), X-Device-Screen-Resolution-Height (double),
-                        X-Device-Screen-Resolution-Width (double), X-Last-Sign-In-Date-Time (date time) and X-Signed-In
-                        (boolean). Local date will be always present in the request."
+                    description: "Gets a user's segments. The set of available headers are: Host (string),
+                        Accept-Language (string), User-Agent (string), X-Browser (string), X-Cookies (collection
+                        string), X-Device-Brand (string), X-Device-Model (string), X-Device-Screen-Resolution-Height
+                        (double), X-Device-Screen-Resolution-Width (double), X-Last-Sign-In-Date-Time (date time) and
+                        X-Signed-In (boolean). Local date will be always present in the request."
                     type: string
 info:
     description: |-

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -166,5 +166,12 @@
 		<!-- Temporary suppressions for frontend React setup (LPS-99901, wincent) -->
 
 		<suppress checks="JSONPackageJSONCheck" files="modules/apps/frontend-js/frontend-js-react-web/package\.json" />
+
+		<!-- Temporary suppressions for YMLLongLinesCheck (Alan Huang) -->
+
+		<suppress checks="YMLLongLinesCheck" files="modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi\.yaml" />
+		<suppress checks="YMLLongLinesCheck" files="modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi\.yaml" />
+		<suppress checks="YMLLongLinesCheck" files="modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi\.yaml" />
+		<suppress checks="YMLLongLinesCheck" files="modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi\.yaml" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
Hi Hugo,

**Issue:** https://github.com/brianchandotcom/liferay-portal/pull/79231

**My changes:**
1. I created YMLLongLinesCheck, set 120 to max line length for yaml, I think 80 is too short for yaml.
2. About my commit ["Skip the temporary lines...."](https://github.com/hhuijser/liferay-portal/commit/5d21a719efe101e44aa1aa4c1ea2c327e078fc46),
Before `format()` in [YMLSourceProcessor](https://github.com/hhuijser/liferay-portal/blob/5d21a719efe101e44aa1aa4c1ea2c327e078fc46/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/YMLSourceProcessor.java#L55-L62), there is `_preProcess()` to do some temporary changes for yaml, in order to easily do other `YML * Check`, when all `YML * Check` are finished, `_postProcess()` will revert what `_preProcess()` did.

Basically, `_preProcess()` will change:
```
            parameters:
                - in: path
                  name: userAccountId
                  required: true
```
to
```
            parameters:
                - 
                  in: path
                  name: userAccountId
                  required: true

```
