### PR TITLE
LPS-103872 Add SF rules for portal.properties

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesEmptyLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesEmptyLinesCheck.java
@@ -71,7 +71,7 @@ public class PropertiesEmptyLinesCheck extends BaseFileCheck {
 
 		if (matcher.find()) {
 			return StringUtil.replaceFirst(
-				content, "\n", "\n\n", matcher.start());
+				content, "\n", "\n\n", matcher.start(1));
 		}
 
 		return content;
@@ -85,6 +85,6 @@ public class PropertiesEmptyLinesCheck extends BaseFileCheck {
 	private static final Pattern _missingEmptyLineBeforeCategoryPattern =
 		Pattern.compile("\n([^\n#]|#[^#]).*\n##\n");
 	private static final Pattern _missingEmptyLineBeforeMultiLinePattern =
-		Pattern.compile("[^#\n\\\\]\n *[^ #\n].*\\\\\n");
+		Pattern.compile("\n *(?![ #]).+(\n(?!\n) *[^#].*=\\\\\n)");
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
@@ -136,6 +136,10 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 				trimmedLine = StringUtil.trim(trimmedLine);
 			}
 
+			if (line.matches(StringPool.FOUR_SPACES + " +.*")) {
+				continue;
+			}
+
 			int pos = trimmedLine.indexOf(StringPool.EQUAL);
 
 			if (pos == -1) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +52,8 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 
 			return content;
 		}
+
+		content = _sortSameProperties(content);
 
 		return _formatPortalProperties(content);
 	}
@@ -152,6 +155,37 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 		return environmentVariables;
 	}
 
+	private String _sortSameProperties(String content) {
+		Matcher matcher = _samePropertyNamesPattern.matcher(content);
+
+		while (matcher.find()) {
+			String sameProperties = content.substring(
+				matcher.start(1), matcher.end() - 1);
+
+			String[] lines = sameProperties.split("\n");
+
+			Arrays.sort(lines);
+
+			StringBundler sb = new StringBundler();
+
+			for (String line : lines) {
+				sb.append(line);
+				sb.append("\n");
+			}
+
+			String newContent = sb.toString();
+
+			if (newContent.endsWith("\n")) {
+				newContent = newContent.substring(0, newContent.length() - 1);
+			}
+
+			return StringUtil.replaceFirst(
+				content, sameProperties, newContent, matcher.start());
+		}
+
+		return content;
+	}
+
 	private static final String _ENV_OVERRIDE_PREFIX = "LIFERAY_";
 
 	private static final Map<Character, String> _charPoolChars =
@@ -177,5 +211,7 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 
 	private static final Pattern _pattern = Pattern.compile(
 		"\n((    #( .*)?\n)*)((    ( |#?\\w).*\n)+)");
+	private static final Pattern _samePropertyNamesPattern = Pattern.compile(
+		"\n(    )#?([^=]+=).*(\n\\1#?\\2.*)+");
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
@@ -162,6 +162,12 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 			String sameProperties = content.substring(
 				matcher.start(1), matcher.end() - 1);
 
+			if (sameProperties.startsWith(
+					StringPool.FOUR_SPACES + "include-and-override")) {
+
+				continue;
+			}
+
 			String[] lines = sameProperties.split("\n");
 
 			Arrays.sort(lines);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
@@ -160,7 +160,7 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 
 		while (matcher.find()) {
 			String sameProperties = content.substring(
-				matcher.start(1), matcher.end() - 1);
+				matcher.start(1), matcher.end());
 
 			if (sameProperties.startsWith(
 					StringPool.FOUR_SPACES + "include-and-override")) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalEnvironmentVariablesCheck.java
@@ -185,8 +185,10 @@ public class PropertiesPortalEnvironmentVariablesCheck extends BaseFileCheck {
 				newContent = newContent.substring(0, newContent.length() - 1);
 			}
 
-			return StringUtil.replaceFirst(
-				content, sameProperties, newContent, matcher.start());
+			if (!sameProperties.equals(newContent)) {
+				return StringUtil.replaceFirst(
+					content, sameProperties, newContent, matcher.start());
+			}
 		}
 
 		return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
@@ -41,7 +41,7 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 		throws IOException {
 
 		if (((isPortalSource() || isSubrepository()) &&
-			 fileName.matches(".*/portal(-[^-]+)*\\.properties")) ||
+			 fileName.matches(".*/portal(-[^-/]+)*\\.properties")) ||
 			(!isPortalSource() && !isSubrepository() &&
 			 fileName.endsWith("portal.properties"))) {
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
@@ -118,7 +118,7 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				if (line.matches(
-						StringPool.FOUR_SPACES + "(?!#).+?=[^,]+(,[^,]+)+")) {
+						StringPool.FOUR_SPACES + "[^# ]+?=[^,]+(,[^,]+)+")) {
 
 					String trimmedLine = StringUtil.trimLeading(line);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
@@ -118,7 +118,8 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				if (line.matches(
-						StringPool.FOUR_SPACES + "[^# ]+?=[^,]+(,[^,]+)+")) {
+						StringPool.FOUR_SPACES +
+							"[^# ]+?=[^,]+(,[^ ][^,]+)+")) {
 
 					String trimmedLine = StringUtil.trimLeading(line);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesPortalFileCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.checks;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
@@ -24,6 +25,8 @@ import com.liferay.source.formatter.PropertiesSourceProcessor;
 import java.io.IOException;
 
 import java.net.URL;
+
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 
@@ -43,6 +46,8 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 			 fileName.endsWith("portal.properties"))) {
 
 			_checkPortalProperties(fileName, absolutePath, content);
+
+			content = _formatPortalProperties(absolutePath, content);
 		}
 
 		return content;
@@ -98,6 +103,49 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 		}
 	}
 
+	private String _formatPortalProperties(String absolutePath, String content)
+		throws IOException {
+
+		List<String> allowedSingleLinePropertyKeys = getAttributeValues(
+			_ALLOWED_SINGLE_LINE_PROPERTY_KEYS, absolutePath);
+
+		StringBundler sb = new StringBundler();
+
+		try (UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(new UnsyncStringReader(content))) {
+
+			String line = null;
+
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				if (line.matches(
+						StringPool.FOUR_SPACES + "(?!#).+?=[^,]+(,[^,]+)+")) {
+
+					String trimmedLine = StringUtil.trimLeading(line);
+
+					if (!allowedSingleLinePropertyKeys.contains(
+							trimmedLine.substring(
+								0, trimmedLine.indexOf("=")))) {
+
+						line = line.replaceFirst("=", "=\\\\\n        ");
+
+						line = line.replaceAll(",", ",\\\\\n        ");
+					}
+				}
+
+				sb.append(line);
+				sb.append("\n");
+			}
+		}
+
+		content = sb.toString();
+
+		if (content.endsWith("\n")) {
+			content = content.substring(0, content.length() - 1);
+		}
+
+		return content;
+	}
+
 	private synchronized String _getPortalPortalPropertiesContent(
 			String absolutePath)
 		throws IOException {
@@ -131,6 +179,9 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 
 		return _portalPortalPropertiesContent;
 	}
+
+	private static final String _ALLOWED_SINGLE_LINE_PROPERTY_KEYS =
+		"allowedSingleLinePropertyKeys";
 
 	private String _portalPortalPropertiesContent;
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4279,9 +4279,7 @@
     # processes the request. The post-service events process after Struts
     # processes the request.
     #
-    # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_POST
     # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_PRE
-    # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_PRE_PERIOD_ERROR_PERIOD_PAGE
     #
     servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction
     #servlet.service.events.pre=com.liferay.portal.events.LogMemoryUsageAction,com.liferay.portal.events.LogThreadCountAction,com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction
@@ -4289,25 +4287,36 @@
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.RandomLayoutAction
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.RandomLookAndFeelAction
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.SecureRequestAction
+
+    #
+    # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_POST
+    # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_PRE_PERIOD_ERROR_PERIOD_PAGE
+    #
     servlet.service.events.pre.error.page=/common/error.jsp
     servlet.service.events.post=com.liferay.portal.events.ServicePostAction
 
     #
     # Login Event
     #
-    # Env: LIFERAY_LOGIN_PERIOD_EVENTS_PERIOD_POST
     # Env: LIFERAY_LOGIN_PERIOD_EVENTS_PERIOD_PRE
     #
     login.events.pre=com.liferay.portal.events.LoginPreAction
+
+    #
+    # Env: LIFERAY_LOGIN_PERIOD_EVENTS_PERIOD_POST
+    #
     login.events.post=com.liferay.portal.events.ChannelLoginPostAction,com.liferay.portal.events.DefaultLandingPageAction,com.liferay.portal.events.LoginPostAction
 
     #
     # Logout Event
     #
-    # Env: LIFERAY_LOGOUT_PERIOD_EVENTS_PERIOD_POST
     # Env: LIFERAY_LOGOUT_PERIOD_EVENTS_PERIOD_PRE
     #
     logout.events.pre=com.liferay.portal.events.LogoutPreAction
+
+    #
+    # Env: LIFERAY_LOGOUT_PERIOD_EVENTS_PERIOD_POST
+    #
     logout.events.post=com.liferay.portal.events.LogoutPostAction,com.liferay.portal.events.DefaultLogoutPageAction
     #logout.events.post=com.liferay.portal.events.LogoutPostAction,com.liferay.portal.events.GarbageCollectorAction
 
@@ -8381,13 +8390,22 @@
     # must be limited by what is supported by OpenOffice.
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_DRAWING_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
     #
     openoffice.conversion.source.extensions[drawing]=odg
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
+    #
     openoffice.conversion.source.extensions[presentation]=odp,ppt,pptx,sxi
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
+    #
     openoffice.conversion.source.extensions[spreadsheet]=csv,ods,sxc,tsv,xls,xlsx
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
+    #
     openoffice.conversion.source.extensions[text]=doc,docx,html,odt,rtf,sxw,txt,wpd
 
     #
@@ -8395,13 +8413,22 @@
     # be limited by what is supported by OpenOffice.
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_DRAWING_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
-    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
     #
     openoffice.conversion.target.extensions[drawing]=pdf,svg,swf
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
+    #
     openoffice.conversion.target.extensions[presentation]=odp,pdf,ppt,swf,sxi
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
+    #
     openoffice.conversion.target.extensions[spreadsheet]=csv,ods,pdf,sxc,tsv,xls
+
+    #
+    # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
+    #
     openoffice.conversion.target.extensions[text]=doc,odt,pdf,rtf,sxw,txt
 
 ##
@@ -9490,7 +9517,6 @@
     # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_NAME_OPENBRACKET__NUMBER6__NUMBER4__MINUS_LINUX_CLOSEBRACKET_
     # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_NAME_OPENBRACKET__NUMBER6__NUMBER4__MINUS_MAC_CLOSEBRACKET_
     # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_NAME_OPENBRACKET__NUMBER6__NUMBER4__MINUS_WIN_CLOSEBRACKET_
-    # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_OPTIONS
     # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_URL
     #
     xuggler.jar.file[32-linux]=xuggle-xuggler-arch-i686-pc-linux-gnu.jar
@@ -9505,8 +9531,12 @@
     xuggler.jar.name[64-linux]=Linux 64-bit JVM (with GNU libc v6)
     xuggler.jar.name[64-mac]=Mac OS X 10.7 64-bit JVM
     xuggler.jar.name[64-win]=Windows 64-bit JVM
-    xuggler.jar.options=32-linux,32-mac,32-win,64-linux,64-mac,64-win
     xuggler.jar.url=https://files.liferay.com/mirrors/xuggle.googlecode.com/svn/trunk/repo/share/java/xuggle/xuggle-xuggler/5.4/
+
+    #
+    # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_OPTIONS
+    #
+    xuggler.jar.options=32-linux,32-mac,32-win,64-linux,64-mac,64-win
 
     #
     # Set these to customize the ffmpeg preset settings used by Xuggler when
@@ -10082,9 +10112,12 @@
     # "main.servlet.https.required" on how to protect this servlet.
     #
     # Env: LIFERAY_ATOM_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
-    # Env: LIFERAY_ATOM_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
     #
     atom.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+
+    #
+    # Env: LIFERAY_ATOM_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
+    #
     atom.servlet.https.required=false
 
 ##
@@ -10096,9 +10129,12 @@
     # "main.servlet.https.required" on how to protect this servlet.
     #
     # Env: LIFERAY_AXIS_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
-    # Env: LIFERAY_AXIS_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
     #
     axis.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+
+    #
+    # Env: LIFERAY_AXIS_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
+    #
     axis.servlet.https.required=false
 
 ##
@@ -10173,9 +10209,12 @@
     # "main.servlet.https.required" on how to protect this servlet.
     #
     # Env: LIFERAY_TUNNEL_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
-    # Env: LIFERAY_TUNNEL_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
     #
     tunnel.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+
+    #
+    # Env: LIFERAY_TUNNEL_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
+    #
     tunnel.servlet.https.required=false
 
 ##
@@ -10840,26 +10879,53 @@
     # documents can be found in:
     # /_unstyled/images/file_system/large/document.png.
     #
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_COMPRESSED_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_DOCUMENT_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_FLASH_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_IMAGE_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_MUSIC_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PDF_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
-    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_VIDEO_CLOSEBRACKET_
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_NAMES
     #
     dl.file.generic.names=compressed,document,flash,image,music,pdf,presentation,spreadsheet,video
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_COMPRESSED_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[compressed]=lar,rar,zip
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_DOCUMENT_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[document]=doc,docx,pages,rtf,odt
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_FLASH_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[flash]=flv,swf
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_IMAGE_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[image]=bmp,gif,jpeg,jpg,odg,png,svg
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_MUSIC_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[music]=acc,mid,mp3,oga,ogg,wav,wma
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PDF_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[pdf]=pdf
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[presentation]=key,keynote,odp,pps,ppt,pptx
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[spreadsheet]=csv,numbers,ods,xls,xlsx
+
+    #
+    # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_VIDEO_CLOSEBRACKET_
+    #
     dl.file.generic.extensions[video]=avi,m4v,mov,mp4,mpg,ogv,qt,rm,wmv
 
     #
@@ -11392,9 +11458,12 @@
     # board format.
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_MESSAGE_PERIOD_FORMATS
-    # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_MESSAGE_PERIOD_FORMATS_PERIOD_DEFAULT
     #
     message.boards.message.formats=bbcode,html
+
+    #
+    # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_MESSAGE_PERIOD_FORMATS_PERIOD_DEFAULT
+    #
     message.boards.message.formats.default=bbcode
 
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -68,9 +68,9 @@
     #
     # Env: LIFERAY_PORTAL_PERIOD_INSTANCE_PERIOD_PROTOCOL
     #
-    portal.instance.protocol=
     #portal.instance.protocol=http
     #portal.instance.protocol=https
+    portal.instance.protocol=
 
     #
     # Set the application server's hostname and port for the protocol specified
@@ -83,9 +83,9 @@
     #
     # Env: LIFERAY_PORTAL_PERIOD_INSTANCE_PERIOD_INET_PERIOD_SOCKET_PERIOD_ADDRESS
     #
-    portal.instance.inet.socket.address=
     #portal.instance.inet.socket.address=localhost:8080
     #portal.instance.inet.socket.address=localhost:8443
+    portal.instance.inet.socket.address=
 
     #
     # Set this property if the application server is served behind a proxy and
@@ -455,7 +455,12 @@
     #
     # Env: LIFERAY_PLUGIN_PERIOD_TYPES
     #
-    plugin.types=portlet,theme,layout-template,hook,web
+    plugin.types=\
+        portlet,\
+        theme,\
+        layout-template,\
+        hook,\
+        web
 
     #
     # Input a list of Liferay plugin repositories separated by \n characters.
@@ -1319,8 +1324,8 @@
     #
     #jdbc.default.liferay.pool.provider=c3po
     #jdbc.default.liferay.pool.provider=dbcp
-    jdbc.default.liferay.pool.provider=hikaricp
     #jdbc.default.liferay.pool.provider=tomcat
+    jdbc.default.liferay.pool.provider=hikaricp
 
     #
     # The following properties will be read by C3PO if Liferay is configured to
@@ -1606,7 +1611,11 @@
     #
     # Env: LIFERAY_TRANSACTIONAL_PERIOD_CACHE_PERIOD_NAMES
     #
-    transactional.cache.names=com.liferay.portal.kernel.dao.orm.EntityCache*,com.liferay.portal.kernel.dao.orm.FinderCache*,com.liferay.portal.kernel.service.persistence.impl.TableMapper-*,com.liferay.portlet.PortalPreferencesWrapperCacheUtil
+    transactional.cache.names=\
+        com.liferay.portal.kernel.dao.orm.EntityCache*,\
+        com.liferay.portal.kernel.dao.orm.FinderCache*,\
+        com.liferay.portal.kernel.service.persistence.impl.TableMapper-*,\
+        com.liferay.portlet.PortalPreferencesWrapperCacheUtil
 
 ##
 ## Ehcache
@@ -1983,10 +1992,10 @@
     #
     # Env: LIFERAY_COMPANY_PERIOD_ENCRYPTION_PERIOD_ALGORITHM
     #
-    company.encryption.algorithm=AES
     #company.encryption.algorithm=Blowfish
     #company.encryption.algorithm=DES
     #company.encryption.algorithm=DESede
+    company.encryption.algorithm=AES
 
     #
     # Set this to define the size used for the company wide encryption key. If
@@ -2001,12 +2010,12 @@
     #
     # Env: LIFERAY_COMPANY_PERIOD_ENCRYPTION_PERIOD_KEY_PERIOD_SIZE
     #
-    #company.encryption.key.size=56
-    company.encryption.key.size=128
     #company.encryption.key.size=168
     #company.encryption.key.size=256
     #company.encryption.key.size=384
     #company.encryption.key.size=512
+    #company.encryption.key.size=56
+    company.encryption.key.size=128
 
     #
     # The login field is prepopulated with the company's domain name if the
@@ -2023,9 +2032,9 @@
     #
     # Env: LIFERAY_COMPANY_PERIOD_SECURITY_PERIOD_AUTH_PERIOD_TYPE
     #
-    company.security.auth.type=emailAddress
     #company.security.auth.type=screenName
     #company.security.auth.type=userId
+    company.security.auth.type=emailAddress
 
     #
     # Set this to true to ensure users login with https. If this is set to true
@@ -2281,7 +2290,9 @@
     #
     # Env: LIFERAY_USERS_PERIOD_LIST_PERIOD_VIEWS
     #
-    users.list.views=tree,flat-user-groups
+    users.list.views=\
+        tree,\
+        flat-user-groups
 
     #
     # Set this to true to enable reminder queries that are used to help reset a
@@ -2306,7 +2317,12 @@
     #
     # Env: LIFERAY_USERS_PERIOD_REMINDER_PERIOD_QUERIES_PERIOD_QUESTIONS
     #
-    users.reminder.queries.questions=what-is-your-primary-frequent-flyer-number,what-is-your-library-card-number,what-was-your-first-phone-number,what-was-your-first-teacher's-name,what-is-your-father's-middle-name
+    users.reminder.queries.questions=\
+        what-is-your-primary-frequent-flyer-number,\
+        what-is-your-library-card-number,\
+        what-was-your-first-phone-number,\
+        what-was-your-first-teacher's-name,\
+        what-is-your-father's-middle-name
 
     #
     # Set this to true to search users from the index. Set this to false to
@@ -2335,7 +2351,9 @@
     #
     # Env: LIFERAY_USERS_PERIOD_EXPORT_PERIOD_CSV_PERIOD_FIELDS
     #
-    users.export.csv.fields=fullName,emailAddress
+    users.export.csv.fields=\
+        fullName,\
+        emailAddress
 
     #
     # Set the friendly URL to a user's profile page. If none is specified, the
@@ -2673,8 +2691,8 @@
     #
     # Env: LIFERAY_MEMBERSHIP_PERIOD_POLICY_PERIOD_SITES
     #
-    #membership.policy.sites=com.liferay.portal.security.membershippolicy.DummySiteMembershipPolicy
     #membership.policy.sites=com.liferay.portal.security.membershippolicy.DefaultSiteMembershipPolicy
+    #membership.policy.sites=com.liferay.portal.security.membershippolicy.DummySiteMembershipPolicy
 
     #
     # Input a class name that implements
@@ -2716,7 +2734,57 @@
     #
     # Env: LIFERAY_LOCALES
     #
-    locales=ar_SA,eu_ES,bg_BG,ca_AD,ca_ES,zh_CN,zh_TW,hr_HR,cs_CZ,da_DK,nl_NL,nl_BE,en_US,en_GB,en_AU,et_EE,fi_FI,fr_FR,fr_CA,gl_ES,de_DE,el_GR,iw_IL,hi_IN,hu_HU,in_ID,it_IT,ja_JP,kk_KZ,ko_KR,lo_LA,lt_LT,nb_NO,fa_IR,pl_PL,pt_BR,pt_PT,ro_RO,ru_RU,sr_RS,sr_RS_latin,sl_SI,sk_SK,es_ES,sv_SE,ta_IN,th_TH,tr_TR,uk_UA,vi_VN
+    locales=\
+        ar_SA,\
+        eu_ES,\
+        bg_BG,\
+        ca_AD,\
+        ca_ES,\
+        zh_CN,\
+        zh_TW,\
+        hr_HR,\
+        cs_CZ,\
+        da_DK,\
+        nl_NL,\
+        nl_BE,\
+        en_US,\
+        en_GB,\
+        en_AU,\
+        et_EE,\
+        fi_FI,\
+        fr_FR,\
+        fr_CA,\
+        gl_ES,\
+        de_DE,\
+        el_GR,\
+        iw_IL,\
+        hi_IN,\
+        hu_HU,\
+        in_ID,\
+        it_IT,\
+        ja_JP,\
+        kk_KZ,\
+        ko_KR,\
+        lo_LA,\
+        lt_LT,\
+        nb_NO,\
+        fa_IR,\
+        pl_PL,\
+        pt_BR,\
+        pt_PT,\
+        ro_RO,\
+        ru_RU,\
+        sr_RS,\
+        sr_RS_latin,\
+        sl_SI,\
+        sk_SK,\
+        es_ES,\
+        sv_SE,\
+        ta_IN,\
+        th_TH,\
+        tr_TR,\
+        uk_UA,\
+        vi_VN
 
     #
     # Specify the locales that are in beta. Go to http://translate.liferay.com
@@ -2724,14 +2792,62 @@
     #
     # Env: LIFERAY_LOCALES_PERIOD_BETA
     #
-    locales.beta=eu_ES,bg_BG,ca_AD,zh_TW,hr_HR,cs_CZ,da_DK,nl_BE,en_GB,en_AU,et_EE,gl_ES,el_GR,iw_IL,hi_IN,in_ID,it_IT,kk_KZ,ko_KR,lo_LA,lt_LT,nb_NO,fa_IR,pl_PL,pt_PT,ro_RO,ru_RU,sr_RS,sr_RS_latin,sl_SI,sk_SK,ta_IN,tr_TR,uk_UA,vi_VN
+    locales.beta=\
+        eu_ES,\
+        bg_BG,\
+        ca_AD,\
+        zh_TW,\
+        hr_HR,\
+        cs_CZ,\
+        da_DK,\
+        nl_BE,\
+        en_GB,\
+        en_AU,\
+        et_EE,\
+        gl_ES,\
+        el_GR,\
+        iw_IL,\
+        hi_IN,\
+        in_ID,\
+        it_IT,\
+        kk_KZ,\
+        ko_KR,\
+        lo_LA,\
+        lt_LT,\
+        nb_NO,\
+        fa_IR,\
+        pl_PL,\
+        pt_PT,\
+        ro_RO,\
+        ru_RU,\
+        sr_RS,\
+        sr_RS_latin,\
+        sl_SI,\
+        sk_SK,\
+        ta_IN,\
+        tr_TR,\
+        uk_UA,\
+        vi_VN
 
     #
     # Specify the locales that are enabled by default.
     #
     # Env: LIFERAY_LOCALES_PERIOD_ENABLED
     #
-    locales.enabled=ar_SA,ca_ES,zh_CN,nl_NL,en_US,fi_FI,fr_FR,de_DE,hu_HU,ja_JP,pt_BR,es_ES,sv_SE
+    locales.enabled=\
+        ar_SA,\
+        ca_ES,\
+        zh_CN,\
+        nl_NL,\
+        en_US,\
+        fi_FI,\
+        fr_FR,\
+        de_DE,\
+        hu_HU,\
+        ja_JP,\
+        pt_BR,\
+        es_ES,\
+        sv_SE
 
     #
     # Specify the collator rules to be used by the CollatorUtil. These rules, if
@@ -2953,7 +3069,9 @@
     #
     # Env: LIFERAY_REQUEST_PERIOD_UNWRAP_PERIOD_PACKAGES
     #
-    request.unwrap.packages=com.liferay.,com.ibm.ws.cache.servlet.
+    request.unwrap.packages=\
+        com.liferay.,\
+        com.ibm.ws.cache.servlet.
 
 ##
 ## Session
@@ -3064,7 +3182,12 @@
     #
     # Env: LIFERAY_SESSION_PERIOD_SHARED_PERIOD_ATTRIBUTES
     #
-    session.shared.attributes=COMPANY_,LIFERAY_SHARED_,PORTLET_RENDER_PARAMETERS_,PUBLIC_RENDER_PARAMETERS_POOL_,USER_
+    session.shared.attributes=\
+        COMPANY_,\
+        LIFERAY_SHARED_,\
+        PORTLET_RENDER_PARAMETERS_,\
+        PUBLIC_RENDER_PARAMETERS_POOL_,\
+        USER_
 
     #
     # Explicitly exclude attributes that are shared from the portal to portlets.
@@ -3136,7 +3259,12 @@
     #
     # Env: LIFERAY_SESSION_PERIOD_PHISHING_PERIOD_PROTECTED_PERIOD_ATTRIBUTES
     #
-    session.phishing.protected.attributes=CAS_LOGIN,HTTPS_INITIAL,LAST_PATH,OPEN_ID_CONNECT_SESSION,SETUP_WIZARD_PASSWORD_UPDATED
+    session.phishing.protected.attributes=\
+        CAS_LOGIN,\
+        HTTPS_INITIAL,\
+        LAST_PATH,\
+        OPEN_ID_CONNECT_SESSION,\
+        SETUP_WIZARD_PASSWORD_UPDATED
 
     #
     # Set this to true to test whether users have cookie support before allowing
@@ -3193,7 +3321,9 @@
     #
     # Env: LIFERAY_SERVLET_PERIOD_SESSION_PERIOD_DESTROY_PERIOD_EVENTS
     #
-    servlet.session.destroy.events=com.liferay.portal.events.SessionDestroyAction,com.liferay.portal.events.ChannelSessionDestroyAction
+    servlet.session.destroy.events=\
+        com.liferay.portal.events.SessionDestroyAction,\
+        com.liferay.portal.events.ChannelSessionDestroyAction
 
     #
     # Set this to true to track user clicks in memory for the duration of a
@@ -3260,9 +3390,9 @@
     # Env: LIFERAY_PORTAL_PERIOD_JAAS_PERIOD_AUTH_PERIOD_TYPE
     #
     #portal.jaas.auth.type=emailAddress
+    #portal.jaas.auth.type=login
     #portal.jaas.auth.type=screenName
     portal.jaas.auth.type=userId
-    #portal.jaas.auth.type=login
 
     #
     # By default, com.liferay.portal.security.jaas.PortalLoginModule loads the
@@ -3427,7 +3557,9 @@
     #
     # Env: LIFERAY_REQUEST_PERIOD_HEADER_PERIOD_IGNORE_PERIOD_INIT_PERIOD_PARAMS
     #
-    request.header.ignore.init.params=url-regex-ignore-pattern,url-regex-pattern
+    request.header.ignore.init.params=\
+        url-regex-ignore-pattern,\
+        url-regex-pattern
 
 ##
 ## Authenticated User UUID Store
@@ -3955,12 +4087,12 @@
     #passwords.encryption.algorithm=MD2
     #passwords.encryption.algorithm=MD5
     #passwords.encryption.algorithm=NONE
-    passwords.encryption.algorithm=PBKDF2WithHmacSHA1/160/128000
     #passwords.encryption.algorithm=SHA
     #passwords.encryption.algorithm=SHA-256
     #passwords.encryption.algorithm=SHA-384
     #passwords.encryption.algorithm=SSHA
     #passwords.encryption.algorithm=UFC-CRYPT
+    passwords.encryption.algorithm=PBKDF2WithHmacSHA1/160/128000
 
     #
     # Digested passwords are encoded via base64 or hex encoding. The default is
@@ -3968,8 +4100,8 @@
     #
     # Env: LIFERAY_PASSWORDS_PERIOD_DIGEST_PERIOD_ENCODING
     #
-    passwords.digest.encoding=base64
     #passwords.digest.encoding=hex
+    passwords.digest.encoding=base64
 
     #
     # Input a class name that implements
@@ -4042,8 +4174,8 @@
     #
     # Env: LIFERAY_PASSWORDS_PERIOD_REGEXPTOOLKIT_PERIOD_PATTERN
     #
-    passwords.regexptoolkit.pattern=(?=.{4})(?:[a-zA-Z0-9]*)
     #passwords.regexptoolkit.pattern=(?=.{8})(?:[a-zA-Z0-9]*)
+    passwords.regexptoolkit.pattern=(?=.{4})(?:[a-zA-Z0-9]*)
 
     #
     # Set the length and key for generating passwords.
@@ -4216,7 +4348,9 @@
     #
     # Env: LIFERAY_GLOBAL_PERIOD_STARTUP_PERIOD_EVENTS
     #
-    global.startup.events=com.liferay.portal.events.GlobalStartupAction,com.liferay.portal.events.CryptoStartupAction
+    global.startup.events=\
+        com.liferay.portal.events.GlobalStartupAction,\
+        com.liferay.portal.events.CryptoStartupAction
 
     #
     # Application startup event that runs once for every web site instance of
@@ -4224,8 +4358,10 @@
     #
     # Env: LIFERAY_APPLICATION_PERIOD_STARTUP_PERIOD_EVENTS
     #
-    application.startup.events=com.liferay.portal.events.AppStartupAction,com.liferay.portal.events.ChannelHubAppStartupAction
     #application.startup.events=com.liferay.portal.events.AppStartupAction,com.liferay.portal.events.SampleAppStartupAction
+    application.startup.events=\
+        com.liferay.portal.events.AppStartupAction,\
+        com.liferay.portal.events.ChannelHubAppStartupAction
 
 ##
 ## Shutdown Events
@@ -4250,7 +4386,9 @@
     #
     # Env: LIFERAY_APPLICATION_PERIOD_SHUTDOWN_PERIOD_EVENTS
     #
-    application.shutdown.events=com.liferay.portal.events.AppShutdownAction,com.liferay.portal.events.ChannelHubAppShutdownAction
+    application.shutdown.events=\
+        com.liferay.portal.events.AppShutdownAction,\
+        com.liferay.portal.events.ChannelHubAppShutdownAction
 
     #
     # Programmatically kill the Java process on shutdown. This is a workaround
@@ -4281,12 +4419,14 @@
     #
     # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_PRE
     #
-    servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction
     #servlet.service.events.pre=com.liferay.portal.events.LogMemoryUsageAction,com.liferay.portal.events.LogThreadCountAction,com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction
     #servlet.service.events.pre=com.liferay.portal.events.LogSessionIdAction,com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.RandomLayoutAction
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.RandomLookAndFeelAction
     #servlet.service.events.pre=com.liferay.portal.events.ServicePreAction,com.liferay.portal.events.ThemeServicePreAction,com.liferay.portal.events.SecureRequestAction
+    servlet.service.events.pre=\
+        com.liferay.portal.events.ServicePreAction,\
+        com.liferay.portal.events.ThemeServicePreAction
 
     #
     # Env: LIFERAY_SERVLET_PERIOD_SERVICE_PERIOD_EVENTS_PERIOD_POST
@@ -4305,7 +4445,10 @@
     #
     # Env: LIFERAY_LOGIN_PERIOD_EVENTS_PERIOD_POST
     #
-    login.events.post=com.liferay.portal.events.ChannelLoginPostAction,com.liferay.portal.events.DefaultLandingPageAction,com.liferay.portal.events.LoginPostAction
+    login.events.post=\
+        com.liferay.portal.events.ChannelLoginPostAction,\
+        com.liferay.portal.events.DefaultLandingPageAction,\
+        com.liferay.portal.events.LoginPostAction
 
     #
     # Logout Event
@@ -4317,8 +4460,10 @@
     #
     # Env: LIFERAY_LOGOUT_PERIOD_EVENTS_PERIOD_POST
     #
-    logout.events.post=com.liferay.portal.events.LogoutPostAction,com.liferay.portal.events.DefaultLogoutPageAction
     #logout.events.post=com.liferay.portal.events.LogoutPostAction,com.liferay.portal.events.GarbageCollectorAction
+    logout.events.post=\
+        com.liferay.portal.events.LogoutPostAction,\
+        com.liferay.portal.events.DefaultLogoutPageAction
 
 ##
 ## Default Landing Page
@@ -4338,9 +4483,9 @@
     #
     # Env: LIFERAY_DEFAULT_PERIOD_LANDING_PERIOD_PAGE_PERIOD_PATH
     #
-    default.landing.page.path=
-    #default.landing.page.path=/web/guest/login
     #default.landing.page.path=/user/${liferay:screenName}/home
+    #default.landing.page.path=/web/guest/login
+    default.landing.page.path=
 
 ##
 ## Default Logout Page
@@ -4357,8 +4502,8 @@
     #
     # Env: LIFERAY_DEFAULT_PERIOD_LOGOUT_PERIOD_PAGE_PERIOD_PATH
     #
-    default.logout.page.path=
     #default.logout.page.path=/web/guest/logout
+    default.logout.page.path=
 
 ##
 ## Default Guest Public Layouts
@@ -5248,7 +5393,15 @@
     #
     # Env: LIFERAY_PORTLET_PERIOD_URL_PERIOD_REFRESH_PERIOD_URL_PERIOD_RESERVED_PERIOD_PARAMETERS
     #
-    portlet.url.refresh.url.reserved.parameters=password,password1,password2,pop3Password,properties--jdbc.default.password,settings--google.apps.password,smtpPassword,settings--ldap.security.credentials
+    portlet.url.refresh.url.reserved.parameters=\
+        password,\
+        password1,\
+        password2,\
+        pop3Password,\
+        properties--jdbc.default.password,\
+        settings--google.apps.password,\
+        smtpPassword,\
+        settings--ldap.security.credentials
 
     #
     # Set this to true to allow portlet URLs to be generated using
@@ -5301,7 +5454,9 @@
     #
     # Env: LIFERAY_REDIRECT_PERIOD_URL_PERIOD_IPS_PERIOD_ALLOWED
     #
-    redirect.url.ips.allowed=127.0.0.1,SERVER_IP
+    redirect.url.ips.allowed=\
+        127.0.0.1,\
+        SERVER_IP
 
 ##
 ## Images
@@ -5366,8 +5521,8 @@
     #
     # Env: LIFERAY_IMAGE_PERIOD_HOOK_PERIOD_IMPL
     #
-    #image.hook.impl=com.liferay.portal.image.DatabaseHook
     #image.hook.impl=com.liferay.portal.image.DLHook
+    #image.hook.impl=com.liferay.portal.image.DatabaseHook
     #image.hook.impl=com.liferay.portal.image.FileSystemHook
 
     #
@@ -5461,7 +5616,9 @@
     #
     # Env: LIFERAY_FIELD_PERIOD_EDITABLE_PERIOD_USER_PERIOD_TYPES
     #
-    field.editable.user.types=user-with-mx,user-without-mx
+    field.editable.user.types=\
+        user-with-mx,\
+        user-without-mx
 
     #
     # Input a list of comma delimited role names. Users associated with one of
@@ -5520,7 +5677,13 @@
     #
     # Env: LIFERAY_MIME_PERIOD_TYPES_PERIOD_CONTENT_PERIOD_DISPOSITION_PERIOD_INLINE
     #
-    mime.types.content.disposition.inline=flv,gif,jpg,pdf,png,wmv
+    mime.types.content.disposition.inline=\
+        flv,\
+        gif,\
+        jpg,\
+        pdf,\
+        png,\
+        wmv
 
     #
     # Input a list of comma delimited MIME types that are optimized for
@@ -5530,7 +5693,12 @@
     #
     # Env: LIFERAY_MIME_PERIOD_TYPES_PERIOD_WEB_PERIOD_IMAGES
     #
-    mime.types.web.images=image/gif,image/jpeg,image/pjpeg,image/png,image/x-png
+    mime.types.web.images=\
+        image/gif,\
+        image/jpeg,\
+        image/pjpeg,\
+        image/png,\
+        image/x-png
 
 ##
 ## Browser Cache
@@ -5762,7 +5930,9 @@
     #
     # Env: LIFERAY_INDEX_PERIOD_SEARCH_PERIOD_SPELL_PERIOD_CHECKER_PERIOD_SUPPORTED_PERIOD_LOCALES
     #
-    index.search.spell.checker.supported.locales=en_US,es_ES
+    index.search.spell.checker.supported.locales=\
+        en_US,\
+        es_ES
 
     #
     # Specify the maximum queue size of the index search writer. Set this to a
@@ -5848,7 +6018,13 @@
     #
     # Env: LIFERAY_INDEX_PERIOD_SORTABLE_PERIOD_TEXT_PERIOD_FIELDS
     #
-    index.sortable.text.fields=firstName,jobTitle,lastName,name,screenName,title
+    index.sortable.text.fields=\
+        firstName,\
+        jobTitle,\
+        lastName,\
+        name,\
+        screenName,\
+        title
 
     #
     # Set the maximum length for sortable keyword fields before they are
@@ -6476,7 +6652,9 @@
     #
     # Env: LIFERAY_COMBO_PERIOD_ALLOWED_PERIOD_FILE_PERIOD_EXTENSIONS
     #
-    combo.allowed.file.extensions=.css,.js
+    combo.allowed.file.extensions=\
+        .css,\
+        .js
 
     #
     # The combo servlet combines multiple JavaScript files into a bundle based
@@ -6699,8 +6877,8 @@
     #
     # Env: LIFERAY_COM_PERIOD_LIFERAY_PERIOD_PORTAL_PERIOD_UTIL_PERIOD__UPPERCASEH_TTP_UPPERCASEI_MPL_PERIOD_PROXY_PERIOD_AUTH_PERIOD_TYPE
     #
-    #com.liferay.portal.util.HttpImpl.proxy.auth.type=username-password
     #com.liferay.portal.util.HttpImpl.proxy.auth.type=ntlm
+    #com.liferay.portal.util.HttpImpl.proxy.auth.type=username-password
 
     #
     # Set user name and password used for HTTP proxy authentication.
@@ -6775,9 +6953,9 @@
     #
     # Env: LIFERAY_TUNNELING_PERIOD_SERVLET_PERIOD_ENCRYPTION_PERIOD_ALGORITHM
     #
-    tunneling.servlet.encryption.algorithm=AES
     #tunneling.servlet.encryption.algorithm=Blowfish
     #tunneling.servlet.encryption.algorithm=DESede
+    tunneling.servlet.encryption.algorithm=AES
 
     #
     # Set this shared secret to secure communications from one portal to another
@@ -7589,7 +7767,11 @@
     #
     # Env: LIFERAY_MAIL_PERIOD_SEND_PERIOD_BLACKLIST
     #
-    mail.send.blacklist=noreply@liferay.com,test@liferay.com,noreply@domain.invalid,test@domain.invalid
+    mail.send.blacklist=\
+        noreply@liferay.com,\
+        test@liferay.com,\
+        noreply@domain.invalid,\
+        test@domain.invalid
 
     #
     # Set the JNDI name to lookup the Java Mail session. If none is set, then
@@ -7736,7 +7918,9 @@
     #
     # Env: LIFERAY_MINIFIER_PERIOD_INLINE_PERIOD_CONTENT_PERIOD_CACHE_PERIOD_SKIP_PERIOD_JAVASCRIPT
     #
-    minifier.inline.content.cache.skip.javascript=getSessionId,encryptedUserId
+    minifier.inline.content.cache.skip.javascript=\
+        getSessionId,\
+        encryptedUserId
 
 ##
 ## Mobile Device Rules
@@ -8333,8 +8517,8 @@
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_ADDRESS_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_CONTROL_QUOTE__CLOSEBRACKET_
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_PORT_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_CONTROL_QUOTE__CLOSEBRACKET_
     #
-    multicast.group.address["cluster-link-control"]=239.255.0.1
     #multicast.group.address["cluster-link-control"]=ff0e::8:8:1
+    multicast.group.address["cluster-link-control"]=239.255.0.1
     multicast.group.port["cluster-link-control"]=23301
 
     #
@@ -8344,8 +8528,8 @@
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_ADDRESS_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_UDP_QUOTE__CLOSEBRACKET_
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_PORT_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_UDP_QUOTE__CLOSEBRACKET_
     #
-    multicast.group.address["cluster-link-udp"]=239.255.0.2
     #multicast.group.address["cluster-link-udp"]=ff0e::8:8:2
+    multicast.group.address["cluster-link-udp"]=239.255.0.2
     multicast.group.port["cluster-link-udp"]=23302
 
     #
@@ -8354,8 +8538,8 @@
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_ADDRESS_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_MPING_QUOTE__CLOSEBRACKET_
     # Env: LIFERAY_MULTICAST_PERIOD_GROUP_PERIOD_PORT_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_MPING_QUOTE__CLOSEBRACKET_
     #
-    multicast.group.address["cluster-link-mping"]=239.255.0.3
     #multicast.group.address["cluster-link-mping"]=ff0e::8:8:3
+    multicast.group.address["cluster-link-mping"]=239.255.0.3
     multicast.group.port["cluster-link-mping"]=23303
 
     #
@@ -8396,17 +8580,35 @@
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
     #
-    openoffice.conversion.source.extensions[presentation]=odp,ppt,pptx,sxi
+    openoffice.conversion.source.extensions[presentation]=\
+        odp,\
+        ppt,\
+        pptx,\
+        sxi
 
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
     #
-    openoffice.conversion.source.extensions[spreadsheet]=csv,ods,sxc,tsv,xls,xlsx
+    openoffice.conversion.source.extensions[spreadsheet]=\
+        csv,\
+        ods,\
+        sxc,\
+        tsv,\
+        xls,\
+        xlsx
 
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_SOURCE_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
     #
-    openoffice.conversion.source.extensions[text]=doc,docx,html,odt,rtf,sxw,txt,wpd
+    openoffice.conversion.source.extensions[text]=\
+        doc,\
+        docx,\
+        html,\
+        odt,\
+        rtf,\
+        sxw,\
+        txt,\
+        wpd
 
     #
     # Specify the file extensions of files to allow conversions to. Entries must
@@ -8414,22 +8616,42 @@
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_DRAWING_CLOSEBRACKET_
     #
-    openoffice.conversion.target.extensions[drawing]=pdf,svg,swf
+    openoffice.conversion.target.extensions[drawing]=\
+        pdf,\
+        svg,\
+        swf
 
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
     #
-    openoffice.conversion.target.extensions[presentation]=odp,pdf,ppt,swf,sxi
+    openoffice.conversion.target.extensions[presentation]=\
+        odp,\
+        pdf,\
+        ppt,\
+        swf,\
+        sxi
 
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
     #
-    openoffice.conversion.target.extensions[spreadsheet]=csv,ods,pdf,sxc,tsv,xls
+    openoffice.conversion.target.extensions[spreadsheet]=\
+        csv,\
+        ods,\
+        pdf,\
+        sxc,\
+        tsv,\
+        xls
 
     #
     # Env: LIFERAY_OPENOFFICE_PERIOD_CONVERSION_PERIOD_TARGET_PERIOD_EXTENSIONS_OPENBRACKET_TEXT_CLOSEBRACKET_
     #
-    openoffice.conversion.target.extensions[text]=doc,odt,pdf,rtf,sxw,txt
+    openoffice.conversion.target.extensions[text]=\
+        doc,\
+        odt,\
+        pdf,\
+        rtf,\
+        sxw,\
+        txt
 
 ##
 ## Phone Number Format
@@ -8948,7 +9170,10 @@
     #
     # Env: LIFERAY_RSS_PERIOD_FEED_PERIOD_TYPES
     #
-    rss.feed.types=atom_1.0,rss_1.0,rss_2.0
+    rss.feed.types=\
+        atom_1.0,\
+        rss_1.0,\
+        rss_2.0
 
     #
     # See the properties "main.servlet.hosts.allowed" and
@@ -9039,8 +9264,8 @@
     # Env: LIFERAY_SCRIPTING_PERIOD_JRUBY_PERIOD_COMPILE_PERIOD_MODE
     #
     #scripting.jruby.compile.mode=force
-    scripting.jruby.compile.mode=jit
     #scripting.jruby.compile.mode=off
+    scripting.jruby.compile.mode=jit
 
     #
     # Set the threshold at which methods will be compiled when "jit" compile
@@ -9071,7 +9296,13 @@
     #
     # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
-    search.container.page.delta.values=5,10,20,30,50,75
+    search.container.page.delta.values=\
+        5,\
+        10,\
+        20,\
+        30,\
+        50,\
+        75
 
     #
     # Set the maximum number of pages available above and below the currently
@@ -9250,7 +9481,9 @@
     #
     # Env: LIFERAY_STRIP_PERIOD_MIME_PERIOD_TYPES
     #
-    strip.mime.types=text/html*,text/xml*
+    strip.mime.types=\
+        text/html*,\
+        text/xml*
 
 ##
 ## Social Activity
@@ -9437,8 +9670,8 @@
     #
     # Env: LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS
     #
-    virtual.hosts.valid.hosts=*
     #virtual.hosts.valid.hosts=localhost,127.0.0.1,[::1],[0:0:0:0:0:0:0:1]
+    virtual.hosts.valid.hosts=*
 
 ##
 ## Work Directory
@@ -9536,7 +9769,13 @@
     #
     # Env: LIFERAY_XUGGLER_PERIOD_JAR_PERIOD_OPTIONS
     #
-    xuggler.jar.options=32-linux,32-mac,32-win,64-linux,64-mac,64-win
+    xuggler.jar.options=\
+        32-linux,\
+        32-mac,\
+        32-win,\
+        64-linux,\
+        64-mac,\
+        64-win
 
     #
     # Set these to customize the ffmpeg preset settings used by Xuggler when
@@ -10061,7 +10300,14 @@
     #
     # Env: LIFERAY_WEBDAV_PERIOD_IGNORE
     #
-    webdav.ignore=.DS_Store,.metadata_index_homes_only,.metadata_never_index,.Spotlight-V100,.TemporaryItems,.Trashes,Backups.backupdb
+    webdav.ignore=\
+        .DS_Store,\
+        .metadata_index_homes_only,\
+        .metadata_never_index,\
+        .Spotlight-V100,\
+        .TemporaryItems,\
+        .Trashes,\
+        Backups.backupdb
 
     #
     # Set the maximum time, in milliseconds, between node responses for nonce
@@ -10113,7 +10359,9 @@
     #
     # Env: LIFERAY_ATOM_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
     #
-    atom.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+    atom.servlet.hosts.allowed=\
+        127.0.0.1,\
+        SERVER_IP
 
     #
     # Env: LIFERAY_ATOM_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
@@ -10130,7 +10378,9 @@
     #
     # Env: LIFERAY_AXIS_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
     #
-    axis.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+    axis.servlet.hosts.allowed=\
+        127.0.0.1,\
+        SERVER_IP
 
     #
     # Env: LIFERAY_AXIS_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
@@ -10210,7 +10460,9 @@
     #
     # Env: LIFERAY_TUNNEL_PERIOD_SERVLET_PERIOD_HOSTS_PERIOD_ALLOWED
     #
-    tunnel.servlet.hosts.allowed=127.0.0.1,SERVER_IP
+    tunnel.servlet.hosts.allowed=\
+        127.0.0.1,\
+        SERVER_IP
 
     #
     # Env: LIFERAY_TUNNEL_PERIOD_SERVLET_PERIOD_HTTPS_PERIOD_REQUIRED
@@ -10227,7 +10479,35 @@
     #
     # Env: LIFERAY_WEB_PERIOD_SERVER_PERIOD_SERVLET_PERIOD_ACCEPT_PERIOD_RANGES_PERIOD_MIME_PERIOD_TYPES
     #
-    web.server.servlet.accept.ranges.mime.types=audio/basic,audio/mid,audio/midi,audio/mod,audio/mp3,audio/mp4,audio/mpeg,audio/mpeg3,audio/ogg,audio/vorbis,audio/wav,audio/x-m4a,audio/x-mid,audio/x-midi,audio/x-mod,audio/x-mpeg,audio/x-pn-realaudio,audio/x-realaudio,audio/x-wav,video/avi,video/mp4,video/mpeg,video/ogg,video/quicktime,video/x-flv,video/x-m4v,video/x-ms-wmv,video/x-msvideo
+    web.server.servlet.accept.ranges.mime.types=\
+        audio/basic,\
+        audio/mid,\
+        audio/midi,\
+        audio/mod,\
+        audio/mp3,\
+        audio/mp4,\
+        audio/mpeg,\
+        audio/mpeg3,\
+        audio/ogg,\
+        audio/vorbis,\
+        audio/wav,\
+        audio/x-m4a,\
+        audio/x-mid,\
+        audio/x-midi,\
+        audio/x-mod,\
+        audio/x-mpeg,\
+        audio/x-pn-realaudio,\
+        audio/x-realaudio,\
+        audio/x-wav,\
+        video/avi,\
+        video/mp4,\
+        video/mpeg,\
+        video/ogg,\
+        video/quicktime,\
+        video/x-flv,\
+        video/x-m4v,\
+        video/x-ms-wmv,\
+        video/x-msvideo
 
     #
     # Set this to true to check whether the request is for an image from the
@@ -10410,7 +10690,16 @@
     #
     # Env: LIFERAY_ADMIN_PERIOD_OBFUSCATED_PERIOD_PROPERTIES
     #
-    admin.obfuscated.properties=auth.mac.shared.key,auth.token.shared.secret,default.admin.password,dl.file.entry.preview.generation.decrypt.passwords.pdfbox,dl.repository.guest.password,jdbc.default.password,mail.session.mail.pop3.password,mail.session.mail.smtp.password,tunneling.servlet.shared.secret
+    admin.obfuscated.properties=\
+        auth.mac.shared.key,\
+        auth.token.shared.secret,\
+        default.admin.password,\
+        dl.file.entry.preview.generation.decrypt.passwords.pdfbox,\
+        dl.repository.guest.password,\
+        jdbc.default.password,\
+        mail.session.mail.pop3.password,\
+        mail.session.mail.smtp.password,\
+        tunneling.servlet.shared.secret
 
 ##
 ## Announcements Portlet
@@ -10445,7 +10734,10 @@
     #
     # Env: LIFERAY_ANNOUNCEMENTS_PERIOD_ENTRY_PERIOD_TYPES
     #
-    announcements.entry.types=general,news,test
+    announcements.entry.types=\
+        general,\
+        news,\
+        test
 
     #
     # Set the interval in minutes on how often CheckEntryMessageListener will
@@ -10462,7 +10754,13 @@
     #
     # Env: LIFERAY_ANNOUNCEMENTS_PERIOD_ENTRY_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
-    announcements.entry.page.delta.values=5,10,20,30,50,75
+    announcements.entry.page.delta.values=\
+        5,\
+        10,\
+        20,\
+        30,\
+        50,\
+        75
 
 ##
 ## Asset
@@ -10604,7 +10902,13 @@
     #
     # Env: LIFERAY_BLOGS_PERIOD_ENTRY_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
-    blogs.entry.page.delta.values=5,10,20,30,50,75
+    blogs.entry.page.delta.values=\
+        5,\
+        10,\
+        20,\
+        30,\
+        50,\
+        75
 
     #
     # Set this to true to enable previous and next navigation for blogs entries.
@@ -10664,8 +10968,8 @@
     #
     # Env: LIFERAY_DISCUSSION_PERIOD_COMMENTS_PERIOD_ALLOWED_PERIOD_CONTENT
     #
-    discussion.comments.allowed.content=a[href];em;p;span[class];strong;u
     #discussion.comments.allowed.content=a[href,title];em;p;strong;u
+    discussion.comments.allowed.content=a[href];em;p;span[class];strong;u
 
     #
     # Set this property to true if users can edit their own discussion comments
@@ -10722,22 +11026,38 @@
     #
     # Env: LIFERAY_DL_PERIOD_DISPLAY_PERIOD_VIEWS
     #
-    dl.display.views=icon,descriptive,list
+    dl.display.views=\
+        icon,\
+        descriptive,\
+        list
 
     #
     # Env: LIFERAY_DL_PERIOD_ENTRY_PERIOD_COLUMNS
     #
-    dl.entry.columns=name,document-type,size,status,modified-date,create-date,action
+    dl.entry.columns=\
+        name,\
+        document-type,\
+        size,\
+        status,\
+        modified-date,\
+        create-date,\
+        action
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_COLUMNS
     #
-    dl.file.entry.columns=name,size,locked
+    dl.file.entry.columns=\
+        name,\
+        size,\
+        locked
 
     #
     # Env: LIFERAY_DL_PERIOD_FOLDER_PERIOD_COLUMNS
     #
-    dl.folder.columns=name,num-of-folders,num-of-documents
+    dl.folder.columns=\
+        name,\
+        num-of-folders,\
+        num-of-documents
 
     #
     # Env: LIFERAY_DL_PERIOD_FOLDERS_PERIOD_SEARCH_PERIOD_VISIBLE
@@ -10807,8 +11127,8 @@
     #
     # Env: LIFERAY_DL_PERIOD_STORE_PERIOD_ANTIVIRUS_PERIOD_IMPL
     #
-    dl.store.antivirus.impl=com.liferay.portlet.documentlibrary.antivirus.DummyAntivirusScannerImpl
     #dl.store.antivirus.impl=com.liferay.portlet.documentlibrary.antivirus.ClamAntivirusScannerImpl
+    dl.store.antivirus.impl=com.liferay.portlet.documentlibrary.antivirus.DummyAntivirusScannerImpl
 
     #
     # These properties define the replacement strings for certain characters
@@ -10837,8 +11157,8 @@
     #
     #dl.store.impl=com.liferay.portal.store.db.DBStore
     #dl.store.impl=com.liferay.portal.store.file.system.AdvancedFileSystemStore
-    dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore
     #dl.store.impl=com.liferay.portal.store.s3.S3Store
+    dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore
 
     #
     # Set this to false to allow users to update file entries by uploading a
@@ -10871,7 +11191,29 @@
     #
     # Env: LIFERAY_DL_PERIOD_NAME_PERIOD_BLACKLIST
     #
-    dl.name.blacklist=con,prn,aux,nul,com1,com2,com3,com4,com5,com6,com7,com8,com9,lpt1,lpt2,lpt3,lpt4,lpt5,lpt6,lpt7,lpt8,lpt9
+    dl.name.blacklist=\
+        con,\
+        prn,\
+        aux,\
+        nul,\
+        com1,\
+        com2,\
+        com3,\
+        com4,\
+        com5,\
+        com6,\
+        com7,\
+        com8,\
+        com9,\
+        lpt1,\
+        lpt2,\
+        lpt3,\
+        lpt4,\
+        lpt5,\
+        lpt6,\
+        lpt7,\
+        lpt8,\
+        lpt9
 
     #
     # You can map a PNG for generic thumbnails by adding the image to the
@@ -10881,32 +11223,65 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_NAMES
     #
-    dl.file.generic.names=compressed,document,flash,image,music,pdf,presentation,spreadsheet,video
+    dl.file.generic.names=\
+        compressed,\
+        document,\
+        flash,\
+        image,\
+        music,\
+        pdf,\
+        presentation,\
+        spreadsheet,\
+        video
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_COMPRESSED_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[compressed]=lar,rar,zip
+    dl.file.generic.extensions[compressed]=\
+        lar,\
+        rar,\
+        zip
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_DOCUMENT_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[document]=doc,docx,pages,rtf,odt
+    dl.file.generic.extensions[document]=\
+        doc,\
+        docx,\
+        pages,\
+        rtf,\
+        odt
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_FLASH_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[flash]=flv,swf
+    dl.file.generic.extensions[flash]=\
+        flv,\
+        swf
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_IMAGE_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[image]=bmp,gif,jpeg,jpg,odg,png,svg
+    dl.file.generic.extensions[image]=\
+        bmp,\
+        gif,\
+        jpeg,\
+        jpg,\
+        odg,\
+        png,\
+        svg
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_MUSIC_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[music]=acc,mid,mp3,oga,ogg,wav,wma
+    dl.file.generic.extensions[music]=\
+        acc,\
+        mid,\
+        mp3,\
+        oga,\
+        ogg,\
+        wav,\
+        wma
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PDF_CLOSEBRACKET_
@@ -10916,17 +11291,37 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_PRESENTATION_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[presentation]=key,keynote,odp,pps,ppt,pptx
+    dl.file.generic.extensions[presentation]=\
+        key,\
+        keynote,\
+        odp,\
+        pps,\
+        ppt,\
+        pptx
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_SPREADSHEET_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[spreadsheet]=csv,numbers,ods,xls,xlsx
+    dl.file.generic.extensions[spreadsheet]=\
+        csv,\
+        numbers,\
+        ods,\
+        xls,\
+        xlsx
 
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_GENERIC_PERIOD_EXTENSIONS_OPENBRACKET_VIDEO_CLOSEBRACKET_
     #
-    dl.file.generic.extensions[video]=avi,m4v,mov,mp4,mpg,ogv,qt,rm,wmv
+    dl.file.generic.extensions[video]=\
+        avi,\
+        m4v,\
+        mov,\
+        mp4,\
+        mpg,\
+        ogv,\
+        qt,\
+        rm,\
+        wmv
 
     #
     # Set the maximum size for a file's indexable content. Files larger than
@@ -10945,8 +11340,16 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_INDEXING_PERIOD_IGNORE_PERIOD_EXTENSIONS
     #
-    dl.file.indexing.ignore.extensions=.bmp,.gif,.jpeg,.jpg,.lar,.odg,.png,.svg
     #dl.file.indexing.ignore.extensions=.pdf,.ppt
+    dl.file.indexing.ignore.extensions=\
+        .bmp,\
+        .gif,\
+        .jpeg,\
+        .jpg,\
+        .lar,\
+        .odg,\
+        .png,\
+        .svg
 
     #
     # Set the number of file entries that will be indexed in every iteration
@@ -10965,7 +11368,45 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ICONS
     #
-    dl.file.icons=.bmp,.css,.doc,.docx,.dot,.gif,.gz,.htm,.html,.jpeg,.jpg,.js,.lar,.odb,.odf,.odg,.odp,.ods,.odt,.pdf,.png,.ppt,.pptx,.rtf,.swf,.sxc,.sxi,.sxw,.tar,.tiff,.tgz,.txt,.vsd,.xls,.xlsx,.xml,.zip,.jrxml
+    dl.file.icons=\
+        .bmp,\
+        .css,\
+        .doc,\
+        .docx,\
+        .dot,\
+        .gif,\
+        .gz,\
+        .htm,\
+        .html,\
+        .jpeg,\
+        .jpg,\
+        .js,\
+        .lar,\
+        .odb,\
+        .odf,\
+        .odg,\
+        .odp,\
+        .ods,\
+        .odt,\
+        .pdf,\
+        .png,\
+        .ppt,\
+        .pptx,\
+        .rtf,\
+        .swf,\
+        .sxc,\
+        .sxi,\
+        .sxw,\
+        .tar,\
+        .tiff,\
+        .tgz,\
+        .txt,\
+        .vsd,\
+        .xls,\
+        .xlsx,\
+        .xml,\
+        .zip,\
+        .jrxml
 
     #
     # Set this to true to check whether folders are empty or not and display a
@@ -10983,7 +11424,18 @@
     #
     # Env: LIFERAY_DL_PERIOD_COMPARABLE_PERIOD_FILE_PERIOD_EXTENSIONS
     #
-    dl.comparable.file.extensions=.css,.doc,.docx,.js,.htm,.html,.odt,.rtf,.sxw,.txt,.xml
+    dl.comparable.file.extensions=\
+        .css,\
+        .doc,\
+        .docx,\
+        .js,\
+        .htm,\
+        .html,\
+        .odt,\
+        .rtf,\
+        .sxw,\
+        .txt,\
+        .xml
 
     #
     # Set this to true to enable comments for document library files.
@@ -11039,7 +11491,12 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PROCESSORS
     #
-    dl.file.entry.processors=com.liferay.portlet.documentlibrary.util.AudioProcessorImpl,com.liferay.portlet.documentlibrary.util.ImageProcessorImpl,com.liferay.portlet.documentlibrary.util.PDFProcessorImpl,com.liferay.portlet.documentlibrary.util.RawMetadataProcessorImpl,com.liferay.portlet.documentlibrary.util.VideoProcessorImpl
+    dl.file.entry.processors=\
+        com.liferay.portlet.documentlibrary.util.AudioProcessorImpl,\
+        com.liferay.portlet.documentlibrary.util.ImageProcessorImpl,\
+        com.liferay.portlet.documentlibrary.util.PDFProcessorImpl,\
+        com.liferay.portlet.documentlibrary.util.RawMetadataProcessorImpl,\
+        com.liferay.portlet.documentlibrary.util.VideoProcessorImpl
 
     #
     # Input a list of comma delimited mime types that will be excluded from raw
@@ -11113,9 +11570,11 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PREVIEW_PERIOD_AUDIO_PERIOD_CONTAINERS
     #
-    dl.file.entry.preview.audio.containers=mp3,ogg
     #dl.file.entry.preview.audio.containers=mp3
     #dl.file.entry.preview.audio.containers=ogg
+    dl.file.entry.preview.audio.containers=\
+        mp3,\
+        ogg
 
     #
     # Set the bit rate and sample rate values for each audio container format.
@@ -11149,7 +11608,26 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PREVIEW_PERIOD_AUDIO_PERIOD_MIME_PERIOD_TYPES
     #
-    dl.file.entry.preview.audio.mime.types=audio/basic,audio/mid,audio/midi,audio/mod,audio/mp3,audio/mp4,audio/mpeg,audio/mpeg3,audio/ogg,audio/vorbis,audio/wav,audio/x-m4a,audio/x-mid,audio/x-midi,audio/x-mod,audio/x-mpeg,audio/x-pn-realaudio,audio/x-realaudio,audio/x-wav
+    dl.file.entry.preview.audio.mime.types=\
+        audio/basic,\
+        audio/mid,\
+        audio/midi,\
+        audio/mod,\
+        audio/mp3,\
+        audio/mp4,\
+        audio/mpeg,\
+        audio/mpeg3,\
+        audio/ogg,\
+        audio/vorbis,\
+        audio/wav,\
+        audio/x-m4a,\
+        audio/x-mid,\
+        audio/x-midi,\
+        audio/x-mod,\
+        audio/x-mpeg,\
+        audio/x-pn-realaudio,\
+        audio/x-realaudio,\
+        audio/x-wav
 
     #
     # Set this to true to generate document previews automatically when
@@ -11205,7 +11683,18 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PREVIEW_PERIOD_IMAGE_PERIOD_MIME_PERIOD_TYPES
     #
-    dl.file.entry.preview.image.mime.types=image/bmp,image/gif,image/jpeg,image/pjpeg,image/png,image/tiff,image/x-citrix-jpeg,image/x-citrix-png,image/x-ms-bmp,image/x-png,image/x-tiff
+    dl.file.entry.preview.image.mime.types=\
+        image/bmp,\
+        image/gif,\
+        image/jpeg,\
+        image/pjpeg,\
+        image/png,\
+        image/tiff,\
+        image/x-citrix-jpeg,\
+        image/x-citrix-png,\
+        image/x-ms-bmp,\
+        image/x-png,\
+        image/x-tiff
 
     #
     # Input a list of comma delimited video containers for preview files. The
@@ -11213,9 +11702,11 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PREVIEW_PERIOD_VIDEO_PERIOD_CONTAINERS
     #
-    dl.file.entry.preview.video.containers=mp4,ogv
     #dl.file.entry.preview.video.containers=mp4
     #dl.file.entry.preview.video.containers=ogv
+    dl.file.entry.preview.video.containers=\
+        mp4,\
+        ogv
 
     #
     # Set the bit rate and frame rate values for each preview video container
@@ -11251,7 +11742,17 @@
     #
     # Env: LIFERAY_DL_PERIOD_FILE_PERIOD_ENTRY_PERIOD_PREVIEW_PERIOD_VIDEO_PERIOD_MIME_PERIOD_TYPES
     #
-    dl.file.entry.preview.video.mime.types=video/avi,video/mp4,video/mpeg,video/ogg,video/quicktime,video/webm,video/x-flv,video/x-m4v,video/x-ms-wmv,video/x-msvideo
+    dl.file.entry.preview.video.mime.types=\
+        video/avi,\
+        video/mp4,\
+        video/mpeg,\
+        video/ogg,\
+        video/quicktime,\
+        video/webm,\
+        video/x-flv,\
+        video/x-m4v,\
+        video/x-ms-wmv,\
+        video/x-msvideo
 
     #
     # Set this to true to generate Image Gallery thumbnails when accessed via
@@ -11446,7 +11947,9 @@
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_CATEGORY_PERIOD_DISPLAY_PERIOD_STYLES
     #
-    message.boards.category.display.styles=default,question
+    message.boards.category.display.styles=\
+        default,\
+        question
 
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_FLAGS_PERIOD_ENABLED
@@ -11459,7 +11962,9 @@
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_MESSAGE_PERIOD_FORMATS
     #
-    message.boards.message.formats=bbcode,html
+    message.boards.message.formats=\
+        bbcode,\
+        html
 
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_MESSAGE_PERIOD_FORMATS_PERIOD_DEFAULT
@@ -11488,8 +11993,8 @@
     #
     # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_EXPIRE_PERIOD_BAN_PERIOD_INTERVAL
     #
-    message.boards.expire.ban.interval=10
     #message.boards.expire.ban.interval=0
+    message.boards.expire.ban.interval=10
 
     #
     # Set this to true to enable pingbacks.
@@ -11536,9 +12041,11 @@
     # Env: LIFERAY__UPPERCASEY_ODA
     # Env: LIFERAY__UPPERCASEY_OUNGLING
     #
+    # Env: LIFERAY_MESSAGE_PERIOD_BOARDS_PERIOD_USER_PERIOD_RANKS
+    #
     message.boards.user.ranks=\
-        #Moderator=organization:Message Boards Administrator,\
         #Moderator=organization-role:Message Boards Administrator,\
+        #Moderator=organization:Message Boards Administrator,\
         #Moderator=regular-role:Message Boards Administrator,\
         #Moderator=site-role:Message Boards Administrator,\
         #Moderator=user-group:Message Boards Administrator,\
@@ -11570,8 +12077,8 @@
     #
     # Env: LIFERAY_MY_PERIOD_SITES_PERIOD_DISPLAY_PERIOD_STYLE
     #
-    my.sites.display.style=simple
     #my.sites.display.style=classic
+    my.sites.display.style=simple
 
     #
     # Set this to true to show user public sites with no layouts.
@@ -11661,7 +12168,9 @@
     #
     # Env: LIFERAY_RATINGS_PERIOD_UPGRADE_PERIOD_THUMBS_PERIOD_CLASS_PERIOD_NAMES
     #
-    ratings.upgrade.thumbs.class.names=com.liferay.message.boards.model.MBDiscussion,com.liferay.message.boards.model.MBMessage
+    ratings.upgrade.thumbs.class.names=\
+        com.liferay.message.boards.model.MBDiscussion,\
+        com.liferay.message.boards.model.MBMessage
 
 ##
 ## Recent Content Portlet

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -500,6 +500,18 @@
         you-have-to-be-signed-in-to-register-for-this-meetup,\
         you-were-redirected-to-x
 
+    source.check.properties.portal.file.check.allowedSingleLinePropertyKeys=\
+        dl.char.blacklist,\
+        hibernate.session.factory.imported.class.name.regexp,\
+        jdbc.default.url,\
+        passwords.default.policy.regex,\
+        passwords.regexptoolkit.charset,\
+        passwords.regexptoolkit.pattern,\
+        phone.number.format.international.regexp,\
+        phone.number.format.usa.regexp,\
+        portlet.resource.id.banned.paths.regexp,\
+        rtl.css.excluded.paths.regexp
+
     source.check.xml.service.file.check.allowedMissingMVVCEnabledFileNames=\
         modules/apps/account/account-service/service.xml,\
         modules/apps/adaptive-media/adaptive-media-image-service/service.xml,\


### PR DESCRIPTION
Hi Hugo,

https://issues.liferay.com/browse/LPS-103872

We should just add this new rule in `PropertiesPortalFileCheck.java`.
But it break other checks, so I also changed other checks.

Let me summarize what I did:

1. Changes in [PropertiesEmptyLinesCheck.java](https://github.com/hhuijser/liferay-portal/pull/3840/files#diff-8a47b000b44c4c42eb19e53c30c12674R88): Avoid to add empty line [here](https://github.com/hhuijser/liferay-portal/blob/380ea65bfe08f423dc0effc2215866f097e1a3fb/portal-impl/src/portal.properties#L4362).

2. Changes in [PropertiesPortalEnvironmentVariablesCheck.java](https://github.com/hhuijser/liferay-portal/pull/3840/files#diff-c5fb39371943641c32f928d75f4114f2R56): Sort same properties [here](https://github.com/hhuijser/liferay-portal/pull/3840/files#diff-70e7a8b9586d2a3f809fcc9e9e22e2b3R2035-R2037).

3. Changes in [PropertiesPortalFileCheck.java](https://github.com/hhuijser/liferay-portal/pull/3840/files#diff-5c35046c5b459cf1c1f5caafb798f6adR50): This LPS-103872

4. Changes in [PropertiesPortalFileCheck.java](https://github.com/hhuijser/liferay-portal/pull/3840/files#diff-5c35046c5b459cf1c1f5caafb798f6adR44): Fix regex, only match the filename, don't match the path that contains "portal-", e.g. "portal-impl/src/system.propertie".

5. [LPS-103872 SF](https://github.com/hhuijser/liferay-portal/pull/3840/commits/4a66aa5fa3f3a79ca496684210ec52bb01e17db1): Manually SF.
