### PR TITLE
LPS-84119 Yaml task: Standardize on "# @review"

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -516,7 +516,7 @@ components:
                     type: string
             type: object
         Site:
-            #@review
+            # @review
             description:
                 Represents the site where the content is created. Properties follow the
                 [WebSite](https://schema.org/WebSite) specification.
@@ -1487,7 +1487,7 @@ paths:
             tags: ["UserAccount"]
     "/sites/{siteId}/user-accounts/{userAccountId}/segments":
         get:
-            #review
+            # @review
             description:
                 "Gets a user's segments. The set of available headers are: Accept-Language (string), Host (string),
                 User-Agent (string), X-Browser (string), X-Cookies (collection string), X-Device-Brand (string),

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
@@ -1,7 +1,7 @@
 components:
     schemas:
         ExportTask:
-            #@review
+            # @review
             properties:
                 className:
                     description:
@@ -50,7 +50,7 @@ components:
                     type: string
             type: object
         ImportTask:
-            #@review
+            # @review
             properties:
                 className:
                     description:
@@ -115,7 +115,7 @@ info:
 openapi: 3.0.1
 paths:
     /export-task/{className}/{version}:
-        #@review
+        # @review
         post:
             description:
                 Submits a request for exporting items to a file.
@@ -153,7 +153,7 @@ paths:
                         Async
             tags: ["ExportTask"]
     /export-task/{exportTaskId}/:
-        #@review
+        # @review
         get:
             description:
                 Retrieves the export task.
@@ -178,7 +178,7 @@ paths:
                         ""
             tags: ["ExportTask"]
     /import-task/{className}/{version}:
-        #@review
+        # @review
         delete:
             description:
                 Uploads a new file for deleting items in batch.
@@ -299,7 +299,7 @@ paths:
                         Async
             tags: ["ImportTask"]
     /import-task/{importTaskId}/:
-        #@review
+        # @review
         get:
             description:
                 Retrieves the import task.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -23,7 +23,7 @@ components:
                     readOnly: true
                     type: integer
                 ratingValue:
-                    #@review
+                    # @review
                     description:
                         The rating value.
                     format: double
@@ -1331,7 +1331,7 @@ components:
             required:
                 - title
             type: object
-        #@review
+        # @review
         MessageBoardThread:
             description:
                 Represents a discussion thread in a message board.
@@ -2446,7 +2446,7 @@ paths:
             tags: ["Comment"]
     "/content-sets/{contentSetId}/content-set-elements":
         get:
-            #review
+            # @review
             description:
                 "Retrieves the content set's elements (e.g., structured content, blogs, etc.). Results can be paginated.
                 The set of available headers are: Accept-Language (string), Host (string), User-Agent (string),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLStylingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/YMLStylingCheck.java
@@ -30,6 +30,9 @@ public class YMLStylingCheck extends BaseFileCheck {
 			"(\\A|\n)( *)(description:) (?!\\|-)(.+)(\\Z|\n)",
 			"$1$2$3\n    $2$4$5");
 
+		content = content.replaceAll(
+			"(\\A|\n)( *#)@? ?(review)(\\Z|\n)", "$1$2 @$3$4");
+
 		return content;
 	}
 

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/YMLSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/YMLSourceProcessorTest.java
@@ -52,6 +52,11 @@ public class YMLSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testStandardizeOnReview() throws Exception {
+		test("StandardizeOnReview.testyaml");
+	}
+
+	@Test
 	public void testStyleBlock() throws Exception {
 		test("StyleBlock.testyaml");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StandardizeOnReview.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StandardizeOnReview.testyaml
@@ -1,0 +1,12 @@
+components:
+    schemas:
+        ExportTask:
+            #review
+            properties:
+                # review
+                className:
+                    #@review
+                    description:
+                        The item class name for which data will be exported in batch.
+                    example: com.liferay.headless.delivery.dto.v1_0.BlogPosting
+                    type: string

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/StandardizeOnReview.testyaml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/StandardizeOnReview.testyaml
@@ -1,0 +1,12 @@
+components:
+    schemas:
+        ExportTask:
+            # @review
+            properties:
+                # @review
+                className:
+                    # @review
+                    description:
+                        The item class name for which data will be exported in batch.
+                    example: com.liferay.headless.delivery.dto.v1_0.BlogPosting
+                    type: string


### PR DESCRIPTION
Hi Hugo,

**Issue:**
> This is from Brian:
> Hey Hugo, for all the *.yaml if you grep the word "review"
> [10:14 AM]
> we do "#review", "# review", and "# @review"
> [10:14 AM]
> can we standardize on "# @review"

This pull can standardize on "# @review".

-------------
**It is not for this pull request:**
Actually I have been working on another issue in *.yaml, but I am still thinking how to fix this **Issue:** `YMLDefinitionOrderCheck`didn't sort the comment line.


_For example:_
```
components:
    schemas:
        ExportTask:
            # @review
            properties:
                className:
                    example: com.liferay.headless.delivery.dto.v1_0.BlogPosting
                    # This is a comment for description... ...
                    # Don't sort... ...
                    description:
                        The item class name for which data will be exported in batch.
                    type: string
```
The `description:` should go before `example:` with its two comment lines,  but current logic didn't  sort for comment line, so SF didn't change this example. 
The current logic sort the values which have the same indentation, and skip the comment line.

So, I need to rethink sort logic a bit.
