### PR TITLE
LPS-113715 Include DXP apps in build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -266,7 +266,30 @@
     #    core/portal-equinox-log-bridge,\
     #    core/registry-api,\
     #    core/registry-impl,\
-    #    dxp/apps,\
+    #    dxp/apps/analytics,\
+    #    dxp/apps/app-builder-workflow,\
+    #    dxp/apps/document-library-opener,\
+    #    dxp/apps/documentum,\
+    #    dxp/apps/frontend-theme,\
+    #    dxp/apps/multi-factor-authentication,\
+    #    dxp/apps/oauth,\
+    #    dxp/apps/portal,\
+    #    dxp/apps/portal-mobile-device-detection-fiftyonedegrees-enterprise,\
+    #    dxp/apps/portal-reports-engine-console,\
+    #    dxp/apps/portal-rules-engine-drools,\
+    #    dxp/apps/portal-search-elasticsearch-cross-cluster-replication,\
+    #    dxp/apps/portal-search-elasticsearch6-xpack-monitoring,\
+    #    dxp/apps/portal-search-elasticsearch6-xpack-security,\
+    #    dxp/apps/portal-search-learning-to-rank,\
+    #    dxp/apps/portal-search-similar-results,\
+    #    dxp/apps/portal-search-tuning,\
+    #    dxp/apps/portal-security-audit,\
+    #    dxp/apps/portal-workflow,\
+    #    dxp/apps/saml,\
+    #    dxp/apps/segments,\
+    #    dxp/apps/sharepoint-rest,\
+    #    dxp/apps/sharepoint-soap,\
+    #    dxp/apps/sync,\
     #    util/portal-tools-db-upgrade-client
 
     build.marketplace.apps.enabled=true

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
@@ -140,16 +140,14 @@ public class PropertiesBuildIncludeDirsCheck extends BaseFileCheck {
 			return null;
 		}
 
-		String moduleDirName = null;
+		int deeper = 2;
 
 		if (absolutePath.indexOf("/modules/dxp/") != -1) {
-			moduleDirName = absolutePath.replaceAll(
-				".*?/modules((/[^/]+){3}).*", "$1");
+			deeper = 3;
 		}
-		else {
-			moduleDirName = absolutePath.replaceAll(
-				".*?/modules((/[^/]+){2}).*", "$1");
-		}
+
+		String moduleDirName = absolutePath.replaceAll(
+			".*?/modules((/[^/]+){" + deeper + "}).*", "$1");
 
 		return moduleDirName.substring(1);
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
@@ -132,7 +132,7 @@ public class PropertiesBuildIncludeDirsCheck extends BaseFileCheck {
 	}
 
 	private String _getModuleDirName(Path dirPath) {
-		String absolutePath = SourceUtil.getAbsolutePath(dirPath) + "/";
+		String absolutePath = SourceUtil.getAbsolutePath(dirPath);
 
 		int x = absolutePath.indexOf("/modules/");
 
@@ -140,19 +140,18 @@ public class PropertiesBuildIncludeDirsCheck extends BaseFileCheck {
 			return null;
 		}
 
-		int y = absolutePath.indexOf("/", x + 9);
+		String moduleDirName = null;
 
-		if (y == -1) {
-			return null;
+		if (absolutePath.indexOf("/modules/dxp/") != -1) {
+			moduleDirName = absolutePath.replaceAll(
+				".*?/modules((/[^/]+){3,3}).*", "$1");
+		}
+		else {
+			moduleDirName = absolutePath.replaceAll(
+				".*?/modules((/[^/]+){2,2}).*", "$1");
 		}
 
-		y = absolutePath.indexOf("/", y + 1);
-
-		if (y != -1) {
-			return absolutePath.substring(x + 9, y);
-		}
-
-		return null;
+		return moduleDirName.substring(1);
 	}
 
 	private static final String[] _SKIP_DIR_NAMES = {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesBuildIncludeDirsCheck.java
@@ -144,11 +144,11 @@ public class PropertiesBuildIncludeDirsCheck extends BaseFileCheck {
 
 		if (absolutePath.indexOf("/modules/dxp/") != -1) {
 			moduleDirName = absolutePath.replaceAll(
-				".*?/modules((/[^/]+){3,3}).*", "$1");
+				".*?/modules((/[^/]+){3}).*", "$1");
 		}
 		else {
 			moduleDirName = absolutePath.replaceAll(
-				".*?/modules((/[^/]+){2,2}).*", "$1");
+				".*?/modules((/[^/]+){2}).*", "$1");
 		}
 
 		return moduleDirName.substring(1);


### PR DESCRIPTION
Hi Hugo,

Issue: https://issues.liferay.com/browse/LPS-113715

DXP apps should be listed under build.include.dirs in build.properties. This check already occurs in format-source-current branch.

Currently, only the modules/dxp/apps directory is displayed. This is the same level as the apps in modules/apps, but we need one level deeper. https://github.com/liferay/liferay-portal/blob/master/build.properties#L268

```
    #    core/registry-impl,\
    #    dxp/apps,\
    #    util/portal-tools-db-upgrade-client
```
Should be:

```
    #    core/registry-impl,\
    #    dxp/apps/analytics,\
    #    dxp/apps/document-library-opener,\
    #    dxp/apps/documentum,\
...
    #    util/portal-tools-db-upgrade-client
```