### PR TITLE
LPS-114655_BaseTagAttributesCheck_master

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseTagAttributesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseTagAttributesCheck.java
@@ -271,7 +271,8 @@ public abstract class BaseTagAttributesCheck extends BaseFileCheck {
 					!attributeValue.contains(StringPool.QUOTE) ||
 					(attributeValue.contains("'\"") &&
 					 attributeValue.contains("\"'")) ||
-					attributeValue.matches(".*_\\w+\\(.*")) {
+					(!_name.contains(StringPool.COLON) &&
+					 attributeValue.matches(".*_\\w+\\(.*"))) {
 
 					delimeter = StringPool.QUOTE;
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseTagAttributesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/BaseTagAttributesCheck.java
@@ -270,7 +270,8 @@ public abstract class BaseTagAttributesCheck extends BaseFileCheck {
 				if (_escapeQuotes ||
 					!attributeValue.contains(StringPool.QUOTE) ||
 					(attributeValue.contains("'\"") &&
-					 attributeValue.contains("\"'"))) {
+					 attributeValue.contains("\"'")) ||
+					attributeValue.matches(".*_\\w+\\(.*")) {
 
 					delimeter = StringPool.QUOTE;
 				}

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -106,7 +106,7 @@ if (forcePost && (portletURL != null)) {
 					%>
 
 						<li>
-							<a class="dropdown-icon" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" onClick='<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>'>
+							<a class="dropdown-icon" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>">
 								<%= String.valueOf(curDelta) %>
 
 								<span class="sr-only"><liferay-ui:message key="entries-per-page" /></span>
@@ -127,7 +127,7 @@ if (forcePost && (portletURL != null)) {
 
 		<ul class="pagination">
 			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
-				<a class="page-link" href='<%= (cur > 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur > 1) && forcePost) ? _getOnClick(namespace, curParam, cur -1) : "" %>'>
+				<a class="page-link" href="<%= (cur > 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur > 1) && forcePost) ? _getOnClick(namespace, curParam, cur -1) : "" %>">
 					<liferay-ui:icon
 						icon="angle-left"
 						markupView="lexicon"
@@ -144,7 +144,7 @@ if (forcePost && (portletURL != null)) {
 					%>
 
 						<li class='page-item <%= (i == cur) ? "active" : StringPool.BLANK %>'>
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%
@@ -154,13 +154,13 @@ if (forcePost && (portletURL != null)) {
 				</c:when>
 				<c:when test="<%= cur == 1 %>">
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
 					</li>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span>2</a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>2</a>
 					</li>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span>3</a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>3</a>
 					</li>
 					<li class="dropdown page-item">
 						<a class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown" href="javascript:;">
@@ -180,7 +180,7 @@ if (forcePost && (portletURL != null)) {
 								%>
 
 									<li>
-										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 									</li>
 
 								<%
@@ -191,12 +191,12 @@ if (forcePost && (portletURL != null)) {
 						</div>
 					</li>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
 					</li>
 				</c:when>
 				<c:when test="<%= cur == pages %>">
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
 					</li>
 					<li class="dropdown page-item">
 						<a class="dropdown-toggle page-link" data-toggle="liferay-dropdown" href="javascript:;">
@@ -213,7 +213,7 @@ if (forcePost && (portletURL != null)) {
 								%>
 
 									<li>
-										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 									</li>
 
 								<%
@@ -224,18 +224,18 @@ if (forcePost && (portletURL != null)) {
 						</div>
 					</li>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages - 2 %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages - 2 %></a>
 					</li>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages - 1 %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages - 1 %></a>
 					</li>
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
 					</li>
 				</c:when>
 				<c:otherwise>
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
 					</li>
 
 					<c:if test="<%= (cur - 3) > 1 %>">
@@ -255,7 +255,7 @@ if (forcePost && (portletURL != null)) {
 					%>
 
 						<li class="page-item">
-							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%
@@ -270,17 +270,17 @@ if (forcePost && (portletURL != null)) {
 
 					<c:if test="<%= (cur - 1) > 1 %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur - 1 %></a>
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur - 1 %></a>
 						</li>
 					</c:if>
 
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, cur) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur %></a>
 					</li>
 
 					<c:if test="<%= (cur + 1) < pages %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur + 1 %></a>
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur + 1 %></a>
 						</li>
 					</c:if>
 
@@ -303,7 +303,7 @@ if (forcePost && (portletURL != null)) {
 					%>
 
 						<li class="page-item">
-							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%
@@ -317,13 +317,13 @@ if (forcePost && (portletURL != null)) {
 					</c:if>
 
 					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick='<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>'><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
+						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
 					</li>
 				</c:otherwise>
 			</c:choose>
 
 			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
-				<a class="page-link" href='<%= (cur < pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur < pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>'>
+				<a class="page-link" href="<%= (cur < pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur < pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>">
 					<liferay-ui:icon
 						icon="angle-right"
 						markupView="lexicon"

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -267,19 +267,19 @@ if (forcePost && (portletURL != null)) {
 		<ul class="lfr-pagination-buttons pager">
 			<c:if test='<%= type.equals("approximate") || type.equals("more") || type.equals("regular") %>'>
 				<li class='<%= (cur != 1) ? "" : "disabled" %> first'>
-					<a href='<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, 1) : "" %>' tabIndex='<%= (cur != 1) ? "0" : "-1" %>' target="<%= target %>">
+					<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, 1) : "" %>" tabIndex='<%= (cur != 1) ? "0" : "-1" %>' target="<%= target %>">
 						<%= PortalUtil.isRightToLeft(request) ? "&rarr;" : "&larr;" %> <liferay-ui:message key="first" />
 					</a>
 				</li>
 			</c:if>
 
 			<li class='<%= (cur != 1) ? "" : "disabled" %>'>
-				<a href='<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, cur - 1) : "" %>' tabIndex='<%= (cur != 1) ? "0" : "-1" %>' target="<%= target %>">
+				<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, cur - 1) : "" %>" tabIndex='<%= (cur != 1) ? "0" : "-1" %>' target="<%= target %>">
 					<liferay-ui:message key="previous" />
 				</a>
 			</li>
 			<li class='<%= (cur != pages) ? "" : "disabled" %>'>
-				<a href='<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>' tabIndex='<%= (cur != pages) ? "0" : "-1" %>' target="<%= target %>">
+				<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>" tabIndex='<%= (cur != pages) ? "0" : "-1" %>' target="<%= target %>">
 					<c:choose>
 						<c:when test='<%= type.equals("approximate") || type.equals("more") %>'>
 							<liferay-ui:message key="more" />
@@ -293,7 +293,7 @@ if (forcePost && (portletURL != null)) {
 
 			<c:if test='<%= type.equals("regular") %>'>
 				<li class='<%= (cur != pages) ? "" : "disabled" %> last'>
-					<a href='<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:;" %>' onclick='<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, pages) : "" %>' tabIndex='<%= (cur != pages) ? "0" : "-1" %>' target="<%= target %>">
+					<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, pages) : "" %>" tabIndex='<%= (cur != pages) ? "0" : "-1" %>' target="<%= target %>">
 						<liferay-ui:message key="last" /> <%= PortalUtil.isRightToLeft(request) ? "&larr;" : "&rarr;" %>
 					</a>
 				</li>


### PR DESCRIPTION
Hi Hugo,

_Fix 1:_
https://issues.liferay.com/browse/LPS-114655

Use double quotes as delimiter when there are method calls inside attribute value


-------
_Fix 2:_

I added `!_name.contains(StringPool.COLON)` back, because of jsp complie error. 


```

alan@alan-5540:~/liferay_code/7.0.x/liferay-portal-ee/portal-web[LPS-114655_BaseTagAttributesCheck_7.0.x]$ git diff
diff --git a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
index 12b3899e0cf4..f098763fc88f 100644
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -210,7 +210,7 @@ if (forcePost && (portletURL != null)) {
 
         <liferay-ui:icon
                 message="<%= String.valueOf(i) %>"
-                onClick='<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>'
+                onClick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"
                 url='<%= url + namespace + curParam + "=" + i + urlAnchor %>'
         />
 
alan@alan-5540:~/liferay_code/7.0.x/liferay-portal-ee/portal-web[LPS-114655_BaseTagAttributesCheck_7.0.x]$ 


compile-common-jsp:
   [delete] Deleting directory /home/alan/liferay_code/7.0.x/liferay-portal-ee/portal-web/classes/tomcat
     [java] Changes to environment variables are ignored when same JVM is used.
     [echo] Jun 09, 2020 11:39:46 PM org.apache.jasper.servlet.TldScanner scanJars
     [echo] INFO: At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
     [echo] org.apache.jasper.JasperException: file:/home/alan/liferay_code/7.0.x/liferay-portal-ee/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp (line: 213, column: 23) Attribute value  forcePost ? _getOnClick(namespace, curParam, i) : ""  is quoted with " which must be escaped when used within the value

BUILD FAILED
/home/alan/liferay_code/7.0.x/liferay-portal-ee/portal-web/build.xml:362: The following error occurred while executing this line:
/home/alan/liferay_code/7.0.x/liferay-portal-ee/portal-web/build.xml:311: The following error occurred while executing this line:
/home/alan/liferay_code/7.0.x/liferay-portal-ee/portal-web/build.xml:133: JSPs failed to compile.

```

----------
_Related pulls:_
7.2.x: https://github.com/hhuijser/liferay-portal-ee/pull/3055
7.1.x: https://github.com/hhuijser/liferay-portal-ee/pull/3056
7.0.x: https://github.com/hhuijser/liferay-portal-ee/pull/3057