### PR TITLE
LPS-113863 Use the implicit LiferayPortletResponse to call getNamespace()

### DIFF
--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_workspace_connection.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_workspace_connection.jsp
@@ -83,7 +83,7 @@ if (analyticsConfiguration != null) {
 		<liferay-ui:message key="connect-analytics-cloud" />
 	</h2>
 
-	<aui:form action="<%= editWorkspaceConnectionURL %>" data-senna-off="true" method="post" name="fm" onSubmit='<%= renderResponse.getNamespace() + "confirmation(event);" %>'>
+	<aui:form action="<%= editWorkspaceConnectionURL %>" data-senna-off="true" method="post" name="fm" onSubmit='<%= liferayPortletResponse.getNamespace() + "confirmation(event);" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
 		<c:if test="<%= connected %>">
@@ -92,7 +92,7 @@ if (analyticsConfiguration != null) {
 
 		<aui:fieldset>
 			<c:if test="<%= !connected %>">
-				<aui:input autocomplete="off" label="analytics-cloud-token" name="token" oninput='<%= renderResponse.getNamespace() + "validateTokenButton();" %>' placeholder="paste-token-here" value="<%= token %>" wrapperCssClass="mb-1" />
+				<aui:input autocomplete="off" label="analytics-cloud-token" name="token" oninput='<%= liferayPortletResponse.getNamespace() + "validateTokenButton();" %>' placeholder="paste-token-here" value="<%= token %>" wrapperCssClass="mb-1" />
 
 				<div class="form-text">
 					<liferay-ui:message key="analytics-cloud-token-help" />

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -67,7 +67,7 @@ List<Long> dataLayoutIds = (List<Long>)request.getAttribute(AppBuilderWebKeys.DA
 								).put(
 									"basePortletURL", String.valueOf(renderResponse.createRenderURL())
 								).put(
-									"containerElementId", renderResponse.getNamespace() + "container"
+									"containerElementId", liferayPortletResponse.getNamespace() + "container"
 								).put(
 									"controlMenuElementId", liferayPortletResponse.getNamespace() + "-control-menu"
 								).put(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -121,7 +121,7 @@ renderResponse.setTitle((category == null) ? LanguageUtil.get(request, "add-new-
 								).put(
 									"groupIds", Collections.singletonList(scopeGroupId)
 								).put(
-									"namespace", renderResponse.getNamespace()
+									"namespace", liferayPortletResponse.getNamespace()
 								).put(
 									"portletURL", assetCategoriesDisplayContext.getCategorySelectorURL()
 								).put(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -101,7 +101,7 @@
 								<liferay-frontend:empty-result-message
 									actionDropdownItems="<%= assetCategoriesDisplayContext.getVocabularyActionDropdownItems() %>"
 									animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
-									componentId='<%= renderResponse.getNamespace() + "emptyResultMessageComponent" %>'
+									componentId='<%= liferayPortletResponse.getNamespace() + "emptyResultMessageComponent" %>'
 									description='<%= LanguageUtil.get(request, "vocabularies-are-needed-to-create-categories") %>'
 									elementType='<%= LanguageUtil.get(request, "vocabularies") %>'
 								/>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -86,7 +86,7 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 			continue;
 		}
 
-		String taglibOnClick = renderResponse.getNamespace() + "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
+		String taglibOnClick = liferayPortletResponse.getNamespace() + "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
 	%>
 
 		<liferay-ui:icon

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/select_change_list.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/select_change_list.jsp
@@ -37,7 +37,7 @@ SelectChangeListManagementToolbarDisplayContext selectChangeListManagementToolba
 </c:if>
 
 <clay:container-fluid
-	id='<%= renderResponse.getNamespace() + "selectChangeListContainer" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "selectChangeListContainer" %>'
 >
 	<div class="table-responsive">
 		<table class="change-lists-table select-change-list-table table table-autofit">

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
@@ -24,14 +24,14 @@
 	<div class="sheet-text"><liferay-ui:message key="change-lists-help" /></div>
 
 	<div class="form-group">
-		<aui:input label="" name="enableChangeLists" onClick='<%= renderResponse.getNamespace() + "updateSubmitRedirectToOverview()" %>' type="toggle-switch" value="<%= changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" />
+		<aui:input label="" name="enableChangeLists" onClick='<%= liferayPortletResponse.getNamespace() + "updateSubmitRedirectToOverview()" %>' type="toggle-switch" value="<%= changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" />
 	</div>
 </clay:sheet-section>
 
 <clay:sheet-footer>
 	<aui:button primary="<%= true %>" type="submit" value="submit" />
 
-	<aui:button disabled="<%= !changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" name="submitRedirectToOverview" onClick='<%= renderResponse.getNamespace() + "doSubmitRedirectToOverview()" %>' primary="<%= false %>" type="submit" value="save-and-go-to-overview" />
+	<aui:button disabled="<%= !changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" name="submitRedirectToOverview" onClick='<%= liferayPortletResponse.getNamespace() + "doSubmitRedirectToOverview()" %>' primary="<%= false %>" type="submit" value="save-and-go-to-overview" />
 </clay:sheet-footer>
 
 <script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -386,14 +386,14 @@ renderResponse.setTitle(headerTitle);
 												%>
 
 												<liferay-data-engine:data-layout-renderer
-													containerId='<%= renderResponse.getNamespace() + "dataEngineLayoutRenderer" %>'
+													containerId='<%= liferayPortletResponse.getNamespace() + "dataEngineLayoutRenderer" %>'
 													dataDefinitionId="<%= ddmStructure.getStructureId() %>"
 													dataRecordValues="<%= ddmFormValuesToMapConverter.convert(ddmFormValues, DDMStructureLocalServiceUtil.getStructure(ddmStructure.getStructureId())) %>"
 													namespace="<%= liferayPortletResponse.getNamespace() %>"
 												/>
 
 												<liferay-frontend:component
-													componentId='<%= renderResponse.getNamespace() + "dataEngineLayoutRendererLanguageProxy" %>'
+													componentId='<%= liferayPortletResponse.getNamespace() + "dataEngineLayoutRendererLanguageProxy" %>'
 													module="document_library/js/dataEngineLayoutRendererLanguageProxy.es"
 													servletContext="<%= application %>"
 												/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
@@ -74,9 +74,9 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 			Map<String, Object> data = HashMapBuilder.<String, Object>put(
 				"articleResourcePrimKey", articleResourcePrimKey
 			).put(
-				"saveDraftBtnId", renderResponse.getNamespace() + "saveDraftBtn"
+				"saveDraftBtnId", liferayPortletResponse.getNamespace() + "saveDraftBtn"
 			).put(
-				"submitBtnId", renderResponse.getNamespace() + "submitBtnId"
+				"submitBtnId", liferayPortletResponse.getNamespace() + "submitBtnId"
 			).build();
 			%>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -117,7 +117,7 @@ else {
 
 <clay:sheet-section
 	className='<%= (selLayout.getMasterLayoutPlid() <= 0) ? StringPool.BLANK : "hide" %>'
-	id='<%= renderResponse.getNamespace() + "themeContainer" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "themeContainer" %>'
 >
 	<h3 class="sheet-subtitle"><liferay-ui:message key="theme" /></h3>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
@@ -33,7 +33,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-collection"));
 
 <clay:container-fluid
 	cssClass="container-view"
-	id='<%= renderResponse.getNamespace() + "collections" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "collections" %>'
 >
 	<c:choose>
 		<c:when test="<%= selectLayoutCollectionDisplayContext.isCollections() %>">

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
@@ -35,7 +35,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 
 <clay:container-fluid
 	cssClass="container-view"
-	id='<%= renderResponse.getNamespace() + "layoutPageTemplateEntries" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "layoutPageTemplateEntries" %>'
 >
 	<clay:row>
 		<clay:col>

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/layout_templates.jspf
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/layout_templates.jspf
@@ -17,7 +17,7 @@
 <c:if test="<%= marketplaceURL != null %>">
 
 	<%
-	String taglibOnClick = "submitForm(document." + renderResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
+	String taglibOnClick = "submitForm(document." + liferayPortletResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
 	%>
 
 	<aui:button onClick="<%= taglibOnClick %>" value="install-more-layout-templates" />

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/portlets.jspf
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/portlets.jspf
@@ -17,7 +17,7 @@
 <c:if test="<%= marketplaceURL != null %>">
 
 	<%
-	String taglibOnClick = "submitForm(document." + renderResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
+	String taglibOnClick = "submitForm(document." + liferayPortletResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
 	%>
 
 	<aui:button onClick="<%= taglibOnClick %>" value="install-more-portlets" />

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/themes.jspf
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/themes.jspf
@@ -17,7 +17,7 @@
 <c:if test="<%= marketplaceURL != null %>">
 
 	<%
-	String taglibOnClick = "submitForm(document." + renderResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
+	String taglibOnClick = "submitForm(document." + liferayPortletResponse.getNamespace() + "fm , '" + marketplaceURL.toString() + "');";
 	%>
 
 	<aui:button onClick="<%= taglibOnClick %>" value="install-more-themes" />

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/edit_question.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/edit_question.jsp
@@ -71,7 +71,7 @@ portletDisplay.setURLBack(redirect);
 	<portlet:param name="mvcPath" value="/polls/edit_question.jsp" />
 </liferay-portlet:actionURL>
 
-<aui:form action="<%= editQuestionURL %>" cssClass="container-fluid-1280" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveQuestion();" %>'>
+<aui:form action="<%= editQuestionURL %>" cssClass="container-fluid-1280" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveQuestion();" %>'>
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="referringPortletResource" type="hidden" value="<%= referringPortletResource %>" />
@@ -133,7 +133,7 @@ portletDisplay.setURLBack(redirect);
 
 						<c:if test="<%= choicesCount > 2 %>">
 							<div class="delete-poll-choice">
-								<aui:button cssClass="btn-delete" onClick='<%= renderResponse.getNamespace() + "deletePollChoice(" + i + ");" %>' value="delete" />
+								<aui:button cssClass="btn-delete" onClick='<%= liferayPortletResponse.getNamespace() + "deletePollChoice(" + i + ");" %>' value="delete" />
 							</div>
 						</c:if>
 					</div>
@@ -143,7 +143,7 @@ portletDisplay.setURLBack(redirect);
 				%>
 
 				<div class="button-holder">
-					<aui:button cssClass="add-choice" onClick='<%= renderResponse.getNamespace() + "addPollChoice();" %>' value="add-choice" />
+					<aui:button cssClass="add-choice" onClick='<%= liferayPortletResponse.getNamespace() + "addPollChoice();" %>' value="add-choice" />
 				</div>
 			</aui:field-wrapper>
 		</aui:fieldset>

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/management_bar.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/management_bar.jsp
@@ -24,7 +24,7 @@
 	disabled="<%= pollsDisplayContext.isDisabledManagementBar() %>"
 	filterDropdownItems="<%= pollsDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= pollsDisplayContext.getTotalItems() %>"
-	namespace="<%= renderResponse.getNamespace() %>"
+	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	searchActionURL="<%= pollsDisplayContext.getSearchActionURL() %>"
 	searchContainerId="<%= pollsDisplayContext.getSearchContainerId() %>"
 	searchFormName="fm1"

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/edit_instance.jsp
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/edit_instance.jsp
@@ -39,7 +39,7 @@ renderResponse.setTitle((selCompany == null) ? LanguageUtil.get(request, "new-in
 
 <portlet:actionURL name="/portal_instances/edit_instance" var="editInstanceURL" />
 
-<aui:form action="<%= editInstanceURL %>" cssClass="container-fluid-1280" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveCompany();" %>'>
+<aui:form action="<%= editInstanceURL %>" cssClass="container-fluid-1280" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveCompany();" %>'>
 	<aui:input name="<%= Constants.CMD %>" type="hidden" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="companyId" type="hidden" value="<%= companyId %>" />

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
@@ -148,7 +148,7 @@ else {
 		<c:if test="<%= redirectEntry != null %>">
 			<clay:alert
 				cssClass="hide"
-				id='<%= renderResponse.getNamespace() + "typeInfoAlert" %>'
+				id='<%= liferayPortletResponse.getNamespace() + "typeInfoAlert" %>'
 				message="changes-to-this-redirect-might-not-be-immediately-seen-for-users-whose-browsers-have-cached-the-old-redirect-configuration"
 			/>
 		</c:if>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
@@ -247,7 +247,7 @@ portletURL.setParameter("delta", String.valueOf(delta));
 			if (groupIds) {
 
 				<%
-				String selectEventName = renderResponse.getNamespace() + "itemSelected";
+				String selectEventName = liferayPortletResponse.getNamespace() + "itemSelected";
 				%>
 
 				<portlet:renderURL var="editSitesDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites_action.jsp
@@ -72,7 +72,7 @@ String groupId = String.valueOf(group.getGroupId());
 	function <portlet:namespace />editDefaultFilePermissions(groupId) {
 
 		<%
-		String selectEventName = renderResponse.getNamespace() + "itemSelected";
+		String selectEventName = liferayPortletResponse.getNamespace() + "itemSelected";
 		%>
 
 		<portlet:renderURL var="editDefaultFilePermissionsURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">

--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -14,6 +14,8 @@
 
     #source.check.JavaSourceFormatterDocumentationCheck.enabled=true
 
+    source.check.JSPMethodCallsCheck.enabled=true
+
     #source.check.MarkdownSourceFormatterReadmeCheck.enabled=true
 
     source.check.NewFileCheck.forbiddenDirNames=\

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSPMethodCallsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JSPMethodCallsCheck.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checks;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Alan Huang
+ */
+public class JSPMethodCallsCheck extends BaseStylingCheck {
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		Matcher matcher = _incorrectMethodCallPattern.matcher(content);
+
+		while (matcher.find()) {
+			addMessage(
+				fileName,
+				"Use tyep of 'LiferayPortletResponse' to call 'getNamespace()'",
+				getLineNumber(content, matcher.start()));
+		}
+
+		return content;
+	}
+
+	private static final Pattern _incorrectMethodCallPattern = Pattern.compile(
+		"(?<!\\bliferayPortlet)Response\\.getNamespace\\(\\)");
+
+}

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -498,7 +498,9 @@
 		<check name="JSPLanguageUtilCheck" />
 		<check name="JSPLineBreakCheck" />
 		<check name="JSPLogFileNameCheck" />
-		<check name="JSPMethodCallsCheck" />
+		<check name="JSPMethodCallsCheck">
+			<property name="enabled" value="false" />
+		</check>
 		<check name="JSPParenthesesCheck" />
 		<check name="JSPRedirectBackURLCheck" />
 		<check name="JSPSessionKeysCheck" />

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -498,6 +498,7 @@
 		<check name="JSPLanguageUtilCheck" />
 		<check name="JSPLineBreakCheck" />
 		<check name="JSPLogFileNameCheck" />
+		<check name="JSPMethodCallsCheck" />
 		<check name="JSPParenthesesCheck" />
 		<check name="JSPRedirectBackURLCheck" />
 		<check name="JSPSessionKeysCheck" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSPSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JSPSourceProcessorTest.java
@@ -62,6 +62,17 @@ public class JSPSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testIncorrectMethodCalls() throws Exception {
+		test(
+			"IncorrectMethodCalls.testjsp",
+			new String[] {
+				"Use tyep of 'LiferayPortletResponse' to call 'getNamespace()'",
+				"Use tyep of 'LiferayPortletResponse' to call 'getNamespace()'"
+			},
+			new Integer[] {21, 28});
+	}
+
+	@Test
 	public void testMisplacedImport() throws Exception {
 		test("MisplacedImport.testjsp", "Move imports to init.jsp");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/FormatBooleanScriptlet.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/FormatBooleanScriptlet.testjsp
@@ -18,14 +18,14 @@
 
 <liferay-ui:panel-container
 	extended="true"
-	id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanelContainer" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "facetAssetEntriesPanelContainer" %>'
 	markupView="lexicon"
 	persistState="true"
 >
 	<liferay-ui:panel
 		collapsible="true"
 		cssClass="search-facet"
-		id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanel" %>'
+		id='<%= liferayPortletResponse.getNamespace() + "facetAssetEntriesPanel" %>'
 		markupView="lexicon"
 		persistState="true"
 		title="type"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectMethodCalls.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectMethodCalls.testjsp
@@ -1,0 +1,33 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<liferay-ui:panel-container
+	extended="<%= true %>"
+	id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanelContainer" %>'
+	markupView="lexicon"
+	persistState="<%= true %>"
+>
+	<liferay-ui:panel
+		collapsible="<%= true %>"
+		cssClass="search-facet"
+		id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanel" %>'
+		markupView="lexicon"
+		persistState="<%= true %>"
+		title="type"
+	/>
+</liferay-ui:panel-container>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/FormatBooleanScriptlet.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/FormatBooleanScriptlet.testjsp
@@ -18,14 +18,14 @@
 
 <liferay-ui:panel-container
 	extended="<%= true %>"
-	id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanelContainer" %>'
+	id='<%= liferayPortletResponse.getNamespace() + "facetAssetEntriesPanelContainer" %>'
 	markupView="lexicon"
 	persistState="<%= true %>"
 >
 	<liferay-ui:panel
 		collapsible="<%= true %>"
 		cssClass="search-facet"
-		id='<%= renderResponse.getNamespace() + "facetAssetEntriesPanel" %>'
+		id='<%= liferayPortletResponse.getNamespace() + "facetAssetEntriesPanel" %>'
 		markupView="lexicon"
 		persistState="<%= true %>"
 		title="type"

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -906,7 +906,7 @@ Boolean renderPortletBoundary = GetterUtil.getBoolean(request.getAttribute(WebKe
 	}
 	%>
 
-	<div class="<%= cssClasses %>" id="p_p_id<%= HtmlUtil.escapeAttribute(liferayRenderResponse.getNamespace()) %>">
+	<div class="<%= cssClasses %>" id="p_p_id<%= HtmlUtil.escapeAttribute((PortalUtil.getLiferayPortletResponse(liferayRenderResponse)).getNamespace()) %>">
 		<span id="p_<%= HtmlUtil.escapeAttribute(portletId) %>"></span>
 </c:if>
 
@@ -979,7 +979,7 @@ else {
 			canEditTitle: <%= canEditTitle %>,
 			columnPos: <%= columnPos %>,
 			isStatic: '<%= staticVar %>',
-			namespacedId: 'p_p_id<%= HtmlUtil.escapeJS(liferayRenderResponse.getNamespace()) %>',
+			namespacedId: 'p_p_id<%= HtmlUtil.escapeJS((PortalUtil.getLiferayPortletResponse(liferayRenderResponse)).getNamespace()) %>',
 			portletId: '<%= HtmlUtil.escapeJS(portletDisplay.getId()) %>',
 			refreshURL: '<%= HtmlUtil.escapeJS(PortletURLUtil.getRefreshURL(request, themeDisplay, false)) %>',
 			refreshURLData: <%= JSONFactoryUtil.looseSerializeDeep(PortletURLUtil.getRefreshURLParameters(request)) %>

--- a/portal-web/docroot/html/taglib/aui/col/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/col/init-ext.jspf
@@ -16,7 +16,7 @@
 
 <%
 if (Validator.isNotNull(id)) {
-	id = portletResponse.getNamespace() + id;
+	id = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + id;
 }
 
 StringBundler sb = new StringBundler();

--- a/portal-web/docroot/html/taglib/aui/container/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/container/init-ext.jspf
@@ -16,6 +16,6 @@
 
 <%
 if ((portletResponse != null) && Validator.isNotNull(id)) {
-	id = portletResponse.getNamespace() + id;
+	id = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + id;
 }
 %>

--- a/portal-web/docroot/html/taglib/aui/nav_bar/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/nav_bar/init-ext.jspf
@@ -24,7 +24,7 @@ if (bodyContent != null) {
 }
 
 if ((portletResponse != null) && Validator.isNotNull(id)) {
-	id = portletResponse.getNamespace() + id;
+	id = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + id;
 }
 
 if (Validator.isNull(id)) {

--- a/portal-web/docroot/html/taglib/aui/nav_item/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/nav_item/init-ext.jspf
@@ -21,7 +21,7 @@ if (Validator.isNull(id)) {
 	id = randomNamespace;
 }
 else if (portletResponse != null) {
-	id = portletResponse.getNamespace() + id;
+	id = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + id;
 }
 
 if (useDialog && Validator.isNull(anchorId)) {
@@ -29,7 +29,7 @@ if (useDialog && Validator.isNull(anchorId)) {
 }
 
 if ((portletResponse != null) && Validator.isNotNull(anchorId)) {
-	anchorId = portletResponse.getNamespace() + anchorId;
+	anchorId = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + anchorId;
 }
 
 if (dropdown) {

--- a/portal-web/docroot/html/taglib/aui/row/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/row/init-ext.jspf
@@ -16,6 +16,6 @@
 
 <%
 if ((portletResponse != null) && Validator.isNotNull(id)) {
-	id = portletResponse.getNamespace() + id;
+	id = (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + id;
 }
 %>

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -332,6 +332,8 @@
 
     source.check.JavaTestMethodAnnotationsCheck.enabled=true
 
+    source.check.JSPMethodCallsCheck.enabled=true
+
     source.check.PropertiesBuildIncludeDirsCheck.buildIncludeCategoryNames=\
         apps,\
         core,\


### PR DESCRIPTION
Hi Hugo,

Issue:

> Brian Chan  1:24 AM
> Hey guys, in JSPs, whereever we have "renderResponse.getNamespace()", or *Response.getNamespace" can you change it to "liferayPortletResponse.getNamespace()
> 1:25
> See portal master 4a701e42d4e8f1e3a11cdcd73952cbe063a8cb1a and dc406dea9d031fd3209834c64a6e1857faa9c69d for more context. Ppl are spending time fixing bugs changing renderResponse, but the proper fix is liferayPortletResponse which will work 100% of the time.