### PR TITLE
LPS-105380_JavaClassNameCheck_20200924

### DIFF
--- a/modules/test/source-formatter-suppressions.xml
+++ b/modules/test/source-formatter-suppressions.xml
@@ -4,7 +4,6 @@
 	<checkstyle>
 		<suppress checks="CamelCaseNameCheck" files="jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/.*" />
 		<suppress checks="CamelCaseNameCheck" files="jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/.*" />
-		<suppress checks="ChainingCheck" files="poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil\.java" />
 		<suppress checks="ConstantNameCheck" files="jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild\.java" />
 		<suppress checks="ParsePrimitiveTypeCheck" files="arquillian-extension-junit-bridge/src/main/java/com/liferay/arquillian/extension/junit/bridge/server/TestBundleActivator\.java" />
 	</checkstyle>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaClassNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaClassNameCheck.java
@@ -141,6 +141,10 @@ public class JavaClassNameCheck extends BaseJavaTermCheck {
 			packageNameParts[packageNameParts.length - level];
 
 		if (classNamePart.equals(packageNamePart)) {
+			if (packageNameParts.length == 1) {
+				return;
+			}
+
 			_checkTypo(fileName, className, packageName, level + 1);
 		}
 		else if (SourceUtil.hasTypo(classNamePart, packageNamePart)) {


### PR DESCRIPTION
Hi Hugo,

IDE reported issue when they use SF on java file which has only one level package.

**Test file:**
```
/**
 * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
...
...
 * details.
 */

package icons;

import com.intellij.openapi.util.IconLoader;

import javax.swing.Icon;

/**
 * @author Joye Luo
 */
public class LiferayIcons {

	public static final Icon BND_ICON = IconLoader.getIcon("/icons/bnd.png");

...
}
```

**SF error:**
```
java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Unable to format ./src/main/java/icons/LiferayIcons.java
        at java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.util.concurrent.FutureTask.get(FutureTask.java:192)
        at com.liferay.source.formatter.SourceFormatter.format(SourceFormatter.java:380)
        at com.liferay.source.formatter.SourceFormatter.main(SourceFormatter.java:276)
Caused by: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Unable to format ./src/main/java/icons/LiferayIcons.java
        at java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.util.concurrent.FutureTask.get(FutureTask.java:192)
        at com.liferay.source.formatter.BaseSourceProcessor.format(BaseSourceProcessor.java:137)
        at com.liferay.source.formatter.SourceFormatter._runSourceProcessor(SourceFormatter.java:988)
        at com.liferay.source.formatter.SourceFormatter.access$000(SourceFormatter.java:69)
        at com.liferay.source.formatter.SourceFormatter$1.call(SourceFormatter.java:366)
        at com.liferay.source.formatter.SourceFormatter$1.call(SourceFormatter.java:362)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: Unable to format ./src/main/java/icons/LiferayIcons.java
        at com.liferay.source.formatter.BaseSourceProcessor._performTask(BaseSourceProcessor.java:757)
        at com.liferay.source.formatter.BaseSourceProcessor.access$000(BaseSourceProcessor.java:77)
        at com.liferay.source.formatter.BaseSourceProcessor$1.call(BaseSourceProcessor.java:126)
        at com.liferay.source.formatter.BaseSourceProcessor$1.call(BaseSourceProcessor.java:122)
        ... 4 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
        at com.liferay.source.formatter.checks.JavaClassNameCheck._checkTypo(JavaClassNameCheck.java:140)
        at com.liferay.source.formatter.checks.JavaClassNameCheck._checkTypo(JavaClassNameCheck.java:144)
        at com.liferay.source.formatter.checks.JavaClassNameCheck.doProcess(JavaClassNameCheck.java:54)
        at com.liferay.source.formatter.checks.BaseJavaTermCheck._walkJavaClass(BaseJavaTermCheck.java:178)
        at com.liferay.source.formatter.checks.BaseJavaTermCheck.process(BaseJavaTermCheck.java:46)
        at com.liferay.source.formatter.checks.util.SourceChecksUtil._processJavaTermCheck(SourceChecksUtil.java:356)
        at com.liferay.source.formatter.checks.util.SourceChecksUtil.processSourceChecks(SourceChecksUtil.java:149)
        at com.liferay.source.formatter.BaseSourceProcessor._processSourceChecks(BaseSourceProcessor.java:768)
        at com.liferay.source.formatter.BaseSourceProcessor.format(BaseSourceProcessor.java:336)
        at com.liferay.source.formatter.BaseSourceProcessor.format(BaseSourceProcessor.java:307)
        at com.liferay.source.formatter.JavaSourceProcessor.format(JavaSourceProcessor.java:71)
        at com.liferay.source.formatter.BaseSourceProcessor._format(BaseSourceProcessor.java:645)
        at com.liferay.source.formatter.BaseSourceProcessor._performTask(BaseSourceProcessor.java:745)
        ... 7 more


```