### PR TITLE
LPS-105380_Path_20210208_2

### DIFF
--- a/modules/apps/account/account-test/src/testFunctional/paths/Account.path
+++ b/modules/apps/account/account-test/src/testFunctional/paths/Account.path
@@ -2,11 +2,13 @@
 <head>
 <title>Account</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Account</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACCOUNT_DOMAIN_ADD_LINK</td>

--- a/modules/apps/account/account-test/src/testFunctional/paths/AccountGroup.path
+++ b/modules/apps/account/account-test/src/testFunctional/paths/AccountGroup.path
@@ -2,11 +2,13 @@
 <head>
 <title>AccountGroup</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AccountGroup</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACCOUNT_GROUP_ACCOUNTS</td>

--- a/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/AppBuilder.path
+++ b/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/AppBuilder.path
@@ -2,11 +2,13 @@
 <head>
 <title>AppBuilder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AppBuilder</td></tr>
 </thead>
+
 <tbody>
 
 <!-- CUSTOM_OBJECTS_LISTING_SCREEN -->
@@ -114,9 +116,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SAVE_BUTTON_DISABLED</td>
-    <td>//button[@disabled='' and contains(@class,'btn-primary') and contains(text(),'Save')]</td>
-    <td></td>
+	<td>SAVE_BUTTON_DISABLED</td>
+	<td>//button[@disabled='' and contains(@class,'btn-primary') and contains(text(),'Save')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>FORM_VIEW_TAB</td>
@@ -318,9 +320,9 @@
 	<td></td>
 </tr>
 <tr>
- 	<td>ENTRY_SUCCESS_MESSAGE</td>
- 	<td>//div[contains(text(),'An entry was added.')]</td>
- 	<td></td>
+	<td>ENTRY_SUCCESS_MESSAGE</td>
+	<td>//div[contains(text(),'An entry was added.')]</td>
+	<td></td>
 </tr>
 
 <!-- CONFIGURATION_PERMISSIONS -->

--- a/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/DetailsView.path
+++ b/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/DetailsView.path
@@ -2,11 +2,13 @@
 <head>
 <title>DetailsView</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DetailsView</td></tr>
 </thead>
+
 <tbody>
 
 <!--DETAILS_VIEW-->
@@ -16,37 +18,31 @@
 </td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PREVIOUS_ENTRY</td>
 	<td>//button//*[contains(@class,'lexicon-icon-angle-left')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>NEXT_ENTRY</td>
 	<td>//button//*[contains(@class,'lexicon-icon-angle-right')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>EDIT_ENTRY</td>
 	<td>//button[contains(@title,'Edit')] | //div[contains(@class,'show')]//button[contains(text(),'Edit')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>DELETE_ENTRY</td>
 	<td>//button[contains(@title,'Delete')] | //div[contains(@class,'show')]//button[contains(text(),'Delete')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VIEW_ENTRY</td>
 	<td>//div[@class='sheet']//*[contains(text(),'${value1}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>BACK_TO_TABLE_VIEW</td>
 	<td>xpath=(//div[contains(@class,'app-builder-control-menu')] | //div[contains(@class,'control-menu')]//*[contains(@class,'lexicon-icon-angle-left')])</td>
@@ -62,8 +58,6 @@
 	<td>//span[contains(text(),'Step')]/parent::div[contains(text(),'${key_step}')]</td>
 	<td></td>
 </tr>
-
-
 
 </tbody>
 </table>

--- a/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/FormViewBuilder.path
+++ b/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/FormViewBuilder.path
@@ -2,11 +2,13 @@
 <head>
 <title>FormViewBuilder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormViewBuilder</td></tr>
 </thead>
+
 <tbody>
 
 <!--FIELDS_SIDEBAR-->
@@ -15,199 +17,166 @@
 	<td>//div[contains(@class,'tab-content')]//div[contains(@class,'field-type')]//span[text()='${key_fieldLabel}']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_BASIC_TAB</td>
 	<td>//span[contains(text(),'Basic')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_TAB</td>
 	<td>//span[contains(text(),'Advanced')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_AUTOCOMPLETE_TAB</td>
 	<td>//span[contains(text(),'Autocomplete')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FORM_VIEW_NAME</td>
 	<td>//input[contains(@placeholder,'Untitled')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_LABEL</td>
 	<td>//label[text()='${fieldLabel}'] | //legend[text()='${fieldLabel}']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_LABEL</td>
 	<td>//span[contains(@class,'panel-title') and contains(text(),'${ruleLabel}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_LABEL_AT_SIDEBAR</td>
 	<td>//input[contains (@name,'${key_fieldType}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_LABEL_MULTIPLE_SELECTION</td>
 	<td>//span[@class='custom-control-label-text' and contains(text(), '${key_fieldType}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_VALUE</td>
 	<td>//input[contains (@name,'${key_fieldType}') and @value='${fieldLabel}']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_FIELDS_TAB</td>
 	<td>//li[@class='nav-item']//*[contains(text(),'Fields')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_BASIC_LABEL</td>
 	<td>//input[contains(@name,'label')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SWITCHER_OPTION</td>
 	<td>//div[contains(@data-field-name,'${key_switcherOption}')]//input[@class='toggle-switch-check']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_BASIC_HELP_TEXT</td>
 	<td>//input[contains(@name,'tip')]</td>
 	<td></td>
 </tr>
-
 <tr>
-    <td>HELP_TEXT_AT_APP_DEPLOYED</td>
-    <td>//span[contains(text(),'${fieldValue}')]</td>
-    <td></td>
+	<td>HELP_TEXT_AT_APP_DEPLOYED</td>
+	<td>//span[contains(text(),'${fieldValue}')]</td>
+	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_BASIC_PLACEHOLDER</td>
 	<td>//input[contains(@name,'placeholder')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_FIELD_NAME</td>
 	<td>//input[contains(@name,'name')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_SHOW_LABEL</td>
 	<td>//input[contains(@name,'showLabel')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_REPEATABLE</td>
 	<td>//input[contains(@name,'repeatable')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_AUTOCOMPLETE_AUTOCOMPLETE</td>
 	<td>//input[contains(@name,'autocomplete')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CLOSE_SIDEBAR</td>
 	<td>//div[contains(@class,'sidebar-header')]//*[contains(@class,'lexicon-icon-angle-left')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OPEN_SIDEBAR</td>
 	<td>//div[contains(@class,'sidebar-header')]//*[contains(@class,'lexicon-icon-angle-right')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OPTIONS_OPTION_VALUE_FIELD</td>
 	<td>//div[contains(@class,'ddm-field-options-container')]//div[contains(@class,'ddm-field-options')][${key_rowNumber}]//input[contains(@name,'keyValueLabeloption')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OPTIONS_OPTION_NAME_FIELD</td>
 	<td>//div[contains(@class,'ddm-field-options-container')]//div[contains(@class,'ddm-field-options')]['${key_rowNumber}']//div[contains(@class, 'key-value-editor')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_LABEL_REQUIRED</td>
 	<td>//label[contains(text(),'${fieldLabel}')] | //legend[contains(text(),'${fieldLabel}')] | //label[contains(text(),'${fieldLabel}')]/span[@class='reference-mark']/*[contains(@class,'lexicon-icon-asterisk')] | //legend[contains(text(),'${fieldLabel}')]/span[@class='reference-mark']/*[contains(@class,'lexicon-icon-asterisk')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_FIELD_REFERENCE</td>
 	<td>//input[contains(@name,'fieldReference')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_PREDEFINED_TEXT</td>
 	<td>//input[contains(@name,'predefinedValue')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_PREDEFINED_DATE</td>
 	<td>//input[contains(@name,'predefinedValue')]/..//input[@type!="hidden"]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SIDEBAR_ADVANCED_PREDEFINED_SELECT_FROM_LIST</td>
 	<td>//div[contains(@data-field-name,'predefinedValue')]//div[contains(@class,'form-builder-select-field')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PREDEFINED_VALUE_AT_FORM</td>
 	<td>//label[contains(text(),'${key_fieldName}')]/..//input[contains(@value,'${key_fieldValue}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PREDEFINED_VALUE_AT_FORM_DATE_FIELD</td>
 	<td>//label[contains(text(),'${key_fieldName}')]/..//input[contains(@value,'${key_fieldValue}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PREDEFINED_VALUE_AT_FORM_SINGLE_SELECTION</td>
 	<td>//legend[contains(text(),'${key_fieldName}')]/..//span[contains(.,'${key_fieldValue}')]/../input[contains(@type,'radio')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PREDEFINED_VALUE_AT_FORM_SELECTLIST</td>
 	<td>//label[contains(text(),'${key_fieldName}')]/..//div[contains(@class,'option-selected') and contains(text(),'${key_fieldValue}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>PROPAGATE_CHANGES</td>
 	<td>//button[contains(@class,'btn-primary') and contains(text(),'Propagate')]</td>
@@ -228,7 +197,6 @@
 	<td>//label[contains(text(),'${key_fieldName}')]/following-sibling::div[contains(@class,'ddm-select-dropdown') or contains(@class,'input-group-container')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>SELECT_FIELD_OPTIONS_LIST</td>
 	<td>//div[contains(@class, 'dropdown-menu') and contains(@class, 'show')]//li[contains(.,'${key_selectOption}')]</td>
@@ -241,25 +209,21 @@
 	<td>//input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldName}')]/..//preceding-sibling::input[contains(@type,'checkbox')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CHECKBOX_AT_FORM_BODY</td>
 	<td>//legend[contains(text(),'${key_fieldName}')]/..//input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldValue}')]/..//input[contains(@type,'checkbox')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CHECKBOX_LABEL</td>
 	<td>//legend[contains(text(),'${key_fieldName}')]/..//input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldValue}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CHECKBOX_PREDEFINED</td>
 	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//button[contains(@label,'${key_fieldName}')]//input[contains(@type,'checkbox')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CHECKBOX_PREDEFINED_LIST</td>
 	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//button[contains(@label,'${key_fieldName}')]</td>
@@ -279,13 +243,11 @@
 	<td>//label[contains(text(),'${key_fieldName}')]/..//input[@type!="hidden"]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>TEXT_BOX_FIELD</td>
 	<td>//label[contains(text(),'${key_fieldName}')]/..//input[1]</td>
 	<td></td>
 </tr>
-
 
 <!--OBJECT_SIDEBAR-->
 <tr>
@@ -293,25 +255,21 @@
 	<td>//div[contains(@class,'custom-object-field')]//span[contains(text(),'${key_fieldLabel}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>DELETE_FROM_OBJECT_X_BUTTON</td>
 	<td>//div[contains(@class,'autofit-col-expand') and contains(.,'${fieldName}')]//..//div[@class='field-type-remove-icon']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OBJECT_FIELD_PLUS</td>
 	<td>//div[contains(@class,'custom-object-sidebar-header')]//*[contains(@class,'lexicon-icon-plus')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OBJECT_FIELD_SEARCH_BUTTON</td>
 	<td>//div[contains(@class,'custom-object-sidebar-header')]//*[contains(@class,'lexicon-icon-search')]</td>
 	<td></td>
 </tr>
-
 
 <!--DELETE_OBJECT-->
 <tr>
@@ -319,37 +277,31 @@
 	<td>//div[contains(@class,'modal d-block show')]//div[@class='btn-group-item']//*[contains(text(),'Cancel')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OBJECT_FIELD_SEARCH_BOX</td>
 	<td>//div[contains(@class,'custom-object-sidebar-header')]//input</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OBJECT_FIELD_SEARCH_RESULT</td>
 	<td>//div[contains(@class,'custom-object-field')]//span[contains(text(),'${key_fieldName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VALIDATE_DELETE_USED_OBJECT_MESSAGE</td>
 	<td>//p[@class='remove-object-field-message'][contains(text(),'Deleting a field also deletes the data stored for the field. The field will be removed from these views:')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>OBJECT_FIELD_BUTTON_DROPDOWN</td>
 	<td>//button[@class='dropdown-item' and contains(text(),'${key_fieldName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VALIDATE_USED_FORM_VIEW</td>
 	<td>//div[contains(@class,'remove-object-field-panel') and //span[contains(text(),'Form Views')]]//label[contains(text(),'${formViewName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VALIDATE_USED_TABLE_VIEW</td>
 	<td>//div[contains(@class,'remove-object-field-panel') and //span[contains(text(),'Table Views')]]//label[contains(text(),'${tableViewName}')]</td>
@@ -362,7 +314,6 @@
 	<td>//div[@class='dropdown dropdown-action']//*[contains(@class,'lexicon-icon-ellipsis-v')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_ELLIPSIS_ACTION</td>
 	<td>//div[contains(@class,'dropdown-menu show')]//button[contains(@class,'dropdown-item')][contains(text(),'${key_selectAction}')]</td>
@@ -376,13 +327,11 @@
 	<td>//div[contains(@class,'modal d-block show')]//button[contains(@class,'btn btn-primary')][contains(text(),'Delete')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VALIDATE_DELETE_OBJECT_MESSAGE</td>
 	<td>//p[@class='remove-object-field-message'][contains(text(),'Are you sure you want to delete this field? It will be deleted immediately.')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>VALIDATE_OBJECT_SIDEBAR_FIELD_NAME</td>
 	<td>//div[contains(@class,'custom-object-field autofit-row autofit-row-center')]//small[contains(text(),'${fieldName}')]</td>
@@ -415,181 +364,151 @@
 	<td>//input[@placeholder='Untitled Rule']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CREATE_NEW_RULE_BUTTON</td>
 	<td>//button[contains(text(),'Create New Rule')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>EDIT_RULE_COLLAPSE</td>
 	<td>//button[contains(@class,'collapse') and contains(@aria-expanded,'false')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>EDIT_RULE_EXPANDED</td>
 	<td>//button[contains(@class,'collapse') and contains(@aria-expanded,'true')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>EDIT_RULE</td>
 	<td>//div[contains(@class,'panel-body')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_FIRST_FIELD</td>
 	<td>//div[contains(@class,'panel-body')]//span[contains(.,'${key_firstField}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_SECOND_FIELD</td>
 	<td>//div[contains(@class,'panel-body')]//span[contains(.,'${key_secondField}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_CONDITION</td>
 	<td>//div[contains(@class,'panel-body')]//span[contains(.,'${key_condition}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_ACTION</td>
 	<td>//div[contains(@class,'panel-body')]//span[contains(.,'${key_action}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_SAVE_BUTTON</td>
 	<td>//div[contains(@class, 'modal-item-last')]//button[contains(@class,'btn-primary')][contains(text(),'Save')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_OR_FIELD_SET_BUILDER_CANCEL_BUTTON</td>
 	<td>xpath=(//div[contains(@class, 'modal-item-last')]//button[contains(@class,'btn-secondary')][contains(text(),'Cancel')])</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_DEFAULT_EDIT</td>
 	<td>//div[contains(@class, 'collapse-icon-options')]//button[contains(@class, 'dropdown-toggle')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_EDIT</td>
 	<td>//button[contains(text(),'Edit')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_FORM_VIEW_NAME</td>
 	<td>//input[contains(@placeholder,'Untitled Form View')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>ASSERT_FORM</td>
 	<td>//td[contains(@class,'table-cell-expand') and contains(.,'${key_formViewName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>BUTTON_LOCALIZATION</td>
 	<td>//button[contains(@class, 'dropdown-toggle btn btn-monospaced btn-secondary') and contains(@symbol, '${key_symbolName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>BUTTON_LOCALIZATION_FIELD_SET</td>
 	<td>//div[contains(@class, 'modal-header')]//button[contains(@class, 'dropdown-toggle btn btn-monospaced btn-secondary') and contains(@symbol, '${key_symbolName}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>LOCALIZATION_LIST</td>
 	<td>//span[contains(@class, 'autofit-section') and contains(., '${key_localizationList}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>LOCALIZATION_LIST_FIELD_SET</td>
 	<td>xpath=(//span[contains(@class, 'autofit-section') and contains(., '${key_localizationList}')])[2]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>TRANSLATED_LIST_FIELD_SET</td>
 	<td>xpath=(//span[contains(@class,'autofit-col-expand') and contains (.,'${key_localizationName}')]/following-sibling::span[contains(@class,'autofit-col') and contains(.,'${key_statusName}')])[2]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>RULE_BUILDER_GO_BACK</td>
 	<td>//div[contains(@class, 'sidebar-header')]//button[contains(@class,'btn btn-secondary')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_SETS_TAB</td>
 	<td>//button[contains(@class,'btn btn-unstyled') and contains(.,'Fieldsets')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CREATE_NEW_FIELD_SETS</td>
 	<td>//button[contains(@class,'btn-secondary') and contains(.,'Create New Fieldset')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_SET_NAME</td>
 	<td>//input[contains(@placeholder,'Untitled Fieldset')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_SET_SAVE_BUTTON</td>
 	<td>//div[contains(@class, 'modal-footer')]//button[contains(@class,'btn-primary')][contains(text(),'Save')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_SET_ELLIPSIS_ACTION</td>
 	<td>//div[contains(@class, 'field-type autofit-row autofit-row-center')]['${key_rowNumber}']//div[contains(@class, 'autofit-col pr-2')]//div[contains(@class, 'dropdown')]//button[contains(@class, 'btn btn-monospaced btn-unstyled')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_SET_DISABLED_ELLIPSIS_ACTION</td>
 	<td>//div[contains(@class, 'field-type disabled autofit-row autofit-row-center')]['${key_rowNumber}']//div[contains(@class, 'autofit-col pr-2')]//div[contains(@class, 'dropdown')]//button[contains(@class, 'btn btn-monospaced btn-unstyled')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>EMPTY_FORM_FIELD</td>
 	<td>//p[contains(text(),'Drag fields from the sidebar to compose your form.')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FORM_FIELD_FIRST_ROW</td>
 	<td>//div[contains(@class,"placeholder row")]//div[contains(@data-ddm-field-page, "0") and contains(@data-ddm-field-row, "0")]//div[contains(@class, "ddm-target")]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FORM_FIELD_FIRST_ITEM</td>
 	<td>//div[contains(@class,"form-group") and contains(.,'${key_fieldLabel}')]//label</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FORM_FIELD_REQUIRED_ITEM</td>
 	<td>//div[contains(@class, 'ddm-field')]//label[contains(., 'Rich Text')]//span[contains(@class, 'ddm-label-required')]</td>

--- a/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/TableViewBuilder.path
+++ b/modules/apps/app-builder/app-builder-test/src/testFunctional/paths/TableViewBuilder.path
@@ -2,33 +2,32 @@
 <head>
 <title>TableViewBuilder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TableViewBuilder</td></tr>
 </thead>
+
 <tbody>
 
 <!--COLUMN_FIELDS-->
 
 <tr>
-    <td>ADD_FIELD_POSITION</td>
-    <td>xpath=(//div[contains(@class,'drop-zone')])[2]</td>
-    <td></td>
+	<td>ADD_FIELD_POSITION</td>
+	<td>xpath=(//div[contains(@class,'drop-zone')])[2]</td>
+	<td></td>
 </tr>
-
 <tr>
 	<td>COLUMN_LABEL</td>
 	<td>//table//div[contains(@class,'col') and contains(.,'${columnLabel}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>DELETE_COLUMN_BY_NAME</td>
 	<td>//header[contains(*, '${columnLabel}')]//button[(@data-title='Remove')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FIELD_LABEL</td>
 	<td>//div[@class='autofit-col']//span[contains(text(),'${key_fieldType}')]</td>
@@ -41,31 +40,26 @@
 	<td>//button[contains(@class,'btn')]//*[contains(@class,'lexicon-icon-times')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>CLOSE_COLUMN_SIDEBAR</td>
 	<td>//div[contains(@class,'sidebar-header')]//*[contains(@class,'lexicon-icon-angle-left')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>COLUMN_LABEL_AT_SIDEBAR</td>
 	<td>//div[contains(@class,'app-builder-table-view__sidebar')]//span[contains(text(),'${columnLabel}')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>TAB_LABEL</td>
 	<td>//button[contains(@role,'tab') and text()='${key_tabName}']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FILTER_DROPDOWN</td>
 	<td>//label[text()='${key_columnLabel}']/parent::div//span[contains(@class,'filter')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>DISABLED_COLUMN</td>
 	<td>//div[contains(@class,'field-type disabled')]//span[contains(text(),'${fieldType}')]</td>
@@ -79,13 +73,11 @@
 	<td>//button[contains(@class,'dropdown') and text()='${key_dropdownItem}']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FILTER_SELECT_ALL</td>
 	<td>//div[contains(@class,'show')]//span[contains(@class,'dropdown')]//button[text()='Select All']</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>FILTER_CLEAR</td>
 	<td>//div[contains(@class,'show')]//span[contains(@class,'dropdown')]//button[text()='Clear']</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/Calendar.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/Calendar.path
@@ -2,11 +2,13 @@
 <head>
 <title>Calendar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Calendar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_EVENT_BUTTON</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarAgendaView.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarAgendaView.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarAgendaView</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarAgendaView</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SCHEDULER_VIEW_AGENDA</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarConfiguration.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--EVENTS_DISPLAYED-->
 <tr>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarDayView.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarDayView.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarDayView</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarDayView</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SCHEDULER_VIEW_DAY</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditCalendar.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditCalendar.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarEditCalendar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarEditCalendar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENABLE_COMMENTS_CHECKBOX</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditEvent.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditEvent.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarEditEvent</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarEditEvent</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DATE_CONTAINER</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditResource.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarEditResource.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarEditResource</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarEditResource</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DETAILS_PANEL_COLLAPSED</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarImport.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarImport.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarImport</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarImport</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SUCCESS_MESSAGE</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarManageCalendars.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarManageCalendars.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarManageCalendars</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarManageCalendars</td></tr>
 </thead>
+
 <tbody>
 <!--CALENDAR_TABLE-->
 <tr>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarMonthView.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarMonthView.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarMonthView</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarMonthView</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SCHEDULER_VIEW_MONTH</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarPermissions.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarPermissions.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarPermissions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarPermissions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PERMISSIONS_TITLE</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarRSS.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarRSS.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarRSS</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarRSS</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FEED_EVENT_LINK</td>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarResources.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarResources.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarResources</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarResources</td></tr>
 </thead>
+
 <tbody>
 <!--RESOURCE_TABLE-->
 <tr>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarViewEventDetails.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarViewEventDetails.path
@@ -2,11 +2,13 @@
 <head>
 <title>CalendarViewEventDetails</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CalendarViewEventDetails</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>STATUS</td>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceAccelerators.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceAccelerators.path
@@ -2,11 +2,13 @@
 <head>
 <title>CommerceAccelerators</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CommerceAccelerators</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACCOUNT_MANAGEMENT_ADD_MODAL_PLUS_BUTTON</td>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>CommerceEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CommerceEntry</td></tr>
 </thead>
+
 <tbody>
 	<tr>
 	<td>ANY_MENU_ITEM</td>
@@ -411,7 +413,7 @@
 <tr>
 	<td>ROW_VERTICAL_ELLIPSIS</td>
 	<td>//td//span[*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
-    <td></td>
+	<td></td>
 </tr>
 <tr>
 	<td>TABLE_ENTRY_NAME</td>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceFrontStore.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceFrontStore.path
@@ -2,11 +2,13 @@
 <head>
 <title>CommerceFrontStore</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CommerceFrontStore</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FS_PRODUCT_PRICE</td>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
@@ -2,11 +2,13 @@
 <head>
 <title>CommerceNavigation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CommerceNavigation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CPOPTIONS_STATUS</td>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceOrders.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceOrders.path
@@ -2,61 +2,63 @@
 <head>
 <title>CommerceOrders</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CommerceOrders</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>ORDER_DETAILS_BILLING_ADDRESS</td>
-    <td>//h5[contains(.,'Billing Address')]/../../div</td>
-    <td></td>
+	<td>ORDER_DETAILS_BILLING_ADDRESS</td>
+	<td>//h5[contains(.,'Billing Address')]/../../div</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PAYMENT_METHOD_NAME</td>
-    <td>//span[contains(@class,'payment-name')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PAYMENT_METHOD_NAME</td>
+	<td>//span[contains(@class,'payment-name')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PRODUCT_DISCOUNT</td>
-    <td>//table[contains(@class,'table')]//td[contains(.,'${key_productDiscount}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PRODUCT_DISCOUNT</td>
+	<td>//table[contains(@class,'table')]//td[contains(.,'${key_productDiscount}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PRODUCT_NAME</td>
-    <td>//table[contains(@class,'table')]//td[contains(.,'${key_productName}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PRODUCT_NAME</td>
+	<td>//table[contains(@class,'table')]//td[contains(.,'${key_productName}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_TOTAL_PRICE</td>
-    <td>//table[contains(@class,'table')]//td[contains(.,'${key_productTotalPrice}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_TOTAL_PRICE</td>
+	<td>//table[contains(@class,'table')]//td[contains(.,'${key_productTotalPrice}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PRODUCT_QUANTITY</td>
-    <td>//table[contains(@class,'table')]//td[contains(.,'${key_productQuantity}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PRODUCT_QUANTITY</td>
+	<td>//table[contains(@class,'table')]//td[contains(.,'${key_productQuantity}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PRODUCT_SKU</td>
-    <td>//table[contains(@class,'table')]//td[2]//a[contains(.,'${key_productSKU}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PRODUCT_SKU</td>
+	<td>//table[contains(@class,'table')]//td[2]//a[contains(.,'${key_productSKU}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_PRODUCT_LIST_PRICE</td>
-    <td>//table[contains(@class,'table')]//td[contains(.,'${key_productListPrice}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_PRODUCT_LIST_PRICE</td>
+	<td>//table[contains(@class,'table')]//td[contains(.,'${key_productListPrice}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_DETAILS_SHIPPING_ADDRESS</td>
-    <td>//h5[contains(.,'Shipping Address')]/../../div[contains(.,'${key_addressInfo}')]</td>
-    <td></td>
+	<td>ORDER_DETAILS_SHIPPING_ADDRESS</td>
+	<td>//h5[contains(.,'Shipping Address')]/../../div[contains(.,'${key_addressInfo}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ORDER_ITEMS_PRODUCT_DETAILS</td>
-    <td>//tbody//td[2][contains(.,'${key_productSKU}')]/..//div[@class='table-list-title']/button</td>
-    <td></td>
+	<td>ORDER_ITEMS_PRODUCT_DETAILS</td>
+	<td>//tbody//td[2][contains(.,'${key_productSKU}')]/..//div[@class='table-list-title']/button</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/path/DataEngineBuilder.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/path/DataEngineBuilder.path
@@ -2,11 +2,13 @@
 <head>
 <title>DataEngineBuilder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DataEngineBuilder</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ELLIPSIS_NESTED_FIELD_GROUP</td>
@@ -97,7 +99,6 @@
 	<td>PANEL_COLLAPSE_BUTTON</td>
 	<td>//div[contains(@class,'collapsable-panel')]//button[contains(@class,'collapse-icon')]</td>
 	<td></td>
-
 </tr>
 <tr>
 	<td>WEB_CONTENT_TEXT_FIELD</td>

--- a/modules/apps/document-library/document-library-web/src/main/resources/content/Language.properties
+++ b/modules/apps/document-library/document-library-web/src/main/resources/content/Language.properties
@@ -190,7 +190,6 @@ you-cannot-perform-this-operation-on-checked-out-documents-.please-check-it-in-o
 you-cannot-remove-default-attributes=You cannot remove default attributes.
 you-do-not-have-permission-to-create-a-shortcut-to-the-selected-document=You do not have permission to create a shortcut to the selected document.
 you-have-entered-invalid-json=You have entered invalid JSON.
-you-have-exceeded-the-x-storage-quota-for-this-instance=You have exceeded the {0} storage quota for this instance.
 you-must-checkin-the-document-before-performing-the-operation=You must check in the document before performing the operation.
 you-now-have-a-lock-on-this-document=You now have a lock on this document. No one else can edit this document until you unlock it. This lock will automatically expire in {0}.
 you-now-have-an-indefinite-lock-on-this-document=You now have an indefinite lock on this document. No one else can edit this document until you unlock it. This lock will never expire.

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/AssetWorkflow.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/AssetWorkflow.path
@@ -2,11 +2,13 @@
 <head>
 <title>AssetWorkflow</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AssetWorkflow</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALL_STRUCTURES_WORKFLOW_SELECT</td>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
@@ -2,11 +2,13 @@
 <head>
 <title>MyWorkflowTasks</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MyWorkflowTasks</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSIGNED_TO_ME_ACTIVE</td>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasksTask.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasksTask.path
@@ -2,11 +2,13 @@
 <head>
 <title>MyWorkflowTasksTask</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MyWorkflowTasksTask</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSIGNED_TO</td>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowConfiguration.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--RESOURCE_TABLE-->
 <tr>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowDefinition.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowDefinition.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowDefinition</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowDefinition</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PUBLICATION_STATUS</td>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowSubmissionsTask.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowSubmissionsTask.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowSubmissionsTask</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowSubmissionsTask</td></tr>
 </thead>
+
 <tbody>
 <!--MENU-->
 <tr>

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowUpload.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/WorkflowUpload.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowUpload</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowUpload</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FILE_UPLOAD</td>

--- a/modules/apps/redirect/redirect-test/src/testFunctional/paths/Redirect.path
+++ b/modules/apps/redirect/redirect-test/src/testFunctional/paths/Redirect.path
@@ -2,11 +2,13 @@
 <head>
 <title>Redirect</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Redirect</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SIDEBAR_INFO_ITEM</td>
@@ -14,9 +16,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>FLOATING_TOOLTIP_URL</td>
-    <td>//div[contains(@class,'tooltip')]//div[contains(.,'${key_redirectURL}')]</td>
-    <td></td>
+	<td>FLOATING_TOOLTIP_URL</td>
+	<td>//div[contains(@class,'tooltip')]//div[contains(.,'${key_redirectURL}')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderAppAdmin.path
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderAppAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>AppBuilderAppAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AppBuilderAppAdmin</td></tr>
 </thead>
+
 <tbody>
 <!--APPS_LISTING_SCREEN-->
 <tr>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderStandardApp.path
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderStandardApp.path
@@ -2,11 +2,13 @@
 <head>
 <title>AppBuilderStandardApp</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AppBuilderStandardApp</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BACK_BUTTON</td>

--- a/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderWorkflow.path
+++ b/modules/dxp/apps/app-builder-workflow/app-builder-workflow-test/src/testFunctional/paths/AppBuilderWorkflow.path
@@ -2,11 +2,13 @@
 <head>
 <title>AppBuilderWorkflow</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AppBuilderWorkflow</td></tr>
 </thead>
+
 <tbody>
 <!--APP_CREATION-->
 <tr>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdmin.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdmin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>REPORT_PDF_CLASS_NAME_PNG</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminConfiguration.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION-->
 <tr>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminDeliverReport.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminDeliverReport.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminDeliverReport</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminDeliverReport</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>REPORT_NAME</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditReportDefinition.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditReportDefinition.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminEditReportDefinition</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminEditReportDefinition</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DATA_SOURCE_NAME_SELECT</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditReportEntry.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditReportEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminEditReportEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminEditReportEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>REPORT_NAME_FIELD</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditScheduleEntry.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditScheduleEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminEditScheduleEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminEditScheduleEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>START_DATE_TIME_FIELD</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditSource.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminEditSource.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminEditSource</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminEditSource</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DATA_SOURCE_NAME_FIELD</td>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminViewReportEntry.path
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/paths/ReportsAdminViewReportEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportsAdminViewReportEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportsAdminViewReportEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>INFO_MESSAGE</td>

--- a/modules/dxp/apps/portal-rules-engine-drools/portal-rules-engine-drools-test/src/testFunctional/paths/Drools.path
+++ b/modules/dxp/apps/portal-rules-engine-drools/portal-rules-engine-drools-test/src/testFunctional/paths/Drools.path
@@ -2,11 +2,13 @@
 <head>
 <title>Drools</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Drools</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DROOLS_CONTENT</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesigner.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesigner.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoDesigner</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoDesigner</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SAVE_BUTTON</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesignerEditWorkflow.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/paths/KaleoDesignerEditWorkflow.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoDesignerEditWorkflow</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoDesignerEditWorkflow</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BODY</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdmin.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdmin</td></tr>
 </thead>
+
 <tbody>
 <!--PROCESS_TABLE-->
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminEditProcess.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminEditProcess.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdminEditProcess</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdminEditProcess</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NEXT_BUTTON_INACTIVE</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminEditProcessForm.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminEditProcessForm.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdminEditProcessForm</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdminEditProcessForm</td></tr>
 </thead>
+
 <tbody>
 <!--FORM_TABLE-->
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminSelectStructure.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminSelectStructure.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdminSelectStructure</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdminSelectStructure</td></tr>
 </thead>
+
 <tbody>
 <!--KALEO_FORMS_STRUCTURE_TABLE-->
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminViewProcessRecords.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminViewProcessRecords.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdminViewProcessRecords</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdminViewProcessRecords</td></tr>
 </thead>
+
 <tbody>
 <!--RECORD_TABLE-->
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminViewProcessRecordsDetails.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/paths/KaleoFormsAdminViewProcessRecordsDetails.path
@@ -2,11 +2,13 @@
 <head>
 <title>KaleoFormsAdminViewProcessRecordsDetails</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KaleoFormsAdminViewProcessRecordsDetails</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CURRENT_RECORD_FIELD</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowAllItems.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowAllItems.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowAllItems</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowAllItems</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>WORKFLOW_ALL_ITEMS_SELECT_ALL</td>
@@ -99,9 +101,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>METRICS_ALL_ITEMS_TABLE_ROW</td>
-    <td>//tr[${key_rowNumber}]//td[3]</td>
-    <td></td>
+	<td>METRICS_ALL_ITEMS_TABLE_ROW</td>
+	<td>//tr[${key_rowNumber}]//td[3]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>WORKFLOW_ALL_ITEMS_FILTER_BY</td>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetrics.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetrics.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowMetrics</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowMetrics</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DASHBOARD_TOTAL_COMPLETED_ITEMS_TITLE</td>
@@ -408,4 +410,3 @@
 </table>
 </body>
 </html>
-

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsIndex.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsIndex.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowMetricsIndex</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowMetricsIndex</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>METRICS_MENU_INDEX</td>
@@ -32,4 +34,3 @@
 </table>
 </body>
 </html>
-

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsPerformanceByStep.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsPerformanceByStep.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowMetricsPerformanceByStep</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowMetricsPerformanceByStep</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DATE_RANGE_DROPDOWN</td>
@@ -20,36 +22,35 @@
 </tr>
 <tr>
 	<td>METRICS_PERFORMANCE_BY_STEP_CARD_VIEW_ALL_STEPS</td>
-    <td>//a//span[contains(text(), 'View All Steps (${key_stepsNumber})')]</td>
+	<td>//a//span[contains(text(), 'View All Steps (${key_stepsNumber})')]</td>
 	<td></td>
 </tr>
 <tr>
-    <td>METRICS_PERFORMANCE_BY_STEP_PAGE_INPUT_FIELD</td>
-    <td>//input[contains(@placeholder, 'Search for Step Name')]</td>
-    <td></td>
+	<td>METRICS_PERFORMANCE_BY_STEP_PAGE_INPUT_FIELD</td>
+	<td>//input[contains(@placeholder, 'Search for Step Name')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>METRICS_PERFORMANCE_BY_STEP_PAGE_NO_RESULTS_FOUND</td>
-    <td>//p[contains(text(),'No results were found.')]</td>
-    <td></td>
+	<td>METRICS_PERFORMANCE_BY_STEP_PAGE_NO_RESULTS_FOUND</td>
+	<td>//p[contains(text(),'No results were found.')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_AVG_COMPLETION_TIME_VALUE</td>
-    <td>//td[contains(text(),'${key_stepName}')]/following-sibling::td[2]</td>
-    <td></td>
+	<td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_AVG_COMPLETION_TIME_VALUE</td>
+	<td>//td[contains(text(),'${key_stepName}')]/following-sibling::td[2]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_SLA_BREACHED_VALUE</td>
-    <td>//td[contains(text(),'${key_stepName}')]/following-sibling::td[1]</td>
-    <td></td>
+	<td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_SLA_BREACHED_VALUE</td>
+	<td>//td[contains(text(),'${key_stepName}')]/following-sibling::td[1]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_STEP_NAME</td>
-    <td>//td[contains(text(),'${key_stepName}')]</td>
-    <td></td>
+	<td>METRICS_PERFORMANCE_BY_STEP_PAGE_TABLE_STEP_NAME</td>
+	<td>//td[contains(text(),'${key_stepName}')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>
 </body>
 </html>
-

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsSLA.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowMetricsSLA.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowMetricsSLA</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowMetricsSLA</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_NEW_SLA_BUTTON</td>
@@ -177,4 +179,3 @@
 </table>
 </body>
 </html>
-

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowReassignModal.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowReassignModal.path
@@ -2,11 +2,13 @@
 <head>
 <title>WorkflowReassignModal</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WorkflowReassignModal</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BULK_REASSIGN_MODAL</td>
@@ -98,7 +100,6 @@
 	<td>//button[contains(text(),'Select All')]</td>
 	<td></td>
 </tr>
-
 <tr>
 	<td>ITEM_CHECKBOX_CHECKED</td>
 	<td>//div[@class='modal-body']//td[contains(text(),"${key_itemName}")]//parent::tr//input[@type='checkbox' and @checked]</td>

--- a/modules/util/source-formatter/README.markdown
+++ b/modules/util/source-formatter/README.markdown
@@ -109,7 +109,7 @@ Checks are configured in the following files:
    - [.function, .macro or .testcase](src/main/resources/documentation/poshi_source_processor_checks.markdown#checks-for-function-macro-or-testcase)
    - [.gradle](src/main/resources/documentation/gradle_source_processor_checks.markdown#checks-for-gradle)
    - [.groovy](src/main/resources/documentation/groovy_source_processor_checks.markdown#checks-for-groovy)
-   - [.html](src/main/resources/documentation/html_source_processor_checks.markdown#checks-for-html)
+   - [.html or .path](src/main/resources/documentation/html_source_processor_checks.markdown#checks-for-html-or-path)
    - [.ipynb, .json or .npmbridgerc](src/main/resources/documentation/json_source_processor_checks.markdown#checks-for-ipynb-json-or-npmbridgerc)
    - [.java](src/main/resources/documentation/java_source_processor_checks.markdown#checks-for-java)
    - [.js or .jsx](src/main/resources/documentation/js_source_processor_checks.markdown#checks-for-js-or-jsx)

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/HTMLSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/HTMLSourceProcessor.java
@@ -38,6 +38,6 @@ public class HTMLSourceProcessor extends BaseSourceProcessor {
 		return _INCLUDES;
 	}
 
-	private static final String[] _INCLUDES = {"**/*.html"};
+	private static final String[] _INCLUDES = {"**/*.html", "**/*.path"};
 
 }

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -92,8 +92,8 @@ GradleProvidedDependenciesCheck | [Bug Prevention](bug_prevention_checks.markdow
 GradleStylingCheck | [Styling](styling_checks.markdown#styling-checks) | .gradle | Applies rules to enforce consisteny in code style. |
 [GradleTaskCreationCheck](checks/gradle_task_creation_check.markdown#gradletaskcreationcheck) | [Styling](styling_checks.markdown#styling-checks) | .gradle | Checks that a task is declared on a separate line before the closure. |
 GradleTestDependencyVersionCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .gradle | Checks the version for dependencies in gradle build files. |
-HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html | Finds missing and unnecessary empty lines. |
-HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html | Finds missing and unnecessary whitespace in `.html` files. |
+HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
+HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |
 [IncorrectFileLocationCheck](checks/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | | Checks that `/src/*/java/` only contains `.java` files. |
 InstanceofOrderCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .tag, .tpl or .vm | Check the order of `instanceof` calls. |
 [ItemListBuilderCheck](checks/builder_check.markdown#buildercheck) | [Miscellaneous](miscellaneous_checks.markdown#miscellaneous-checks) | .java | Checks that `DropdownItemListBuilder`, `LabelItemListBuilder` or `NavigationItemListBuilder` is used when possible. |
@@ -417,7 +417,7 @@ XMLSpringFileCheck | [Styling](styling_checks.markdown#styling-checks) | .action
 XMLStrutsConfigFileCheck | [Styling](styling_checks.markdown#styling-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Checks the order of elements in `struts-config.xml` file. |
 XMLStylingCheck | [Styling](styling_checks.markdown#styling-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Applies rules to enforce consisteny in code style. |
 XMLSuppressionsFileCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on `source-formatter-suppressions.xml` file. |
-XMLTagAttributesCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .action, .function, .html, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on tag attributes. |
+XMLTagAttributesCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .action, .function, .html, .jrxml, .macro, .path, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on tag attributes. |
 XMLTestIgnorableErrorLinesFileCheck | [Styling](styling_checks.markdown#styling-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Checks the order of elements in `test-ignorable-error-lines.xml` file. |
 XMLTilesDefsFileCheck | [Styling](styling_checks.markdown#styling-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Checks the order of elements in `tiles-defs.xml` file. |
 XMLToggleFileCheck | [Styling](styling_checks.markdown#styling-checks) | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Checks the order of elements in `.toggle` file. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -168,5 +168,5 @@ XMLServiceFileCheck | .action, .function, .jrxml, .macro, .pom, .testcase, .togg
 XMLServiceReferenceCheck | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Checks for unused references in `service.xml` file. |
 XMLSourcechecksFileCheck | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on `sourcechecks.xml` file. |
 XMLSuppressionsFileCheck | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on `source-formatter-suppressions.xml` file. |
-XMLTagAttributesCheck | .action, .function, .html, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on tag attributes. |
+XMLTagAttributesCheck | .action, .function, .html, .jrxml, .macro, .path, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on tag attributes. |
 XMLWebFileCheck | .action, .function, .jrxml, .macro, .pom, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Performs several checks on `web.xml` file. |

--- a/modules/util/source-formatter/src/main/resources/documentation/html_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/html_source_processor_checks.markdown
@@ -1,4 +1,4 @@
-# Checks for .html
+# Checks for .html or .path
 
 Check | Category | Description
 ----- | -------- | -----------

--- a/modules/util/source-formatter/src/main/resources/documentation/styling_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/styling_checks.markdown
@@ -46,8 +46,8 @@ GradleImportsCheck | .gradle | Sorts and groups imports in `.gradle` files. |
 GradleIndentationCheck | .gradle | Finds incorrect indentation in gradle build files. |
 GradleStylingCheck | .gradle | Applies rules to enforce consisteny in code style. |
 [GradleTaskCreationCheck](checks/gradle_task_creation_check.markdown#gradletaskcreationcheck) | .gradle | Checks that a task is declared on a separate line before the closure. |
-HTMLEmptyLinesCheck | .html | Finds missing and unnecessary empty lines. |
-HTMLWhitespaceCheck | .html | Finds missing and unnecessary whitespace in `.html` files. |
+HTMLEmptyLinesCheck | .html or .path | Finds missing and unnecessary empty lines. |
+HTMLWhitespaceCheck | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |
 InstanceofOrderCheck | .java, .jsp, .jspf, .tag, .tpl or .vm | Check the order of `instanceof` calls. |
 JSONStylingCheck | .ipynb, .json or .npmbridgerc | Applies rules to enforce consisteny in code style. |
 [JSONUtilCheck](checks/json_util_check.markdown#jsonutilcheck) | .java, .jsp, .jspf, .tag, .tpl or .vm | Checks for utilization of class `JSONUtil`. |

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/FacebookLogin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/FacebookLogin.path
@@ -2,11 +2,13 @@
 <head>
 <title>FacebookLogin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FacebookLogin</td></tr>
 </thead>
+
 <tbody>
 <!--LOGIN-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/GoogleDoc.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/GoogleDoc.path
@@ -2,11 +2,13 @@
 <head>
 <title>GoogleDoc</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GoogleDoc</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/GoogleLogin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/GoogleLogin.path
@@ -2,11 +2,13 @@
 <head>
 <title>GoogleLogin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GoogleLogin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PAGE_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/LCSClient.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/LCSClient.path
@@ -2,11 +2,13 @@
 <head>
 <title>LCSClient</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">LCSClient</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PROJECT_HOME_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/MicrosoftLogin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/MicrosoftLogin.path
@@ -2,11 +2,13 @@
 <head>
 <title>MicrosoftLogin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MicrosoftLogin</td></tr>
 </thead>
+
 <tbody>
 <!--LOGIN-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/OneDrive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/OneDrive.path
@@ -2,11 +2,13 @@
 <head>
 <title>OneDrive</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OneDrive</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DELETE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenAM.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenAM.path
@@ -2,11 +2,13 @@
 <head>
 <title>OpenAM</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OpenAM</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>LOG_IN</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenIDConnectLogin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenIDConnectLogin.path
@@ -2,11 +2,13 @@
 <head>
 <title>OpenIDConnectLogin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OpenIDConnectLogin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>OPENID_CONNECT_DROPDOWN_MENU</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenIDLogin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/external/OpenIDLogin.path
@@ -2,11 +2,13 @@
 <head>
 <title>OpenIDLogin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OpenIDLogin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>YAHOO_LOGIN_SKIP_SECURE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Breadcrumb.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Breadcrumb.path
@@ -2,11 +2,13 @@
 <head>
 <title>Breadcrumb</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Breadcrumb</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BREADCRUMB_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -2,11 +2,13 @@
 <head>
 <title>Button</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Button</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_ACTION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Checkbox.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Checkbox.path
@@ -2,11 +2,13 @@
 <head>
 <title>Checkbox</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Checkbox</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ContentRow.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ContentRow.path
@@ -2,11 +2,13 @@
 <head>
 <title>ContentRow</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ContentRow</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENTRY_CONTENT_ROW_1</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Dropdown.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Dropdown.path
@@ -2,11 +2,13 @@
 <head>
 <title>Dropdown</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Dropdown</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CAPTION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Header.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Header.path
@@ -2,17 +2,19 @@
 <head>
 <title>Header</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Header</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>H1_TITLE</td>
 	<td>//h1[contains(.,'${key_title}')]</td>
 	<td></td>
-</tr>	
+</tr>
 <tr>
 	<td>H2_TITLE</td>
 	<td>//h2[contains(.,'${key_title}')]</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
@@ -2,11 +2,13 @@
 <head>
 <title>IFrame</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">IFrame</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_ASSIGNEE_TO_ACCOUNT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
@@ -2,11 +2,13 @@
 <head>
 <title>Icon</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Icon</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_FAVORITE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Link.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Link.path
@@ -2,11 +2,13 @@
 <head>
 <title>Link</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Link</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_CHILD_PAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ListGroupItem.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ListGroupItem.path
@@ -2,11 +2,13 @@
 <head>
 <title>ListGroupItem</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ListGroupItem</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ITEM_ACTIONS_DEFAULT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/MenuItem.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/MenuItem.path
@@ -2,11 +2,13 @@
 <head>
 <title>MenuItem</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MenuItem</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ANY_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
@@ -2,11 +2,13 @@
 <head>
 <title>Message</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Message</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALERT_DISMISSIBLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Modal.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Modal.path
@@ -2,11 +2,13 @@
 <head>
 <title>Modal</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Modal</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavTab.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavTab.path
@@ -2,11 +2,13 @@
 <head>
 <title>NavTab</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NavTab</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_TAB_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavUnderline.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/NavUnderline.path
@@ -2,11 +2,13 @@
 <head>
 <title>NavUnderline</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NavUnderline</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_NAV_UNDERLINE_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Radio.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Radio.path
@@ -2,11 +2,13 @@
 <head>
 <title>Radio</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Radio</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>APPEND</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
@@ -2,11 +2,13 @@
 <head>
 <title>Select</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Select</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ANY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextArea.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextArea.path
@@ -2,11 +2,13 @@
 <head>
 <title>TextArea</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TextArea</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACE_EDITOR</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextInput.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextInput.path
@@ -2,11 +2,13 @@
 <head>
 <title>TextInput</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TextInput</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADDRESS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ToggleSwitch.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ToggleSwitch.path
@@ -2,11 +2,13 @@
 <head>
 <title>ToggleSwitch</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ToggleSwitch</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACCOUNT_STATUS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Tooltip.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Tooltip.path
@@ -2,21 +2,23 @@
 <head>
 <title>Tooltip</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Tooltip</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>GENERIC_TOOLTIP</td>
-    <td>//div[contains(@class,'tooltip') and contains(@class,'top')]</td>
-    <td></td>
+	<td>GENERIC_TOOLTIP</td>
+	<td>//div[contains(@class,'tooltip') and contains(@class,'top')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>GENERIC_TOOLTIP_VISIBLE</td>
-    <td>//div[contains(@class,'tooltip') and contains(@class,'top')][contains(@class,'show') or contains(@class,'in')]</td>
-    <td></td>
+	<td>GENERIC_TOOLTIP_VISIBLE</td>
+	<td>//div[contains(@class,'tooltip') and contains(@class,'top')][contains(@class,'show') or contains(@class,'in')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
@@ -2,11 +2,13 @@
 <head>
 <title>AlloyEditor</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AlloyEditor</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EDITOR</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetCategorization.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetCategorization.path
@@ -2,11 +2,13 @@
 <head>
 <title>AssetCategorization</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AssetCategorization</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CATEGORIES_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetPermissions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetPermissions.path
@@ -2,11 +2,13 @@
 <head>
 <title>AssetPermissions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AssetPermissions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>VIEWABLE_AS_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetRelatedAssets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetRelatedAssets.path
@@ -2,11 +2,13 @@
 <head>
 <title>AssetRelatedAssets</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AssetRelatedAssets</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -2,11 +2,13 @@
 <head>
 <title>CKEditor</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CKEditor</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ANY_BODY_FIELD_IFRAME_WEB_CONTENT_ARTICLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Card.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Card.path
@@ -2,11 +2,13 @@
 <head>
 <title>Card</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Card</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CARD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Comments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Comments.path
@@ -2,11 +2,13 @@
 <head>
 <title>Comments</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Comments</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PANEL_HEADING</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Configuration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Configuration.path
@@ -2,11 +2,13 @@
 <head>
 <title>Configuration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Configuration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/DDMField.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/DDMField.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMField</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMField</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BOOLEAN</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/DynamicUploader.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/DynamicUploader.path
@@ -2,11 +2,13 @@
 <head>
 <title>DynamicUploader</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DynamicUploader</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_ALL_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ExportImport.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ExportImport.path
@@ -2,11 +2,13 @@
 <head>
 <title>ExportImport</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ExportImport</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EXPORT_FILE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ItemSelector.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ItemSelector.path
@@ -2,11 +2,13 @@
 <head>
 <title>ItemSelector</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ItemSelector</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ITEM_SELECTOR_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/LexiconList.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/LexiconList.path
@@ -2,11 +2,13 @@
 <head>
 <title>LexiconList</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">LexiconList</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>LIST_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/LexiconTable.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/LexiconTable.path
@@ -2,11 +2,13 @@
 <head>
 <title>LexiconTable</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">LexiconTable</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TABLE_SESSION_ID</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -2,11 +2,13 @@
 <head>
 <title>ManagementBar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ManagementBar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FILTER_AND_ORDER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MenuBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MenuBar.path
@@ -2,11 +2,13 @@
 <head>
 <title>MenuBar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MenuBar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_NAV_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockLDAP.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockLDAP.path
@@ -2,11 +2,13 @@
 <head>
 <title>MockLDAP</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MockLDAP</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BROWSE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockMock.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockMock.path
@@ -2,11 +2,13 @@
 <head>
 <title>MockMock</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MockMock</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MOCKMOCK_HEADER_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavBar.path
@@ -2,11 +2,13 @@
 <head>
 <title>NavBar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NavBar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_NAV_ITEM_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
@@ -2,11 +2,13 @@
 <head>
 <title>NavNested</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NavNested</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_NAV_NESTED_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/PagesConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/PagesConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>PagesConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PagesConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PAGES_SPECIFIC_PAGE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Pagination.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Pagination.path
@@ -2,11 +2,13 @@
 <head>
 <title>Pagination</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Pagination</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PAGES</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>Portlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Portlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>APPLICATION_DECORATOR_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Ratings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Ratings.path
@@ -2,11 +2,13 @@
 <head>
 <title>Ratings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Ratings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>LIKE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ReportContent.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ReportContent.path
@@ -2,11 +2,13 @@
 <head>
 <title>ReportContent</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ReportContent</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>WARNING</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Sidebar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Sidebar.path
@@ -2,56 +2,58 @@
 <head>
 <title>Sidebar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Sidebar</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>ADD_FIELD_TARGET</td>
-    <td>//div[contains(@class,'col-empty')]/div[contains(@class,'target')]</td>
-    <td></td>
+	<td>ADD_FIELD_TARGET</td>
+	<td>//div[contains(@class,'col-empty')]/div[contains(@class,'target')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_NESTED_TARGET</td>
-    <td>//div[contains(@class,'ddm-drag')]//div[@data-field-name='${key_fieldName}']</td>
-    <td></td>
+	<td>ADD_FIELD_NESTED_TARGET</td>
+	<td>//div[contains(@class,'ddm-drag')]//div[@data-field-name='${key_fieldName}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_NAME</td>
-    <td>//div[contains(@class,'field-type')]//span[normalize-space(text())='${key_fieldName}']</td>
-    <td></td>
+	<td>ADD_FIELD_NAME</td>
+	<td>//div[contains(@class,'field-type')]//span[normalize-space(text())='${key_fieldName}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_POSITION</td>
-    <td>xpath=(//div[contains(@class,'col-empty')]/div[contains(@class,'target')])[${key_fieldLocation}]</td>
-    <td></td>
+	<td>ADD_FIELD_POSITION</td>
+	<td>xpath=(//div[contains(@class,'col-empty')]/div[contains(@class,'target')])[${key_fieldLocation}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>BACK</td>
-    <td>//button[*[name()='svg'][contains(@class,'lexicon-icon-angle-left')]]</td>
-    <td></td>
+	<td>BACK</td>
+	<td>//button[*[name()='svg'][contains(@class,'lexicon-icon-angle-left')]]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DDM_ANY</td>
-    <td>//div[contains(@class,'sidebar')]//label[contains(.,'${key_text}')]//following-sibling::input</td>
-    <td></td>
+	<td>DDM_ANY</td>
+	<td>//div[contains(@class,'sidebar')]//label[contains(.,'${key_text}')]//following-sibling::input</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DDM_LABEL</td>
-    <td>//div[contains(@class,'sidebar')]//label[contains(.,'Label')]//following-sibling::input</td>
-    <td></td>
+	<td>DDM_LABEL</td>
+	<td>//div[contains(@class,'sidebar')]//label[contains(.,'Label')]//following-sibling::input</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DDM_HELP_TEXT</td>
-    <td>//div[contains(@class,'sidebar')]//label[contains(.,'Help Text')]//following-sibling::input</td>
-    <td></td>
+	<td>DDM_HELP_TEXT</td>
+	<td>//div[contains(@class,'sidebar')]//label[contains(.,'Help Text')]//following-sibling::input</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELDSET_ITEM_ELLIPSIS</td>
-    <td>//div[contains(@class, 'field-type')][contains(.,'${key_fieldsetName}')]//button[contains(@class, 'dropdown-toggle')]</td>
-    <td></td>
+	<td>FIELDSET_ITEM_ELLIPSIS</td>
+	<td>//div[contains(@class, 'field-type')][contains(.,'${key_fieldsetName}')]//button[contains(@class, 'dropdown-toggle')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>FORM_BUILDER</td>
@@ -64,29 +66,29 @@
 	<td></td>
 </tr>
 <tr>
-    <td>TEXT_INPUT</td>
-    <td>//div[contains(@data-field-name,'${key_fieldName}')]//label[normalize-space(text())='${key_fieldLabel}']//following-sibling::input[@type='text']</td>
-    <td></td>
+	<td>TEXT_INPUT</td>
+	<td>//div[contains(@data-field-name,'${key_fieldName}')]//label[normalize-space(text())='${key_fieldLabel}']//following-sibling::input[@type='text']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>OPTION_INPUT</td>
-    <td>xpath=(//label[normalize-space(text())='${key_optionFieldLabel}']//following-sibling::div[contains(@class,'options-container')]//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'ddm-field-text')])[${index}]</td>
-    <td></td>
+	<td>OPTION_INPUT</td>
+	<td>xpath=(//label[normalize-space(text())='${key_optionFieldLabel}']//following-sibling::div[contains(@class,'options-container')]//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'ddm-field-text')])[${index}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>OPTION_INPUT_WITHOUT_LABEL</td>
-    <td>xpath=(//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'ddm-field-text')])[${index}]</td>
-    <td></td>
+	<td>OPTION_INPUT_WITHOUT_LABEL</td>
+	<td>xpath=(//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'ddm-field-text')])[${index}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>OPTION_FIELD_REFERENCE_INPUT</td>
-    <td>xpath=(//label[normalize-space(text())='${key_optionFieldLabel}']//following-sibling::div[contains(@class,'options-container')]//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'key-value-reference')])[${index}]</td>
-    <td></td>
+	<td>OPTION_FIELD_REFERENCE_INPUT</td>
+	<td>xpath=(//label[normalize-space(text())='${key_optionFieldLabel}']//following-sibling::div[contains(@class,'options-container')]//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'key-value-reference')])[${index}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>OPTION_WITHOUT_LABEL_FIELD_REFERENCE_INPUT</td>
-    <td>xpath=(//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'key-value-reference')])[${index}]</td>
-    <td></td>
+	<td>OPTION_WITHOUT_LABEL_FIELD_REFERENCE_INPUT</td>
+	<td>xpath=(//div[contains(@class,'ddm-option-entry')]//input[contains(@class,'key-value-reference')])[${index}]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>TAB</td>
@@ -94,9 +96,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>DDM_FIELD_REFERENCE</td>
-    <td>//div[contains(@class,'sidebar')]//label[contains(.,'Field Reference')]//following-sibling::input</td>
-    <td></td>
+	<td>DDM_FIELD_REFERENCE</td>
+	<td>//div[contains(@class,'sidebar')]//label[contains(.,'Field Reference')]//following-sibling::input</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/SocialBookmarks.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/SocialBookmarks.path
@@ -2,11 +2,13 @@
 <head>
 <title>SocialBookmarks</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SocialBookmarks</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SOCIAL_BOOKMARK_ICON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Toolbar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Toolbar.path
@@ -2,11 +2,13 @@
 <head>
 <title>Toolbar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Toolbar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Translation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Translation.path
@@ -2,11 +2,13 @@
 <head>
 <title>Translation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Translation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -2,11 +2,13 @@
 <head>
 <title>Treeview</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Treeview</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NODE_COLLAPSED</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/YUICalendarWidget.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/YUICalendarWidget.path
@@ -2,11 +2,13 @@
 <head>
 <title>YUICalendarWidget</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">YUICalendarWidget</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PREVIOUS_MONTH_ARROW</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/akismet/Akismet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/akismet/Akismet.path
@@ -2,11 +2,13 @@
 <head>
 <title>Akismet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Akismet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENABLED_FOR_MESSAGE_BOARDS_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/akismet/SpamModeration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/akismet/SpamModeration.path
@@ -2,11 +2,13 @@
 <head>
 <title>SpamModeration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SpamModeration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/audit/AuditReports.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/audit/AuditReports.path
@@ -2,11 +2,13 @@
 <head>
 <title>AuditReports</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AuditReports</td></tr>
 </thead>
+
 <tbody>
 <!--REPORTS_TABLE -->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CTSimulator.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CTSimulator.path
@@ -2,11 +2,13 @@
 <head>
 <title>CTSimulator</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CTSimulator</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>USER_SEGMENT_MATCHED</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CampaignContentDisplay.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CampaignContentDisplay.path
@@ -2,11 +2,13 @@
 <head>
 <title>CampaignContentDisplay</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CampaignContentDisplay</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENTRY_CONTENT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CampaignReports.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/CampaignReports.path
@@ -2,11 +2,13 @@
 <head>
 <title>CampaignReports</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CampaignReports</td></tr>
 </thead>
+
 <tbody>
 <!--CONTENT_GRAPH-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/ContentTargeting.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/ContentTargeting.path
@@ -2,11 +2,13 @@
 <head>
 <title>ContentTargeting</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ContentTargeting</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PLUS_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/EditCampaign.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/EditCampaign.path
@@ -2,11 +2,13 @@
 <head>
 <title>EditCampaign</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">EditCampaign</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_USER_SEGMENT_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/EditUserSegment.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/EditUserSegment.path
@@ -2,11 +2,13 @@
 <head>
 <title>EditUserSegment</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">EditUserSegment</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>USER_SEGMENT_RULE_DELETE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/UserSegmentContentDisplay.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/contenttargeting/UserSegmentContentDisplay.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserSegmentContentDisplay</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserSegmentContentDisplay</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENTRY_CONTENT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/dummyfactory/DummyFactory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/dummyfactory/DummyFactory.path
@@ -2,11 +2,13 @@
 <head>
 <title>DummyFactory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DummyFactory</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BASE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/notifications/Notifications.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/notifications/Notifications.path
@@ -2,11 +2,13 @@
 <head>
 <title>Notifications</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Notifications</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>USER_BAR_BADGE_COUNT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/AddTask.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/AddTask.path
@@ -2,11 +2,13 @@
 <head>
 <title>AddTask</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AddTask</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_TASK_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/Tasks.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/Tasks.path
@@ -2,11 +2,13 @@
 <head>
 <title>Tasks</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Tasks</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_TASK_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/TasksTask.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/tasks/TasksTask.path
@@ -2,11 +2,13 @@
 <head>
 <title>TasksTask</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TasksTask</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TASK_DESCRIPTION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testblob/TestBlob.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testblob/TestBlob.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestBlob</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestBlob</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TEST_PORTLET_BODY_PASSED</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testevent/TestEventConsumer.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testevent/TestEventConsumer.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestEventConsumer</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestEventConsumer</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EVENT_CONSUMER_PORTLET_BODY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testevent/TestEventProducer.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testevent/TestEventProducer.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestEventProducer</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestEventProducer</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EVENT_PRODUCER_PORTLET_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testjsr/TestJSR.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testjsr/TestJSR.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestJSR</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestJSR</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TEST_PORTLET_BODY_FAILED</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testlocalized/TestLocalized.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testlocalized/TestLocalized.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestLocalized</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestLocalized</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CHINESE_LOCALIZATION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testopensocialpubsub/TestPublisher.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testopensocialpubsub/TestPublisher.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestPublisher</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestPublisher</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PUBLISHER_PORTLET_PUBLISH_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testopensocialpubsub/TestSubscriber.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/testopensocialpubsub/TestSubscriber.path
@@ -2,11 +2,13 @@
 <head>
 <title>TestSubscriber</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TestSubscriber</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SUBSCRIBER_PORTLET_SUBSCRIBE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/plugin/youtube/YoutubePortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/plugin/youtube/YoutubePortlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>YoutubePortlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">YoutubePortlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>VIDEO_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/Embedded.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/Embedded.path
@@ -2,11 +2,13 @@
 <head>
 <title>Embedded</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Embedded</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EMBEDDED_TEXT_YES</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/Panel.path
@@ -2,11 +2,13 @@
 <head>
 <title>Panel</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Panel</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PANEL_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/SetupWizard.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/SetupWizard.path
@@ -2,11 +2,13 @@
 <head>
 <title>SetupWizard</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SetupWizard</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BASIC_CONFIGURATION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWS.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWS.path
@@ -2,11 +2,13 @@
 <head>
 <title>JSONWS</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JSONWS</td></tr>
 </thead>
+
 <tbody>
 <!--ADDRESS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWSAddress.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWSAddress.path
@@ -2,11 +2,13 @@
 <head>
 <title>JSONWSAddress</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JSONWSAddress</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>P_AUTH_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWSUser.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/jsonws/JSONWSUser.path
@@ -2,11 +2,13 @@
 <head>
 <title>JSONWSUser</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JSONWSUser</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>API_METHOD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
@@ -2,11 +2,13 @@
 <head>
 <title>ABTest</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ABTest</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>AB_TEST_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/adaptivemedia/AdaptiveMedia.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/adaptivemedia/AdaptiveMedia.path
@@ -2,11 +2,13 @@
 <head>
 <title>AdaptiveMedia</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AdaptiveMedia</td></tr>
 </thead>
+
 <tbody>
 <!--IMAGE_VARIANT-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/adaptivemedia/AdaptiveMediaTable.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/adaptivemedia/AdaptiveMediaTable.path
@@ -2,11 +2,13 @@
 <head>
 <title>AdaptiveMediaTable</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AdaptiveMediaTable</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>IMAGE_RESOLUTION_OPTIONS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/analyticscloudconnection/AnalyticsCloudConnection.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/analyticscloudconnection/AnalyticsCloudConnection.path
@@ -2,11 +2,13 @@
 <head>
 <title>AnalyticsCloudConnection</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AnalyticsCloudConnection</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_NEW_PROPERTY_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/Announcements.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/Announcements.path
@@ -2,11 +2,13 @@
 <head>
 <title>Announcements</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Announcements</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PRIORITY_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/AnnouncementsManageEntries.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/announcements/AnnouncementsManageEntries.path
@@ -2,11 +2,13 @@
 <head>
 <title>AnnouncementsManageEntries</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AnnouncementsManageEntries</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DISTRIBUTION_SCOPE_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationdisplaytemplates/ApplicationDisplayTemplates.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationdisplaytemplates/ApplicationDisplayTemplates.path
@@ -2,11 +2,13 @@
 <head>
 <title>ApplicationDisplayTemplates</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ApplicationDisplayTemplates</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADT_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationdisplaytemplates/ApplicationDisplayTemplatesConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationdisplaytemplates/ApplicationDisplayTemplatesConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>ApplicationDisplayTemplatesConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ApplicationDisplayTemplatesConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MANAGE_DISPLAY_TEMPLATES_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -2,11 +2,13 @@
 <head>
 <title>ApplicationsMenu</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ApplicationsMenu</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_PANEL</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetlists/AssetLists.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetlists/AssetLists.path
@@ -2,17 +2,19 @@
 <head>
 <title>AssetLists</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AssetLists</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_LIST_ELLIPSIS</td>
 	<td>//div[contains(@class,'dropdown')]//a[span/*[name()='svg'][contains(@class,'lexicon-icon-ellipsis')]]</td>
 	<td></td>
-</tr>	
+</tr>
 <tr>
 	<td>ASSET_LIST_ENTRY_TITLE</td>
 	<td>//li[contains(@class,'list-group-item')]//a[contains(.,'${key_title}')] | //li[contains(@class,'list-group-item')]//p[contains(.,'${key_title}')]</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/AP.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/AP.path
@@ -2,11 +2,13 @@
 <head>
 <title>AP</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AP</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_ASSET_PLUS_ICON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APAsset.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APAsset.path
@@ -2,11 +2,13 @@
 <head>
 <title>APAsset</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APAsset</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_BACK_TO_ICON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>APConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--ASSET_SELECTION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationDisplaysettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationDisplaysettings.path
@@ -2,11 +2,13 @@
 <head>
 <title>APConfigurationDisplaysettings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APConfigurationDisplaysettings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_LINK_BEHAVIOR_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationFilterbyfield.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationFilterbyfield.path
@@ -2,11 +2,13 @@
 <head>
 <title>APConfigurationFilterbyfield</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APConfigurationFilterbyfield</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FIELD_FILTER_RADIO_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationManual.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationManual.path
@@ -2,11 +2,13 @@
 <head>
 <title>APConfigurationManual</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APConfigurationManual</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_SELECTION_MANUAL_ASSET_ENTRIES_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationSites.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfigurationSites.path
@@ -2,11 +2,13 @@
 <head>
 <title>APConfigurationSites</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">APConfigurationSites</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITES_TABLE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/bladetemplates/NPMTemplates.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/bladetemplates/NPMTemplates.path
@@ -2,11 +2,13 @@
 <head>
 <title>NPMTemplates</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NPMTemplates</td></tr>
 </thead>
+
 <tbody>
 <!--NPM-TEMPLATES-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/Blogs.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/Blogs.path
@@ -2,11 +2,13 @@
 <head>
 <title>Blogs</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Blogs</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_BLOGS_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsAggregator.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsAggregator.path
@@ -2,11 +2,13 @@
 <head>
 <title>BlogsAggregator</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BlogsAggregator</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NO_ENTRY_MESSAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEditEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEditEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>BlogsEditEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BlogsEditEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>STATUS_READING_TIME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>BlogsEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BlogsEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENTRY_COVER_IMAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/bookmarks/Bookmarks.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/bookmarks/Bookmarks.path
@@ -2,11 +2,13 @@
 <head>
 <title>Bookmarks</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Bookmarks</td></tr>
 </thead>
+
 <tbody>
 <!--BOOKMARKS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/breadcrumb/BreadcrumbPortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/breadcrumb/BreadcrumbPortlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>BreadcrumbPortlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BreadcrumbPortlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BREADCRUMB_FOLDER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/cas/CAS.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/cas/CAS.path
@@ -2,11 +2,13 @@
 <head>
 <title>CAS</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CAS</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>APP_NAME_HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/Categories.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/Categories.path
@@ -2,11 +2,13 @@
 <head>
 <title>Categories</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Categories</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_CATEGORY_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesEditCategory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesEditCategory.path
@@ -2,11 +2,13 @@
 <head>
 <title>CategoriesEditCategory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CategoriesEditCategory</td></tr>
 </thead>
+
 <tbody>
 <!--PROPERTIES-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesEditVocabulary.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesEditVocabulary.path
@@ -2,11 +2,13 @@
 <head>
 <title>CategoriesEditVocabulary</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CategoriesEditVocabulary</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALLOW_MULTIPLE_CATEGORIES_TOGGLE_SWITCH</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesNavigation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/categories/CategoriesNavigation.path
@@ -2,11 +2,13 @@
 <head>
 <title>CategoriesNavigation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CategoriesNavigation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contactscenter/ContactsCenter.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contactscenter/ContactsCenter.path
@@ -2,11 +2,13 @@
 <head>
 <title>ContactsCenter</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ContactsCenter</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SUCCESS_MESSAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
@@ -2,11 +2,13 @@
 <head>
 <title>ContentDashboard</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ContentDashboard</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>AUDIT_GRAPH_CATEGORY_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenu.path
@@ -2,11 +2,13 @@
 <head>
 <title>ControlMenu</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ControlMenu</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuAddPanel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuAddPanel.path
@@ -2,11 +2,13 @@
 <head>
 <title>ControlMenuAddPanel</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ControlMenuAddPanel</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_NEW_DROPDOWN</td>
@@ -19,9 +21,9 @@
 	<td></td>
 </tr>
 <tr>
-  <td>SIDEBAR_HEADER</td>
-  <td>//div[contains(@class,'sidebar-header')]/*[normalize-space(text())='Add']</td>
-  <td></td>
+<td>SIDEBAR_HEADER</td>
+<td>//div[contains(@class,'sidebar-header')]/*[normalize-space(text())='Add']</td>
+<td></td>
 </tr>
 <tr>
 	<td></td>
@@ -30,9 +32,9 @@
 </tr>
 <!--APPLICATIONS-->
 <tr>
-  <td>ADD_PORTLET_LINK</td>
-  <td>//div[contains(@class,'item-body')]//*[normalize-space(text())='${key_portletName}']/../../..//button[contains(@class,'item-add')]</td>
-  <td></td>
+<td>ADD_PORTLET_LINK</td>
+<td>//div[contains(@class,'item-body')]//*[normalize-space(text())='${key_portletName}']/../../..//button[contains(@class,'item-add')]</td>
+<td></td>
 </tr>
 <tr>
 	<td>ASSET_ITEM</td>
@@ -41,9 +43,9 @@
 </tr>
 <!--CONTENT-->
 <tr>
-  <td>ASSET_ENTRY</td>
-  <td>//div[contains(@class,'item-body') and contains(.,'${key_entryTitle}')]</td>
-  <td></td>
+<td>ASSET_ENTRY</td>
+<td>//div[contains(@class,'item-body') and contains(.,'${key_entryTitle}')]</td>
+<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuPreviewPanel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuPreviewPanel.path
@@ -2,11 +2,13 @@
 <head>
 <title>ControlMenuPreviewPanel</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ControlMenuPreviewPanel</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PREVIEW_DATA_DEVICE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/SystemSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/SystemSettings.path
@@ -2,11 +2,13 @@
 <head>
 <title>SystemSettings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SystemSettings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONFIGURATION_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/currencyconverter/CurrencyConverter.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/currencyconverter/CurrencyConverter.path
@@ -2,11 +2,13 @@
 <head>
 <title>CurrencyConverter</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CurrencyConverter</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NUMBER_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/customfields/CustomFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/customfields/CustomFields.path
@@ -2,11 +2,13 @@
 <head>
 <title>CustomFields</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CustomFields</td></tr>
 </thead>
+
 <tbody>
 <!--RESOURCE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/customfields/CustomFieldsEditResource.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/customfields/CustomFieldsEditResource.path
@@ -2,11 +2,13 @@
 <head>
 <title>CustomFieldsEditResource</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CustomFieldsEditResource</td></tr>
 </thead>
+
 <tbody>
 <!--CUSTOM_FIELDS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMedia.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMedia.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMedia</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMedia</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BREADCRUMB_HOME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaAddShortcut.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaAddShortcut.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaAddShortcut</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaAddShortcut</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_SITE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--DISPLAY_SETTINGS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaDocument</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaDocument</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DOCUMENT_VIEW_VERSION_NUMBER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocumentTypes.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocumentTypes.path
@@ -2,61 +2,63 @@
 <head>
 <title>DocumentsAndMediaDocumentTypes</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaDocumentTypes</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>ADD_FIELD_TYPE</td>
-    <td>//div[contains(@class,'field-type')]//span[normalize-space(text())='${key_fieldType}']</td>
-    <td></td>
+	<td>ADD_FIELD_TYPE</td>
+	<td>//div[contains(@class,'field-type')]//span[normalize-space(text())='${key_fieldType}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_DROP_TARGET</td>
-    <td>//div[contains(@class,'ddm-empty-page ddm-target')]</td>
-    <td></td>
+	<td>FIELD_DROP_TARGET</td>
+	<td>//div[contains(@class,'ddm-empty-page ddm-target')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_BOTTOM_DROP_TARGET</td>
-    <td>//div[contains(@class,'placeholder row')]/div[@data-ddm-field-row='${key_rowNum}']/div[contains(@class,'ddm-target')]</td>
-    <td></td>
+	<td>FIELD_BOTTOM_DROP_TARGET</td>
+	<td>//div[contains(@class,'placeholder row')]/div[@data-ddm-field-row='${key_rowNum}']/div[contains(@class,'ddm-target')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_NAME</td>
-    <td>//div[contains(@class,'ddm-field')]//label[normalize-space(text())='${key_fieldName}']</td>
-    <td></td>
+	<td>FIELD_NAME</td>
+	<td>//div[contains(@class,'ddm-field')]//label[normalize-space(text())='${key_fieldName}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ACTIVE_BASIC_TAB</td>
-    <td>//li[contains(@class,'nav-item')]/button[contains(@class,'active') and contains(.,'Basic')]</td>
-    <td></td>
+	<td>SIDEBAR_ACTIVE_BASIC_TAB</td>
+	<td>//li[contains(@class,'nav-item')]/button[contains(@class,'active') and contains(.,'Basic')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SEARCH_FIELD</td>
-    <td>//div[contains(@class,'input-group-item')]//input[contains(@placeholder,'Search')]</td>
-    <td></td>
+	<td>SEARCH_FIELD</td>
+	<td>//div[contains(@class,'input-group-item')]//input[contains(@placeholder,'Search')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BACK</td>
-    <td>//button[*[name()='svg'][contains(@class,'lexicon-icon-angle-left')]]</td>
-    <td></td>
+	<td>SIDEBAR_BACK</td>
+	<td>//button[*[name()='svg'][contains(@class,'lexicon-icon-angle-left')]]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BUTTON</td>
-    <td>//div[contains(@class,'multi-panel-sidebar')]//ul[contains(@class,'tbar-nav')]//button[contains(@title,'${key_sidebarButton}')]</td>
-    <td></td>
+	<td>SIDEBAR_BUTTON</td>
+	<td>//div[contains(@class,'multi-panel-sidebar')]//ul[contains(@class,'tbar-nav')]//button[contains(@title,'${key_sidebarButton}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_DELETE</td>
-    <td>//button[*[name()='svg'][contains(@class,'lexicon-icon-times')]]</td>
-    <td></td>
+	<td>SIDEBAR_DELETE</td>
+	<td>//button[*[name()='svg'][contains(@class,'lexicon-icon-times')]]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_TITLE</td>
-    <td>//div[contains(@class,'sidebar-content-open')]//div[contains(@class,'sidebar-header') and contains(.,'${key_sidebarTitle}')]</td>
-    <td></td>
+	<td>SIDEBAR_TITLE</td>
+	<td>//div[contains(@class,'sidebar-content-open')]//div[contains(@class,'sidebar-header') and contains(.,'${key_sidebarTitle}')]</td>
+	<td></td>
 </tr>
 <!--DOCUMENT_TYPES_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditCustomDocumentType.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditCustomDocumentType.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditCustomDocumentType</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditCustomDocumentType</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_OPTIONS_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditDocument.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditDocument</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditDocument</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>UNIQUE_DOCUMENT_ERROR_MESSAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditDocumentType.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditDocumentType.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditDocumentType</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditDocumentType</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditFolder.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditFolder.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditFolder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditFolder</td></tr>
 </thead>
+
 <tbody>
 <!--WORKFLOW -->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditMarketingBanner.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditMarketingBanner.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditMarketingBanner</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditMarketingBanner</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MARKETING_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditRepository.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEditRepository.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEditRepository</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEditRepository</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>REPOSITORY_TYPE_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECTED_DOCUMENT_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaMetadataSets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaMetadataSets.path
@@ -2,31 +2,33 @@
 <head>
 <title>DocumentsAndMediaMetadataSets</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaMetadataSets</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>ADD_FIELD_TYPE</td>
-    <td>//div[contains(@class,'field-type')]//span[contains(text(),'${key_fieldType}')]</td>
-    <td></td>
+	<td>ADD_FIELD_TYPE</td>
+	<td>//div[contains(@class,'field-type')]//span[contains(text(),'${key_fieldType}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_TARGET</td>
-    <td>//div[contains(@class,'col-empty')]/div</td>
-    <td></td>
+	<td>ADD_FIELD_TARGET</td>
+	<td>//div[contains(@class,'col-empty')]/div</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_BOTTOM_DROP_TARGET</td>
-    <td>//div[contains(@class,'placeholder row')]/div[@data-ddm-field-row='${key_rowNum}']/div[contains(@class,'ddm-target')]</td>
-    <td></td>
+	<td>FIELD_BOTTOM_DROP_TARGET</td>
+	<td>//div[contains(@class,'placeholder row')]/div[@data-ddm-field-row='${key_rowNum}']/div[contains(@class,'ddm-target')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_LABEL</td>
-    <td>xpath=(//div[contains(@class,'ddm-drag')]//div/p[contains(@class,'ddm-label')])[last()]</td>
-    <td></td>
+	<td>FIELD_LABEL</td>
+	<td>xpath=(//div[contains(@class,'ddm-drag')]//div/p[contains(@class,'ddm-label')])[last()]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>METADATA_SETS_NAME</td>
@@ -39,19 +41,19 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BASIC_TAB</td>
-    <td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Basic')]</td>
-    <td></td>
+	<td>SIDEBAR_BASIC_TAB</td>
+	<td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Basic')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ACTIVE_BASIC_TAB</td>
-    <td>//li[contains(@class,'nav-item')]/button[contains(@class,'active') and contains(.,'Basic')]</td>
-    <td></td>
+	<td>SIDEBAR_ACTIVE_BASIC_TAB</td>
+	<td>//li[contains(@class,'nav-item')]/button[contains(@class,'active') and contains(.,'Basic')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ADVANCED_TAB</td>
-    <td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Advanced')]</td>
-    <td></td>
+	<td>SIDEBAR_ADVANCED_TAB</td>
+	<td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Advanced')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>SIDEBAR_BACK</td>
@@ -59,9 +61,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_FIELDS_TAB</td>
-    <td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Fields')]</td>
-    <td></td>
+	<td>SIDEBAR_FIELDS_TAB</td>
+	<td>//li[contains(@class,'nav-item')]/button[contains(@class,'nav-link') and contains(.,'Fields')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaSelectDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaSelectDocument.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaSelectDocument</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaSelectDocument</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_DOCUMENT_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaSelectFolder.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaSelectFolder.path
@@ -2,11 +2,13 @@
 <head>
 <title>DocumentsAndMediaSelectFolder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DocumentsAndMediaSelectFolder</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_FOLDER_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDL.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDL.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDL</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDL</td></tr>
 </thead>
+
 <tbody>
 
 <!--TOOLBAR-->

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDLConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDLConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONFIGURATION_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLEditList.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLEditList.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDLEditList</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDLEditList</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DATA_DEFINITION_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLEditRecord.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLEditRecord.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDLEditRecord</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDLEditRecord</td></tr>
 </thead>
+
 <tbody>
 <!--FIELDS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLRecord.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLRecord.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDLRecord</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDLRecord</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>WORKFLOW_STATUS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLSpreadsheet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatalists/DDLSpreadsheet.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDLSpreadsheet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDLSpreadsheet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SPREADSHEET_CONTAINER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMEditStructure</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMEditStructure</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditTemplate.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMEditTemplate</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMEditTemplate</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SCRIPT_VARIABLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectFeed.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectFeed.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMSelectFeed</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMSelectFeed</td></tr>
 </thead>
+
 <tbody>
 <!--FEED_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectStructure.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMSelectStructure</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMSelectStructure</td></tr>
 </thead>
+
 <tbody>
 <!--DDM_STRUCTURE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectTemplate.path
@@ -2,11 +2,13 @@
 <head>
 <title>DDMSelectTemplate</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DDMSelectTemplate</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>COPY_FORM_TEMPLATES_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/Dynamicdatamapping.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/Dynamicdatamapping.path
@@ -2,11 +2,13 @@
 <head>
 <title>Dynamicdatamapping</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Dynamicdatamapping</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
@@ -2,194 +2,193 @@
 <head>
 <title>Form</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Form</td></tr>
 </thead>
+
 <tbody>
 <tr>
-    <td>SAVE_NOTIFICATION</td>
-    <td>//div[contains(@class,'autosave-bar')]//span</td>
-    <td></td>
+	<td>SAVE_NOTIFICATION</td>
+	<td>//div[contains(@class,'autosave-bar')]//span</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SAVE_ELEMENT_SET_BUTTON</td>
-    <td>//button[contains(.,'Save') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>SAVE_ELEMENT_SET_BUTTON</td>
+	<td>//button[contains(.,'Save') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SAVE_FORM_BUTTON</td>
-    <td>//button[contains(.,'Save') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>SAVE_FORM_BUTTON</td>
+	<td>//button[contains(.,'Save') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SAVE_FORM_BUTTON_LOCALE</td>
-    <td>//button[contains(.,'${key_localeSaveForm}') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>SAVE_FORM_BUTTON_LOCALE</td>
+	<td>//button[contains(.,'${key_localeSaveForm}') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SAVE_FORM_BUTTON_LOCALIZED</td>
-    <td>//button[contains(.,'${key_saveButton}') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>SAVE_FORM_BUTTON_LOCALIZED</td>
+	<td>//button[contains(.,'${key_saveButton}') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>NAME_FIELD</td>
-    <td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'nameEditor')]</td>
-    <td></td>
+	<td>NAME_FIELD</td>
+	<td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'nameEditor')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DESCRIPTION_FIELD</td>
-    <td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'descriptionEditor')]</td>
-    <td></td>
+	<td>DESCRIPTION_FIELD</td>
+	<td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'descriptionEditor')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_TITLE_FIELD</td>
-    <td>xpath=(//input[contains(@class,'form-builder-page-header-title')])[${key_titleNumber}]</td>
-    <td></td>
+	<td>PAGE_TITLE_FIELD</td>
+	<td>xpath=(//input[contains(@class,'form-builder-page-header-title')])[${key_titleNumber}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PREVIEW_FORM_BUTTON</td>
-    <td>//button[contains(.,'Preview') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>PREVIEW_FORM_BUTTON</td>
+	<td>//button[contains(.,'Preview') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PUBLISH_FORM_BUTTON</td>
-    <td>//button[contains(.,'Publish') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>PUBLISH_FORM_BUTTON</td>
+	<td>//button[contains(.,'Publish') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>UNPUBLISH_FORM_BUTTON</td>
-    <td>//button[contains(.,'Unpublish') and not (contains(@class,'disabled'))]</td>
-    <td></td>
+	<td>UNPUBLISH_FORM_BUTTON</td>
+	<td>//button[contains(.,'Unpublish') and not (contains(@class,'disabled'))]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FORM_PAGE</td>
-    <td>//ol[contains(@class,'multi-step-nav')]//li/div[contains(.,'${key_formPageName}')]</td>
-    <td></td>
+	<td>FORM_PAGE</td>
+	<td>//ol[contains(@class,'multi-step-nav')]//li/div[contains(.,'${key_formPageName}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--ALT_PAGINATION-->
 <tr>
-    <td>ALT_PAGINATION_PAGE</td>
-    <td>//*[contains(@class,'ddm-pagination')]//*[contains(@class,'page-item')]//*[contains(text(),'${key_page}')]</td>
-    <td></td>
+	<td>ALT_PAGINATION_PAGE</td>
+	<td>//*[contains(@class,'ddm-pagination')]//*[contains(@class,'page-item')]//*[contains(text(),'${key_page}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ALT_PAGINATION_SUCCESS_PAGE</td>
-    <td>//*[contains(@class,'ddm-pagination')]//*[contains(text(),'Success Page')]</td>
-    <td></td>
+	<td>ALT_PAGINATION_SUCCESS_PAGE</td>
+	<td>//*[contains(@class,'ddm-pagination')]//*[contains(text(),'Success Page')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--PAGE_CONTROLS-->
 <tr>
-    <td>PAGE_CONTROLS_ELLIPSIS_ICON</td>
-    <td>xpath=(//div[@class="page"])[${key_formPageNumber}]//div[contains(@class,'paginated-builder-dropdown')]//button[contains(@class,'dropdown-toggle')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_ELLIPSIS_ICON</td>
+	<td>xpath=(//div[@class="page"])[${key_formPageNumber}]//div[contains(@class,'paginated-builder-dropdown')]//button[contains(@class,'dropdown-toggle')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_CONTROLS_ADD_NEW_PAGE</td>
-    <td>xpath=(//div[contains(@class,'add-page-button-container')]//button[contains(text(),'New Page')])[${key_formAddNewPageNumber}]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_ADD_NEW_PAGE</td>
+	<td>xpath=(//div[contains(@class,'add-page-button-container')]//button[contains(text(),'New Page')])[${key_formAddNewPageNumber}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_CONTROLS_ADD_SUCCESS_PAGE</td>
-    <td>//li[contains(@class,'dropdown-item')]//a[text()='Add Success Page'] | //button[contains(@class,'dropdown-item') and contains(text(),'Add Success Page')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_ADD_SUCCESS_PAGE</td>
+	<td>//li[contains(@class,'dropdown-item')]//a[text()='Add Success Page'] | //button[contains(@class,'dropdown-item') and contains(text(),'Add Success Page')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_CONTROLS_DELETE_CURRENT_PAGE</td>
-    <td>//button[contains(@class,'dropdown-item') and contains(text(),'Remove Page')][${key_formDropDownNumber}]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_DELETE_CURRENT_PAGE</td>
+	<td>//button[contains(@class,'dropdown-item') and contains(text(),'Remove Page')][${key_formDropDownNumber}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_CONTROLS_DELETE_SUCCESS_PAGE</td>
-    <td>//li[contains(@class,'dropdown-item')]//a[text()='Remove Success Page'] | //button[contains(@class,'dropdown-item') and contains(text(),'Remove Success Page')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_DELETE_SUCCESS_PAGE</td>
+	<td>//li[contains(@class,'dropdown-item')]//a[text()='Remove Success Page'] | //button[contains(@class,'dropdown-item') and contains(text(),'Remove Success Page')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE</td>
-    <td>//li[contains(@class,'dropdown-item')]//a[text()='Switch Pagination Mode'] | //button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination Mode')] | //button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE</td>
+	<td>//li[contains(@class,'dropdown-item')]//a[text()='Switch Pagination Mode'] | //button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination Mode')] | //button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to')]</td>
+	<td></td>
 </tr>
-
 <tr>
-    <td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE_TO_BOTTOM</td>
-    <td>//button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to Bottom')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE_TO_BOTTOM</td>
+	<td>//button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to Bottom')]</td>
+	<td></td>
 </tr>
-
 <tr>
-    <td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE_TO_TOP</td>
-    <td>//button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to Top')]</td>
-    <td></td>
+	<td>PAGE_CONTROLS_SWITCH_PAGINATION_MODE_TO_TOP</td>
+	<td>//button[contains(@class,'dropdown-item') and contains(text(),'Switch Pagination to Top')]</td>
+	<td></td>
 </tr>
-
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--ADD_FIELD-->
 <tr>
-    <td>ADD_FIELD</td>
-    <td>//button[contains(@class,'add-button-large')]/span | //div[contains(@class,'portlet-forms')]//button[contains(@class,'ddm-add-field')]</td>
-    <td></td>
+	<td>ADD_FIELD</td>
+	<td>//button[contains(@class,'add-button-large')]/span | //div[contains(@class,'portlet-forms')]//button[contains(@class,'ddm-add-field')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_TYPE</td>
-    <td>//div[contains(@class,'field-type')]//span[contains(text(),'${key_fieldType}')]</td>
-    <td></td>
+	<td>ADD_FIELD_TYPE</td>
+	<td>//div[contains(@class,'field-type')]//span[contains(text(),'${key_fieldType}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_POSITION</td>
-    <td>xpath=(//div[contains(@class,'yui3-dd-drop') and contains(@class,'col-empty')] | //div[contains(@class,'col-empty')])[${key_fieldLocation}]</td>
-    <td></td>
+	<td>ADD_FIELD_POSITION</td>
+	<td>xpath=(//div[contains(@class,'yui3-dd-drop') and contains(@class,'col-empty')] | //div[contains(@class,'col-empty')])[${key_fieldLocation}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_FIELD_POSITION_1</td>
-    <td>//div[contains(@class,'ddm-target')]</td>
-    <td></td>
+	<td>ADD_FIELD_POSITION_1</td>
+	<td>//div[contains(@class,'ddm-target')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>ADD_IMAGE_DESCRIPTION</td>
-    <td>xpath=(//div[contains(@class,'form-group') ]//input[@placeholder='Add image description.'])[${descriptionPosition}]</td>
-    <td></td>
+	<td>ADD_IMAGE_DESCRIPTION</td>
+	<td>xpath=(//div[contains(@class,'form-group') ]//input[@placeholder='Add image description.'])[${descriptionPosition}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--SUCCESS_PAGE-->
 <tr>
-    <td>SUCCESS_PAGE_TITLE_FIELD</td>
-    <td>//div[contains(@class,'form-builder-success-page')]//input[contains(@class,'form-builder-page-header-title')]</td>
-    <td></td>
+	<td>SUCCESS_PAGE_TITLE_FIELD</td>
+	<td>//div[contains(@class,'form-builder-success-page')]//input[contains(@class,'form-builder-page-header-title')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SUCCESS_PAGE_DESCRIPTION_FIELD</td>
-    <td>//div[contains(@class,'form-builder-success-page')]//input[contains(@class,'form-builder-page-header-description')]</td>
-    <td></td>
+	<td>SUCCESS_PAGE_DESCRIPTION_FIELD</td>
+	<td>//div[contains(@class,'form-builder-success-page')]//input[contains(@class,'form-builder-page-header-description')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--PUBLISH-->
 <tr>
-    <td>PUBLISH_FORM_NAME_FIELD</td>
-    <td>//h1[contains(@class,'form-name') and contains(.,'${key_formName}')]</td>
-    <td></td>
+	<td>PUBLISH_FORM_NAME_FIELD</td>
+	<td>//h1[contains(@class,'form-name') and contains(.,'${key_formName}')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>PUBLISH_FORM_PUBLIC_URL</td>
@@ -197,114 +196,112 @@
 	<td></td>
 </tr>
 <tr>
-    <td>PUBLISH_URL_FORM_PAGE</td>
-    <td>//div[contains(@class,'ddm-form-basic-info')]</td>
-    <td></td>
+	<td>PUBLISH_URL_FORM_PAGE</td>
+	<td>//div[contains(@class,'ddm-form-basic-info')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PUBLISH_ICON</td>
-    <td>//button[contains(@id,'publishIcon')]</td>
-    <td></td>
+	<td>PUBLISH_ICON</td>
+	<td>//button[contains(@id,'publishIcon')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>PUBLISH_UNPUBLISH_ICON_CLOSE</td>
-    <td>//div[contains(@class,'alert-dismissable')]//div[contains(.,'${key_alertMessage}')]/preceding-sibling::button[@class='close']</td>
-    <td></td>
+	<td>PUBLISH_UNPUBLISH_ICON_CLOSE</td>
+	<td>//div[contains(@class,'alert-dismissable')]//div[contains(.,'${key_alertMessage}')]/preceding-sibling::button[@class='close']</td>
+	<td></td>
 </tr>
 <tr>
 	<td>PUBLISH_URL_ICON</td>
 	<td>//button[contains(@class,'share-form-icon')]</td>
 	<td></td>
 </tr>
-
-
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--SETTINGS_TAB-->
 <tr>
-    <td>SETTINGS_TAB_EMAIL_NOTIFICATIONS</td>
-    <td>//a[contains(@class,'tab-content') and contains(.,'Email Notifications')] | //span[contains(text(),'Email Notifications')]</td>
-    <td></td>
+	<td>SETTINGS_TAB_EMAIL_NOTIFICATIONS</td>
+	<td>//a[contains(@class,'tab-content') and contains(.,'Email Notifications')] | //span[contains(text(),'Email Notifications')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SETTINGS_TAB_WORKFLOW_CONFIGURATION_FIELD</td>
-    <td>//div[contains(@data-field-name,'workflowDefinition')]//div[contains(@class,form-builder-select-field)]</td>
-    <td></td>
+	<td>SETTINGS_TAB_WORKFLOW_CONFIGURATION_FIELD</td>
+	<td>//div[contains(@data-field-name,'workflowDefinition')]//div[contains(@class,form-builder-select-field)]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SETTINGS_TAB_WORKFLOW_CONFIGURATION</td>
-    <td>//div[contains(@class,'dropdown-menu')]//li/button[contains(@class,'dropdown-item') and contains(.,'${key_workflowDefinition}')]</td>
-    <td></td>
+	<td>SETTINGS_TAB_WORKFLOW_CONFIGURATION</td>
+	<td>//div[contains(@class,'dropdown-menu')]//li/button[contains(@class,'dropdown-item') and contains(.,'${key_workflowDefinition}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--FIELD-->
 <tr>
-    <td>FIELD_BODY</td>
-    <td>//div[contains(@class,'form-group')]//label[contains(text(),'${key_fieldName}')] | //div[contains(@class,'form-group')]//legend[contains(text(),'${key_fieldName}')] |//div[contains(@data-field-name,'${key_fieldName}')] | //div[contains(@class,'form-group')]//input[contains(@name,'${key_fieldName}')]/parent::div/parent::div</td>
-    <td></td>
+	<td>FIELD_BODY</td>
+	<td>//div[contains(@class,'form-group')]//label[contains(text(),'${key_fieldName}')] | //div[contains(@class,'form-group')]//legend[contains(text(),'${key_fieldName}')] |//div[contains(@data-field-name,'${key_fieldName}')] | //div[contains(@class,'form-group')]//input[contains(@name,'${key_fieldName}')]/parent::div/parent::div</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_BODY_IN_SPECIFIC_POSITION</td>
-    <td>xpath=(//div[contains(@class,'form-group')]//label[contains(text(),'${key_fieldName}')])[${key_fieldPositionNumber}]</td>
-    <td></td>
+	<td>FIELD_BODY_IN_SPECIFIC_POSITION</td>
+	<td>xpath=(//div[contains(@class,'form-group')]//label[contains(text(),'${key_fieldName}')])[${key_fieldPositionNumber}]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_LABEL</td>
-    <td>//div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//label[contains(@class,'ddm-label')] | //div[contains(@class,'ddm-field-container')]//label[text()='${key_fieldName}'] | //div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//legend[contains(@class,'lfr-ddm-legend')] | //div[contains(@class,'ddm-field-container')]//legend[text()='${key_fieldName}']</td>
-    <td></td>
+	<td>FIELD_LABEL</td>
+	<td>//div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//label[contains(@class,'ddm-label')] | //div[contains(@class,'ddm-field-container')]//label[text()='${key_fieldName}'] | //div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//legend[contains(@class,'lfr-ddm-legend')] | //div[contains(@class,'ddm-field-container')]//legend[text()='${key_fieldName}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>FIELD_REFERENCE</td>
-    <td>//input[contains(@name,'fieldReference')]</td>
-    <td></td>
+	<td>FIELD_REFERENCE</td>
+	<td>//input[contains(@name,'fieldReference')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--SIDEBAR -->
 <tr>
-    <td>SIDEBAR_AUTOCOMPLETE_TAB</td>
-    <td>//a[contains(@class,'tab') and .='Autocomplete'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Autocomplete')]</td>
-    <td></td>
+	<td>SIDEBAR_AUTOCOMPLETE_TAB</td>
+	<td>//a[contains(@class,'tab') and .='Autocomplete'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Autocomplete')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ADVANCED_TAB</td>
-    <td>//a[contains(@class,'tab') and .='Advanced'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Advanced')]</td>
-    <td></td>
+	<td>SIDEBAR_ADVANCED_TAB</td>
+	<td>//a[contains(@class,'tab') and .='Advanced'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Advanced')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ADVANCED_TAB_LOCALE</td>
-    <td>//a[contains(@class,'tab') and .='${key_localeAdvanced}'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'${key_localeAdvanced}')]</td>
-    <td></td>
+	<td>SIDEBAR_ADVANCED_TAB_LOCALE</td>
+	<td>//a[contains(@class,'tab') and .='${key_localeAdvanced}'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'${key_localeAdvanced}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_PROPERTIES_TAB</td>
-    <td>//a[contains(@class,'tab') and .='Properties'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Properties')]</td>
-    <td></td>
+	<td>SIDEBAR_PROPERTIES_TAB</td>
+	<td>//a[contains(@class,'tab') and .='Properties'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Properties')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BACK</td>
-    <td>//div[contains(@class,'open') and contains(@class,'form-builder-sidebar')]//a[contains(@class,'back')]</td>
-    <td></td>
+	<td>SIDEBAR_BACK</td>
+	<td>//div[contains(@class,'open') and contains(@class,'form-builder-sidebar')]//a[contains(@class,'back')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BASIC_TAB</td>
-    <td>//a[contains(@class,'tab') and .='Basic'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Basic')]</td>
-    <td></td>
+	<td>SIDEBAR_BASIC_TAB</td>
+	<td>//a[contains(@class,'tab') and .='Basic'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'Basic')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_BASIC_TAB_LOCALE</td>
-    <td>//a[contains(@class,'tab') and .='${key_localeBasic}'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'${key_localeBasic}')]</td>
-    <td></td>
+	<td>SIDEBAR_BASIC_TAB_LOCALE</td>
+	<td>//a[contains(@class,'tab') and .='${key_localeBasic}'] | //a[contains(@aria-controls,'sidebarLightDetails')]//*[contains(text(),'${key_localeBasic}')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>SIDEBAR_CHANGE_FIELD_TYPE_MODAL_BUTTON</td>
@@ -312,34 +309,34 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ELEMENTS_TAB</td>
-    <td>//a[contains(@class,'tab') and .='Elements'] | //a[contains(@class,'nav-link active') and .='Elements']</td>
-    <td></td>
+	<td>SIDEBAR_ELEMENTS_TAB</td>
+	<td>//a[contains(@class,'tab') and .='Elements'] | //a[contains(@class,'nav-link active') and .='Elements']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ELEMENTS_TAB_LOCALE</td>
-    <td>//a[contains(@class,'tab') and .='${key_localeElements}'] | //a[contains(@class,'nav-link active') and .='${key_localeElements}']</td>
-    <td></td>
+	<td>SIDEBAR_ELEMENTS_TAB_LOCALE</td>
+	<td>//a[contains(@class,'tab') and .='${key_localeElements}'] | //a[contains(@class,'nav-link active') and .='${key_localeElements}']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ELEMENT_SETS_TAB</td>
-    <td>//*[contains(@class,'nav-link') and .='Element Sets']</td>
-    <td></td>
+	<td>SIDEBAR_ELEMENT_SETS_TAB</td>
+	<td>//*[contains(@class,'nav-link') and .='Element Sets']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_ELLIPSIS</td>
-    <td>//div[contains(@class,'sidebar')]//a[*[contains(@class,'lexicon-icon-ellipsis-v')]] | //div[contains(@class,'sidebar')]//button[*[contains(@class,'lexicon-icon-ellipsis-v')]]</td>
-    <td></td>
+	<td>SIDEBAR_ELLIPSIS</td>
+	<td>//div[contains(@class,'sidebar')]//a[*[contains(@class,'lexicon-icon-ellipsis-v')]] | //div[contains(@class,'sidebar')]//button[*[contains(@class,'lexicon-icon-ellipsis-v')]]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_MENUITEM_REMOVE_FIELD</td>
-    <td>//a[@title='Remove Field'] | //button[text()='Remove Field']</td>
-    <td></td>
+	<td>SIDEBAR_MENUITEM_REMOVE_FIELD</td>
+	<td>//a[@title='Remove Field'] | //button[text()='Remove Field']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_MENUITEM_DUPLICATE_FIELD</td>
-    <td>//a[@title='Duplicate Field'] | //button[text()='Duplicate Field']</td>
-    <td></td>
+	<td>SIDEBAR_MENUITEM_DUPLICATE_FIELD</td>
+	<td>//a[@title='Duplicate Field'] | //button[text()='Duplicate Field']</td>
+	<td></td>
 </tr>
 <tr>
 	<td>SIDEBAR_DELETE_FIELD_MODAL_DELETE_BUTTON</td>
@@ -347,9 +344,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SIDEBAR_CLOSE</td>
-    <td>//div[contains(@class,'open') and contains(@class,'sidebar-container')]//a[contains(@class,'sidebar-close')]</td>
-    <td></td>
+	<td>SIDEBAR_CLOSE</td>
+	<td>//div[contains(@class,'open') and contains(@class,'sidebar-container')]//a[contains(@class,'sidebar-close')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>VALIDATE_CHANGE_FIELD_TYPE_MODAL_MESSAGE</td>
@@ -362,30 +359,30 @@
 	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--DATA_PROVIDER_OUTPUT_PARAMETER-->
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_PATH_FIELD</td>
-    <td>//div[contains(@data-field-name,'outputParameters')]//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'path')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_PATH_FIELD</td>
+	<td>//div[contains(@data-field-name,'outputParameters')]//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'path')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_PATH_FIELD_2</td>
-    <td>//div[contains(@data-field-name,'outputParameters')]/following-sibling::div/div//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'path')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_PATH_FIELD_2</td>
+	<td>//div[contains(@data-field-name,'outputParameters')]/following-sibling::div/div//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'path')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_LABEL_FIELD</td>
-    <td>//div[contains(@data-field-name,'outputParameters')]//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'label')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_LABEL_FIELD</td>
+	<td>//div[contains(@data-field-name,'outputParameters')]//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'label')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_LABEL_FIELD_2</td>
-    <td>//div[contains(@data-field-name,'outputParameters')]/following-sibling::div/div//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'label')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_LABEL_FIELD_2</td>
+	<td>//div[contains(@data-field-name,'outputParameters')]/following-sibling::div/div//input[@type='text' and contains(@name,'outputParameters') and contains(@placeholder,'label')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>DATA_PROVIDER_OUTPUT_PARAMETER_TYPE_FIELD</td>
@@ -398,35 +395,35 @@
 	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_TYPE_FIELD_OPTIONS_LIST</td>
-    <td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_outputParameterType}')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_TYPE_FIELD_OPTIONS_LIST</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_outputParameterType}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_TYPE_FIELD_OPTIONS_LIST_2</td>
-    <td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_outputParameterType}')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_TYPE_FIELD_OPTIONS_LIST_2</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_outputParameterType}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_OUTPUT_PARAMETER_REPEAT_ICON</td>
-    <td>//div[contains(@data-field-name,'outputParameters')]//div[contains(@class,'field-repeatable')]//button[contains(@class,'add-button')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_OUTPUT_PARAMETER_REPEAT_ICON</td>
+	<td>//div[contains(@data-field-name,'outputParameters')]//div[contains(@class,'field-repeatable')]//button[contains(@class,'add-button')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--DATA_PROVIDER_PERMISSIONS_PARAMETER-->
 <tr>
-    <td>DATA_PROVIDER_PERMISSIONS_PARAMETER_PANEL</td>
-    <td>//div[contains(@id,'permissionsTitle')]//a[contains(@class,'collapse-icon')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_PERMISSIONS_PARAMETER_PANEL</td>
+	<td>//div[contains(@id,'permissionsTitle')]//a[contains(@class,'collapse-icon')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>DATA_PROVIDER_PERMISSIONS_VIEWABLE_BY_SELECT</td>
-    <td>//div[contains(@id,'permissionsContent')]//select[contains(@id,'inputPermissionsViewRole')]</td>
-    <td></td>
+	<td>DATA_PROVIDER_PERMISSIONS_VIEWABLE_BY_SELECT</td>
+	<td>//div[contains(@id,'permissionsContent')]//select[contains(@id,'inputPermissionsViewRole')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -2,11 +2,13 @@
 <head>
 <title>FormFields</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormFields</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FIELD_ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>FormPortlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormPortlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FORM_CONTAINER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortletConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortletConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>FormPortletConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormPortletConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--FORMS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormRules.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormRules.path
@@ -2,42 +2,44 @@
 <head>
 <title>FormRules</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormRules</td></tr>
 </thead>
+
 <tbody>
 <!--RULE_BUILDER-->
 <tr>
-    <td>RULE_BUILDER_ADD_RULE_BUTTON</td>
-    <td>//button[contains(@class,'ddm-add-rule')] | //button[contains(@id,'addFieldButton')]</td>
-    <td></td>
+	<td>RULE_BUILDER_ADD_RULE_BUTTON</td>
+	<td>//button[contains(@class,'ddm-add-rule')] | //button[contains(@id,'addFieldButton')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_ROW_VERTICAL_ELLIPSIS</td>
-    <td>//div[contains(@class,'form-rule-list')]//li[contains(@class,'list-group-item')][${key_ruleNumber}]//button[contains(@class,'dropdown-toggle')]</td>
-    <td></td>
+	<td>RULE_BUILDER_ROW_VERTICAL_ELLIPSIS</td>
+	<td>//div[contains(@class,'form-rule-list')]//li[contains(@class,'list-group-item')][${key_ruleNumber}]//button[contains(@class,'dropdown-toggle')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_ADD_ACTION</td>
-    <td>//ul[contains(@class, 'timeline')][2]//li[contains(@class,'timeline-increment-action-button')]//button</td>
-    <td></td>
+	<td>RULE_BUILDER_ADD_ACTION</td>
+	<td>//ul[contains(@class, 'timeline')][2]//li[contains(@class,'timeline-increment-action-button')]//button</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_ADD_CONDITION</td>
-    <td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-increment-action-button')]//button</td>
-    <td></td>
+	<td>RULE_BUILDER_ADD_CONDITION</td>
+	<td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-increment-action-button')]//button</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_BROKEN</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'form-rule-list-invalid-rule')]//div[contains(text(), 'Broken Rule')]</td>
-    <td></td>
+	<td>RULE_BUILDER_BROKEN</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'form-rule-list-invalid-rule')]//div[contains(text(), 'Broken Rule')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_RULE_CONDITION_DROPDOWN</td>
-    <td>//div[contains(@class,'timeline-dropdown')]//button</td>
-    <td></td>
+	<td>RULE_BUILDER_RULE_CONDITION_DROPDOWN</td>
+	<td>//div[contains(@class,'timeline-dropdown')]//button</td>
+	<td></td>
 </tr>
 <tr>
 	<td>RULE_BUILDER_CONDITION_FIELD</td>
@@ -55,34 +57,34 @@
 	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CONDITION_VALUE_FIELD</td>
-    <td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditionRowNumber}]//div[contains(@class,'form-group-item') and not(contains(@class, 'form-group-item-label'))][${key_fieldColumnNumber}]//div[contains(@class,'option-selected')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CONDITION_VALUE_FIELD</td>
+	<td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditionRowNumber}]//div[contains(@class,'form-group-item') and not(contains(@class, 'form-group-item-label'))][${key_fieldColumnNumber}]//div[contains(@class,'option-selected')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CONDITION_VALUE_TEXT_FIELD</td>
-    <td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditionRowNumber}]//div[contains(@class,'form-group-item') and not(contains(@class, 'form-group-item-label'))][${key_fieldColumnNumber}]//input</td>
-    <td></td>
+	<td>RULE_BUILDER_CONDITION_VALUE_TEXT_FIELD</td>
+	<td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditionRowNumber}]//div[contains(@class,'form-group-item') and not(contains(@class, 'form-group-item-label'))][${key_fieldColumnNumber}]//input</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_TIMELINE_RULE_CONDITION</td>
-    <td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditonRowNumber}]//div[contains(@class, 'operator')]//span[contains(.,'${key_condition}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_TIMELINE_RULE_CONDITION</td>
+	<td>//ul[contains(@class, 'timeline')][1]//li[contains(@class,'timeline-item')]/following-sibling::li[contains(@class, 'timeline-item')][${key_conditonRowNumber}]//div[contains(@class, 'operator')]//span[contains(.,'${key_condition}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SAVE_BUTTON</td>
-    <td>//div[contains(@class,'form-rule-builder-footer')]//button[contains(@class,'btn-primary')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SAVE_BUTTON</td>
+	<td>//div[contains(@class,'form-rule-builder-footer')]//button[contains(@class,'btn-primary')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SAVE_BUTTON_DISABLED</td>
-    <td>//div[contains(@class,'form-rule-builder-footer')]//button[@disabled='' and contains(@class,'btn-primary')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SAVE_BUTTON_DISABLED</td>
+	<td>//div[contains(@class,'form-rule-builder-footer')]//button[@disabled='' and contains(@class,'btn-primary')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--RULE_BUILDER_AUTOFILL-->
 <tr>
@@ -91,71 +93,71 @@
 	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_AUTOFILL_SELECT_OUTPUT_FIELD</td>
-    <td>//div[contains(@class, 'dropdown-menu') and contains(@class, 'show')]//button[contains(text(),'${key_dataProviderOutput}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_AUTOFILL_SELECT_OUTPUT_FIELD</td>
+	<td>//div[contains(@class, 'dropdown-menu') and contains(@class, 'show')]//button[contains(text(),'${key_dataProviderOutput}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--RULE_BUILDER_CALCULATE-->
 <tr>
-    <td>RULE_BUILDER_CALCULATE_OPERATOR</td>
-    <td>//div[contains(@class,'calculator-buttons-operators')]//button[contains(., '${key_calculateOperator}') and contains(@class, 'calculator-button')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CALCULATE_OPERATOR</td>
+	<td>//div[contains(@class,'calculator-buttons-operators')]//button[contains(., '${key_calculateOperator}') and contains(@class, 'calculator-button')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CALCULATE_ADD_FIELD_BUTTON</td>
-    <td>//button[contains(@class,'calculator-add-field-button')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CALCULATE_ADD_FIELD_BUTTON</td>
+	<td>//button[contains(@class,'calculator-add-field-button')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CALCULATE_ADD_FIELD_LIST</td>
-    <td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_calculateFieldOption}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CALCULATE_ADD_FIELD_LIST</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li[contains(.,'${key_calculateFieldOption}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CALCULATE_ADD_FIELD_LIST_BY_FIELD_REFERENCE</td>
-    <td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//span[contains(.,'${key_calculateFieldOption}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CALCULATE_ADD_FIELD_LIST_BY_FIELD_REFERENCE</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//span[contains(.,'${key_calculateFieldOption}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_CALCULATE_RESULT_EXPRESSION</td>
-    <td>//div[contains(@class,'calculate-container-fields')]//textarea[contains(.,'${key_calculatorExpression}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_CALCULATE_RESULT_EXPRESSION</td>
+	<td>//div[contains(@class,'calculate-container-fields')]//textarea[contains(.,'${key_calculatorExpression}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td></td>
-    <td></td>
-    <td></td>
+	<td></td>
+	<td></td>
+	<td></td>
 </tr>
 <!--RULE_BUILDER_SUMMARY-->
 <tr>
-    <td>RULE_BUILDER_SUMMARY_CONDITION_FIELD</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//span[contains(@class,'inline-item')]//div[contains(text(),'${key_conditionField}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SUMMARY_CONDITION_FIELD</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//span[contains(@class,'inline-item')]//div[contains(text(),'${key_conditionField}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SUMMARY_CONDITION_FIELD_CONSTANT</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span//div[contains(text(),'${key_conditionFieldConstant}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SUMMARY_CONDITION_FIELD_CONSTANT</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span//div[contains(text(),'${key_conditionFieldConstant}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SUMMARY_CONDITION_OPERATOR</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class,'inline-item')]//em[contains(text(),'${key_conditionOperator}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SUMMARY_CONDITION_OPERATOR</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class,'inline-item')]//em[contains(text(),'${key_conditionOperator}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SUMMARY_ACTION</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span[contains(.,'${key_action}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SUMMARY_ACTION</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span[contains(.,'${key_action}')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>RULE_BUILDER_SUMMARY_ACTION_TARGET</td>
-    <td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span[contains(.,'${key_action}')]//div[contains(text(), '${key_actionTarget}')]</td>
-    <td></td>
+	<td>RULE_BUILDER_SUMMARY_ACTION_TARGET</td>
+	<td>//li[contains(@class, 'list-group-item')][${key_ruleNumber}]//div[contains(@class,'autofit-col-expand')]//b[contains(@class, 'text-lowercase')]/following-sibling::span[contains(.,'${key_action}')]//div[contains(text(), '${key_actionTarget}')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormsAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormsAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>FormsAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FormsAdmin</td></tr>
 </thead>
+
 <tbody>
 <!--FORMS_ENTRY_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
@@ -2,11 +2,13 @@
 <head>
 <title>Fragment</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Fragment</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>COLLECTION_CATEGORY_FILTER_DROPDOWN_TOGGLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/FragmentAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/FragmentAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>FragmentAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FragmentAdmin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>FRAGMENT_COLLECTION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/FragmentEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/FragmentEditor.path
@@ -2,11 +2,13 @@
 <head>
 <title>FragmentEditor</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FragmentEditor</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>AUTOCOMPLETE_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gdpr/DataErasure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gdpr/DataErasure.path
@@ -2,11 +2,13 @@
 <head>
 <title>DataErasure</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">DataErasure</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gdpr/ExportPersonalData.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gdpr/ExportPersonalData.path
@@ -2,11 +2,13 @@
 <head>
 <title>ExportPersonalData</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ExportPersonalData</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gogoshell/GogoShell.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/gogoshell/GogoShell.path
@@ -2,11 +2,13 @@
 <head>
 <title>GogoShell</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GogoShell</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>COMMAND_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/helloworld/HelloWorld.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/helloworld/HelloWorld.path
@@ -2,11 +2,13 @@
 <head>
 <title>HelloWorld</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">HelloWorld</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PORTLET_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/invitemembers/InviteMembers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/invitemembers/InviteMembers.path
@@ -2,11 +2,13 @@
 <head>
 <title>InviteMembers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">InviteMembers</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>INVITE_USER_FULL_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBase.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBase.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBase</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBase</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>KB_TOOLS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBaseArticle</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBaseArticle</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBaseConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBaseConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION_TAB-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSelectParent.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSelectParent.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBaseSelectParent</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBaseSelectParent</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSuggestions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSuggestions.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBaseSuggestions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBaseSuggestions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONTENT_INPUT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseTemplate.path
@@ -2,11 +2,13 @@
 <head>
 <title>KnowledgeBaseTemplate</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">KnowledgeBaseTemplate</td></tr>
 </thead>
+
 <tbody>
 <!--TEMPLATE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/language/Language.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/language/Language.path
@@ -2,11 +2,13 @@
 <head>
 <title>Language</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Language</td></tr>
 </thead>
+
 <tbody>
 <!--LANGUAGE_MENU-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/language/LanguageConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/language/LanguageConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>LanguageConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">LanguageConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--LANGUAGES-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/AlloyShowcase.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/AlloyShowcase.path
@@ -2,11 +2,13 @@
 <head>
 <title>AlloyShowcase</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AlloyShowcase</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALLOY_DATA_LIST_ITEM_DESCRIPTION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/BridgeDemos.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/BridgeDemos.path
@@ -2,11 +2,13 @@
 <head>
 <title>BridgeDemos</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BridgeDemos</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_ATTACHMENT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/BridgeIssues.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/BridgeIssues.path
@@ -2,11 +2,13 @@
 <head>
 <title>BridgeIssues</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">BridgeIssues</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTION_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/JSFShowcase.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/JSFShowcase.path
@@ -2,11 +2,13 @@
 <head>
 <title>JSFShowcase</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JSFShowcase</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ATTRIBUTE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/JSFSignInAndPrimeFacesUsers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/JSFSignInAndPrimeFacesUsers.path
@@ -2,11 +2,13 @@
 <head>
 <title>JSFSignInAndPrimeFacesUsers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JSFSignInAndPrimeFacesUsers</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CHOOSE_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/PortalShowcase.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/liferayfaces/PortalShowcase.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalShowcase</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalShowcase</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>RENDERED_CHECKBOX</td>
@@ -34,39 +36,39 @@
 	<td></td>
 </tr>
 <tr>
-    <td>WRITEABLE_FIELD</td>
-    <td>//div[contains(@id,':comments')]//iframe</td>
-    <td></td>
+	<td>WRITEABLE_FIELD</td>
+	<td>//div[contains(@id,':comments')]//iframe</td>
+	<td></td>
 </tr>
 <tr>
-    <td>WRITEABLE_FIELD_2</td>
-    <td>xpath=(//div[contains(@id,':comments')]//iframe)[2]</td>
-    <td></td>
+	<td>WRITEABLE_FIELD_2</td>
+	<td>xpath=(//div[contains(@id,':comments')]//iframe)[2]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SUBMIT_BUTTON</td>
-    <td>//input[@value='Submit']</td>
-    <td></td>
+	<td>SUBMIT_BUTTON</td>
+	<td>//input[@value='Submit']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>SUBMIT_BUTTON_2</td>
-    <td>xpath=(//input[@value='Submit'])[2]</td>
-    <td></td>
+	<td>SUBMIT_BUTTON_2</td>
+	<td>xpath=(//input[@value='Submit'])[2]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>MODAL_VALUE</td>
-    <td>//span[@id='_1_WAR_comliferayfacesdemoportalshowcaseportlet_:modelValue']</td>
-    <td></td>
+	<td>MODAL_VALUE</td>
+	<td>//span[@id='_1_WAR_comliferayfacesdemoportalshowcaseportlet_:modelValue']</td>
+	<td></td>
 </tr>
 <tr>
-    <td>MODAL_VALUE_TITLE</td>
-    <td>//label[contains(text(),'Model Value')]</td>
-    <td></td>
+	<td>MODAL_VALUE_TITLE</td>
+	<td>//label[contains(text(),'Model Value')]</td>
+	<td></td>
 </tr>
 <tr>
-    <td>TEXT_FEEDBACK</td>
-    <td>//div[contains(@id,':feedback')]</td>
-    <td></td>
+	<td>TEXT_FEEDBACK</td>
+	<td>//div[contains(@id,':feedback')]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/AppManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/AppManager.path
@@ -2,11 +2,13 @@
 <head>
 <title>AppManager</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">AppManager</td></tr>
 </thead>
+
 <tbody>
 <!--APP-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/LicenseManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/marketplace/LicenseManager.path
@@ -2,11 +2,13 @@
 <head>
 <title>LicenseManager</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">LicenseManager</td></tr>
 </thead>
+
 <tbody>
 <!--LICENSE_MANAGER-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mediagallery/MediaGallery.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mediagallery/MediaGallery.path
@@ -2,11 +2,13 @@
 <head>
 <title>MediaGallery</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MediaGallery</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BREADCRUMB</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mentions/Mentions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mentions/Mentions.path
@@ -2,11 +2,13 @@
 <head>
 <title>Mentions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Mentions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MENTIONS_COMMENT_TAG_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoards.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoards.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoards</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoards</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_CATEGORY_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsAdmin</td></tr>
 </thead>
+
 <tbody>
 <!--THREADS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsAdminConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsAdminConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsAdminConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsAdminConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--GENERAL-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsBannedUsers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsBannedUsers.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsBannedUsers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsBannedUsers</td></tr>
 </thead>
+
 <tbody>
 <!--BANNED_USERS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditCategory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditCategory.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsEditCategory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsEditCategory</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DISPLAY_STYLE_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsEditMessage</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsEditMessage</td></tr>
 </thead>
+
 <tbody>
 <!--ATTACHMENTS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsMoveThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsMoveThread.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsMoveThread</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsMoveThread</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CATEGORY_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsMySubscriptions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsMySubscriptions.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsMySubscriptions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsMySubscriptions</td></tr>
 </thead>
+
 <tbody>
 <!--CATEGORY_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsRemovedAttachments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsRemovedAttachments.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsRemovedAttachments</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsRemovedAttachments</td></tr>
 </thead>
+
 <tbody>
 <!--ATTACHMENT_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSearch.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSearch.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsSearch</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsSearch</td></tr>
 </thead>
+
 <tbody>
 <!--SEARCH_RESULTS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSelectCategory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSelectCategory.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsSelectCategory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsSelectCategory</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSplitThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsSplitThread.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsSplitThread</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsSplitThread</td></tr>
 </thead>
+
 <tbody>
 <!--THREAD_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsStatistics.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsStatistics.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsStatistics</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsStatistics</td></tr>
 </thead>
+
 <tbody>
 <!--GENERAL-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
@@ -2,11 +2,13 @@
 <head>
 <title>MessageBoardsThread</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MessageBoardsThread</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TITLE_HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mfa/MultiFactorAuthentication.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mfa/MultiFactorAuthentication.path
@@ -2,11 +2,13 @@
 <head>
 <title>MultiFactorAuthentication</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MultiFactorAuthentication</td></tr>
 </thead>
+
 <tbody>
 <!--CUSTOM_MFA_VERIFICATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/microblogs/Microblogs.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/microblogs/Microblogs.path
@@ -2,11 +2,13 @@
 <head>
 <title>Microblogs</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Microblogs</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_TAB</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/myaccount/MyAccount.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/myaccount/MyAccount.path
@@ -2,11 +2,13 @@
 <head>
 <title>MyAccount</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MyAccount</td></tr>
 </thead>
+
 <tbody>
 <!--DISPLAY_SETTINGS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mysubscriptions/MySubscriptions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/mysubscriptions/MySubscriptions.path
@@ -2,11 +2,13 @@
 <head>
 <title>MySubscriptions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MySubscriptions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/Navigation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/Navigation.path
@@ -2,11 +2,13 @@
 <head>
 <title>Navigation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Navigation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BREADCRUMB_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/NavigationMenusWidget.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/NavigationMenusWidget.path
@@ -2,11 +2,13 @@
 <head>
 <title>NavigationMenusWidget</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NavigationMenusWidget</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CHILD_TOGGLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/SiteNavigationMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/SiteNavigationMenu.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteNavigationMenu</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteNavigationMenu</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ITEM_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/networkutilities/NetworkUtilities.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/networkutilities/NetworkUtilities.path
@@ -2,11 +2,13 @@
 <head>
 <title>NetworkUtilities</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">NetworkUtilities</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DNS_LOOKUP_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
@@ -2,11 +2,13 @@
 <head>
 <title>OAuth2</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OAuth2</td></tr>
 </thead>
+
 <tbody>
 <!--ADMIN-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
@@ -2,11 +2,13 @@
 <head>
 <title>PageEditor</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PageEditor</td></tr>
 </thead>
+
 <tbody>
 <!--BASED_ON_CUSTOM_MASTERS-->
 <tr>
@@ -366,10 +368,10 @@
 	<td>//strong[contains(@class,'text-dark') and contains(.,'${key_fragmentName}')]</td>
 	<td></td>
 </tr>
-<tr>	
-	<td>FRAGMENT_SIDEBAR_COMMENT_LIST_SECONDARY_TEXT</td>	
-	<td>//span[contains(@class,'text-secondary') and contains(.,'${key_commentCount}')]</td>	
-	<td></td>	
+<tr>
+	<td>FRAGMENT_SIDEBAR_COMMENT_LIST_SECONDARY_TEXT</td>
+	<td>//span[contains(@class,'text-secondary') and contains(.,'${key_commentCount}')]</td>
+	<td></td>
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_COMMENT_LIST_TITLE</td>
@@ -536,9 +538,9 @@
 	<td></td>
 </tr>
 <tr>
-  <td>CONTAINER_CONTAINER_EMPTY</td>
-  <td>xpath=(//div[contains(@class,'page-editor__topper__bar') and contains(.,'Container')]//following-sibling::div[contains(@class,'page-editor__topper__content')])[${key_position}]/div[contains(@class,'page-editor__container')][contains(@class,'empty')]</td>
-  <td></td>
+<td>CONTAINER_CONTAINER_EMPTY</td>
+<td>xpath=(//div[contains(@class,'page-editor__topper__bar') and contains(.,'Container')]//following-sibling::div[contains(@class,'page-editor__topper__content')])[${key_position}]/div[contains(@class,'page-editor__container')][contains(@class,'empty')]</td>
+<td></td>
 </tr>
 <tr>
 	<td>CONTAINER_CONTAINER_NESTED_ELEMENT</td>
@@ -551,9 +553,9 @@
 	<td></td>
 </tr>
 <tr>
-  <td>GRID_COLUMN_EMPTY</td>
-  <td>xpath=(//div[contains(@class,'page-editor__topper__bar') and contains(.,'Grid')]//following-sibling::div[contains(@class,'page-editor__topper__content')])[${key_position}]//div[contains(@class,'page-editor__row')][contains(@class,'empty')]</td>
-  <td></td>
+<td>GRID_COLUMN_EMPTY</td>
+<td>xpath=(//div[contains(@class,'page-editor__topper__bar') and contains(.,'Grid')]//following-sibling::div[contains(@class,'page-editor__topper__content')])[${key_position}]//div[contains(@class,'page-editor__row')][contains(@class,'empty')]</td>
+<td></td>
 </tr>
 <tr>
 	<td>GRID_COLUMN_NESTED_ELEMENT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditorEditableLink.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditorEditableLink.path
@@ -2,11 +2,13 @@
 <head>
 <title>PageEditorEditableLink</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PageEditorEditableLink</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_SELECT_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagesfinder/PagesFinder.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagesfinder/PagesFinder.path
@@ -2,11 +2,13 @@
 <head>
 <title>PagesFinder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PagesFinder</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CHILD_PAGE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagetemplates/PageTemplates.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pagetemplates/PageTemplates.path
@@ -2,11 +2,13 @@
 <head>
 <title>PageTemplates</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PageTemplates</td></tr>
 </thead>
+
 <tbody>
 <!--PAGE_TEMPLATE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/passwordpolicies/PasswordPolicies.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/passwordpolicies/PasswordPolicies.path
@@ -2,11 +2,13 @@
 <head>
 <title>PasswordPolicies</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PasswordPolicies</td></tr>
 </thead>
+
 <tbody>
 <!--ASSIGN_ORGANIZATIONS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalinstances/PortalInstances.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalinstances/PortalInstances.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalInstances</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalInstances</td></tr>
 </thead>
+
 <tbody>
 <!--INSTANCE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettings.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalSettings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalSettings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>VIRTUAL_HOST_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsAuthentication.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsAuthentication.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalSettingsAuthentication</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalSettingsAuthentication</td></tr>
 </thead>
+
 <tbody>
 <!--AUTHENTICATION_GENERAL-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsContentSharing.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsContentSharing.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalSettingsContentSharing</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalSettingsContentSharing</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONTENT_SHARING_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsEmailNotifications.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsEmailNotifications.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalSettingsEmailNotifications</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalSettingsEmailNotifications</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NAVIGATION_EMAIL_VERIFICATION_NOTIFICATION_BODY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsUsers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/portalsettings/PortalSettingsUsers.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalSettingsUsers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalSettingsUsers</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>APPLY_TO_EXISTING_USERS_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
@@ -2,11 +2,13 @@
 <head>
 <title>ProductMenu</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ProductMenu</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PANEL_COLLAPSED</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/Publications.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/Publications.path
@@ -2,11 +2,13 @@
 <head>
 <title>Publications</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Publications</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>AUTOMATICALLY_RESOLVED_TABLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/PublicationsChanges.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/PublicationsChanges.path
@@ -2,11 +2,13 @@
 <head>
 <title>PublicationsChanges</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PublicationsChanges</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PUBLICATIONS_CHANGE_SITE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/PublicationsSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/publications/PublicationsSettings.path
@@ -2,11 +2,13 @@
 <head>
 <title>PublicationsSettings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PublicationsSettings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PUBLICATIONS_TOGGLE_SWITCH</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
@@ -2,11 +2,13 @@
 <head>
 <title>Questions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Questions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ANSWER_BODY</td>
@@ -303,5 +305,3 @@
 </table>
 </body>
 </html>
-
-

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/quicknote/QuickNote.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/quicknote/QuickNote.path
@@ -2,11 +2,13 @@
 <head>
 <title>QuickNote</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">QuickNote</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NOTE_CONTENT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/recyclebin/RecycleBin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/recyclebin/RecycleBin.path
@@ -2,11 +2,13 @@
 <head>
 <title>RecycleBin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RecycleBin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SUCCESS_MESSAGE_CONTENT_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/relatedassets/Relatedassets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/relatedassets/Relatedassets.path
@@ -2,11 +2,13 @@
 <head>
 <title>Relatedassets</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Relatedassets</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_EDIT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -2,11 +2,13 @@
 <head>
 <title>RemoteApps</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RemoteApps</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TABLE_ENTRY_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteAppsEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>RemoteAppsEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RemoteAppsEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/Roles.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/Roles.path
@@ -2,11 +2,13 @@
 <head>
 <title>Roles</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Roles</td></tr>
 </thead>
+
 <tbody>
 <!--ROLE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesAssignMembers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesAssignMembers.path
@@ -2,11 +2,13 @@
 <head>
 <title>RolesAssignMembers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RolesAssignMembers</td></tr>
 </thead>
+
 <tbody>
 <!--ADD_ASSIGNEE_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissions.path
@@ -2,11 +2,13 @@
 <head>
 <title>RolesPermissions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RolesPermissions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PERMISSION_HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsNavigation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsNavigation.path
@@ -2,11 +2,13 @@
 <head>
 <title>RolesPermissionsNavigation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RolesPermissionsNavigation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PERMISSIONS_NAVITEM</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSelectSite.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSelectSite.path
@@ -2,11 +2,13 @@
 <head>
 <title>RolesPermissionsSelectSite</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RolesPermissionsSelectSite</td></tr>
 </thead>
+
 <tbody>
 <!--SELECT_SITE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSummary.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSummary.path
@@ -2,11 +2,13 @@
 <head>
 <title>RolesPermissionsSummary</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RolesPermissionsSummary</td></tr>
 </thead>
+
 <tbody>
 <!--PERMISSION_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/rss/RSS.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/rss/RSS.path
@@ -2,11 +2,13 @@
 <head>
 <title>RSS</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RSS</td></tr>
 </thead>
+
 <tbody>
 <!--FEED-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/rss/RSSFeed.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/rss/RSSFeed.path
@@ -2,11 +2,13 @@
 <head>
 <title>RSSFeed</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">RSSFeed</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>UNDO_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>CPSAMLAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CPSAMLAdmin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CREATE_CERTIFICATE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminIdentityProvider.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminIdentityProvider.path
@@ -2,11 +2,13 @@
 <head>
 <title>CPSAMLAdminIdentityProvider</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CPSAMLAdminIdentityProvider</td></tr>
 </thead>
+
 <tbody>
 <!--IDENTITY_PROVIDER-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminIdentityProviderConnection.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminIdentityProviderConnection.path
@@ -2,11 +2,13 @@
 <head>
 <title>CPSAMLAdminIdentityProviderConnection</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CPSAMLAdminIdentityProviderConnection</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_IDENTITY_PROVIDER_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminServiceProvider.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminServiceProvider.path
@@ -2,11 +2,13 @@
 <head>
 <title>CPSAMLAdminServiceProvider</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CPSAMLAdminServiceProvider</td></tr>
 </thead>
+
 <tbody>
 <!--SERVICE_PROVIDER-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminServiceProviderConnections.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/saml/CPSAMLAdminServiceProviderConnections.path
@@ -2,11 +2,13 @@
 <head>
 <title>CPSAMLAdminServiceProviderConnections</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">CPSAMLAdminServiceProviderConnections</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_SERVICE_PROVIDER_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/samplelar/Samplelarportlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/samplelar/Samplelarportlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>Samplelarportlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Samplelarportlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_SAMPLE_BOOKING_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/ElasticsearchMonitoring.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/ElasticsearchMonitoring.path
@@ -2,11 +2,13 @@
 <head>
 <title>ElasticsearchMonitoring</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ElasticsearchMonitoring</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CLUSTER_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
@@ -2,11 +2,13 @@
 <head>
 <title>Search</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Search</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_PORTLET_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchAdmin.path
@@ -2,11 +2,13 @@
 <head>
 <title>SearchAdmin</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SearchAdmin</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVE_CONNECTION_COUNT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>SearchConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SearchConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BASIC_DISPLAY_USER_FACET_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchResults.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchResults.path
@@ -2,11 +2,13 @@
 <head>
 <title>SearchResults</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SearchResults</td></tr>
 </thead>
+
 <tbody>
 <!--ASSET_DETAILS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchTuning.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/SearchTuning.path
@@ -2,11 +2,13 @@
 <head>
 <title>SearchTuning</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SearchTuning</td></tr>
 </thead>
+
 <tbody>
 <!--RESULT_RANKINGS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Experience.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Experience.path
@@ -2,11 +2,13 @@
 <head>
 <title>Experience</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Experience</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BANNER_CENTER_TITLE_EXAMPLE_PORTLET</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Segmentation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Segmentation.path
@@ -2,11 +2,13 @@
 <head>
 <title>Segmentation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Segmentation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_FIELD_POSITION</td>
@@ -107,4 +109,3 @@
 </table>
 </body>
 </html>
-

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationExternalServices.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationExternalServices.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationExternalServices</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationExternalServices</td></tr>
 </thead>
+
 <tbody>
 <!--OPEN_OFFICE_INTEGRATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationFileUploads.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationFileUploads.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationFileUploads</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationFileUploads</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>GENERAL_OVERALL_MAX_FILE_SIZE_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationLogLevels.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationLogLevels.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationLogLevels</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationLogLevels</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_CATEGORY_NAME_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationMail.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationMail.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationMail</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationMail</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>INCOMING_POP_SERVER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationProperties.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationProperties.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationProperties</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationProperties</td></tr>
 </thead>
+
 <tbody>
 <!--ACTIONS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationResources.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationResources.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationResources</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationResources</td></tr>
 </thead>
+
 <tbody>
 <!--ACTIONS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationScript.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serveradministration/ServerAdministrationScript.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServerAdministrationScript</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServerAdministrationScript</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>LANGUAGE_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serviceaccesspolicy/ServiceAccessPolicy.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/serviceaccesspolicy/ServiceAccessPolicy.path
@@ -2,11 +2,13 @@
 <head>
 <title>ServiceAccessPolicy</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">ServiceAccessPolicy</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALLOWED_SERVICE_SIGNATURES_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sharing/Sharing.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sharing/Sharing.path
@@ -2,11 +2,13 @@
 <head>
 <title>Sharing</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Sharing</td></tr>
 </thead>
+
 <tbody>
 	<!--BLOGS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignIn.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignIn.path
@@ -2,11 +2,13 @@
 <head>
 <title>SignIn</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SignIn</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PORTLET_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignInCreateAccount.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignInCreateAccount.path
@@ -2,11 +2,13 @@
 <head>
 <title>SignInCreateAccount</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SignInCreateAccount</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EMAIL_VERIFICATION_CODE_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignInOpenID.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/signin/SignInOpenID.path
@@ -2,11 +2,13 @@
 <head>
 <title>SignInOpenID</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SignInOpenID</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>OPENID_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitemap/SiteMap.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitemap/SiteMap.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteMap</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteMap</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_MAP_PAGE_DISPLAY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePages.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePages.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitePages</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitePages</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesEditPage.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesEditPage.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitePagesEditPage</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitePagesEditPage</td></tr>
 </thead>
+
 <tbody>
 <!--DETAILS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesExport.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesExport.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitePagesExport</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitePagesExport</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>EXPORT_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesImport.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePagesImport.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitePagesImport</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitePagesImport</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>IMPORT_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMemberships.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMemberships.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteMemberships</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteMemberships</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MEMBERSHIP_TYPE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsAddMembers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsAddMembers.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteMembershipsAddMembers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteMembershipsAddMembers</td></tr>
 </thead>
+
 <tbody>
 <!--USER_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsUserGroups.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsUserGroups.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteMembershipsUserGroups</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteMembershipsUserGroups</td></tr>
 </thead>
+
 <tbody>
 <!--USER_GROUP_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsViewMembershipRequests.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMembershipsViewMembershipRequests.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteMembershipsViewMembershipRequests</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteMembershipsViewMembershipRequests</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>STATUS</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsDefaultUserAssociations.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsDefaultUserAssociations.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteSettingsDefaultUserAssociations</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteSettingsDefaultUserAssociations</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TEAMS_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsDisplaySettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsDisplaySettings.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteSettingsDisplaySettings</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteSettingsDisplaySettings</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>LANGUAGES_RADIO</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsSiteTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsSiteTemplate.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteSettingsSiteTemplate</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteSettingsSiteTemplate</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_NOT_CLONED_FROM_TEMPLATE_MESSAGE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsSiteURL.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsSiteURL.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteSettingsSiteURL</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteSettingsSiteURL</td></tr>
 </thead>
+
 <tbody>
 <!--SITE_URL-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsStaging.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteSettingsStaging.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteSettingsStaging</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteSettingsStaging</td></tr>
 </thead>
+
 <tbody>
 <!--STAGING-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteTeams.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteTeams.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteTeams</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteTeams</td></tr>
 </thead>
+
 <tbody>
 <!--TEAM_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteTeamsAssignMembers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteTeamsAssignMembers.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteTeamsAssignMembers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteTeamsAssignMembers</td></tr>
 </thead>
+
 <tbody>
 <!--USER_GROUPS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/Sites.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/Sites.path
@@ -2,11 +2,13 @@
 <head>
 <title>Sites</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Sites</td></tr>
 </thead>
+
 <tbody>
 <!--SELECT_SITE_MODAL-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SitesEditSite.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SitesEditSite.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitesEditSite</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitesEditSite</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>MEMBERSHIP_TYPE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SitesSelectSite.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SitesSelectSite.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitesSelectSite</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitesSelectSite</td></tr>
 </thead>
+
 <tbody>
 <!--SELECT_SITE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitesdirectory/SitesDirectory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitesdirectory/SitesDirectory.path
@@ -2,11 +2,13 @@
 <head>
 <title>SitesDirectory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SitesDirectory</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_ENTRY</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitetemplates/SiteTemplates.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitetemplates/SiteTemplates.path
@@ -2,11 +2,13 @@
 <head>
 <title>SiteTemplates</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SiteTemplates</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_TEMPLATE_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/Activities.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/Activities.path
@@ -2,11 +2,13 @@
 <head>
 <title>Activities</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Activities</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ACTIVITY_TITLE_ASSET_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/GroupStatistics.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/GroupStatistics.path
@@ -2,11 +2,13 @@
 <head>
 <title>GroupStatistics</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GroupStatistics</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SITE_STATISTICS_PANEL</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/GroupStatisticsConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/GroupStatisticsConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>GroupStatisticsConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GroupStatisticsConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONFIGURATION_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/Polls.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/Polls.path
@@ -2,11 +2,13 @@
 <head>
 <title>Polls</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Polls</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CHOICE_FIELD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/PortalDirectory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/PortalDirectory.path
@@ -2,11 +2,13 @@
 <head>
 <title>PortalDirectory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">PortalDirectory</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>USER_TABLE_FIRST_NAME_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/SocialActivity.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/SocialActivity.path
@@ -2,11 +2,13 @@
 <head>
 <title>SocialActivity</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">SocialActivity</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>POSSIBLE_USER_ACTIONS_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/UserStatistics.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/UserStatistics.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserStatistics</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserStatistics</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>RANKING_TABLE_USER_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/UserStatisticsConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/socialnetworking/UserStatisticsConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserStatisticsConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserStatisticsConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>CONFIGURATION_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
@@ -2,11 +2,13 @@
 <head>
 <title>Staging</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Staging</td></tr>
 </thead>
+
 <tbody>
 <!--DELETIONS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingManageVariations.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingManageVariations.path
@@ -2,11 +2,13 @@
 <head>
 <title>StagingManageVariations</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">StagingManageVariations</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
@@ -2,11 +2,13 @@
 <head>
 <title>StagingPublishToLive</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">StagingPublishToLive</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SWITCH_TO_ADVANCED_PUBLICATION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/stylebookeditor/StyleBookEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/stylebookeditor/StyleBookEditor.path
@@ -2,11 +2,13 @@
 <head>
 <title>StyleBookEditor</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">StyleBookEditor</td></tr>
 </thead>
+
 <tbody>
 <!--PAGE_PREVIEW-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/Tags.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/Tags.path
@@ -2,11 +2,13 @@
 <head>
 <title>Tags</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Tags</td></tr>
 </thead>
+
 <tbody>
 <!--TAG_ENTRY_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/TagsNavigation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/TagsNavigation.path
@@ -2,11 +2,13 @@
 <head>
 <title>TagsNavigation</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TagsNavigation</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TAG_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/TagsNavigationConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/tags/TagsNavigationConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>TagsNavigationConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">TagsNavigationConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TAG_CLOUD_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/themes/Theme.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/themes/Theme.path
@@ -2,11 +2,13 @@
 <head>
 <title>Theme</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Theme</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TEST_THEME_HOME_PAGE_PNG</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserBar</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserBar</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>USER_AVATAR_DROPDOWN_ITEM</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroups.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroups.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserGroups</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserGroups</td></tr>
 </thead>
+
 <tbody>
 <!--USER_GROUP_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroupsAssignUsers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroupsAssignUsers.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserGroupsAssignUsers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserGroupsAssignUsers</td></tr>
 </thead>
+
 <tbody>
 <!--USER_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroupsEditUserGroup.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usergroups/UserGroupsEditUserGroup.path
@@ -2,11 +2,13 @@
 <head>
 <title>UserGroupsEditUserGroup</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UserGroupsEditUserGroup</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PUBLIC_PAGES_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizations.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizations.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizations</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizations</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsAssignOrganizationalRoles.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsAssignOrganizationalRoles.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsAssignOrganizationalRoles</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsAssignOrganizationalRoles</td></tr>
 </thead>
+
 <tbody>
 <!--USER_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsAssignUsers.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsAssignUsers.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsAssignUsers</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsAssignUsers</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>BACK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditOrganization.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditOrganization.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsEditOrganization</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsEditOrganization</td></tr>
 </thead>
+
 <tbody>
 <!--DETAILS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsEditUser</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsEditUser</td></tr>
 </thead>
+
 <tbody>
 <!--DETAILS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsOrganization.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsOrganization.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsOrganization</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsOrganization</td></tr>
 </thead>
+
 <tbody>
 <!--MENU-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsSelectOrganization.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsSelectOrganization.path
@@ -2,11 +2,13 @@
 <head>
 <title>UsersAndOrganizationsSelectOrganization</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">UsersAndOrganizationsSelectOrganization</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>SELECT_ORGANIZATION_IFRAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WC.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WC.path
@@ -2,11 +2,13 @@
 <head>
 <title>WC</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WC</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_TO_FAVORITES</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCConfiguration</td></tr>
 </thead>
+
 <tbody>
 <!--NAVIGATION-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditFolder.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditFolder.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCEditFolder</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCEditFolder</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>WORKFLOW_FOLDER_WORKFLOW</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCEditWebContent</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCEditWebContent</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ANY_TEXT_INPUT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCPreview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCPreview.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCPreview</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCPreview</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PREVIEW_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCViewHistory.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCViewHistory.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCViewHistory</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCViewHistory</td></tr>
 </thead>
+
 <tbody>
 <!--VERSIONS_TABLE-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentdisplay/WCD.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentdisplay/WCD.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCD</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCD</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ARTICLE_ELLIPSIS_ICON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentdisplay/WCDConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentdisplay/WCDConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>WCDConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WCDConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ENABLE_VIEW_COUNT_INCREMENT_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentsearch/WebContentSearchResults.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontentsearch/WebContentSearchResults.path
@@ -2,11 +2,13 @@
 <head>
 <title>WebContentSearchResults</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WebContentSearchResults</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webproxy/WebProxy.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webproxy/WebProxy.path
@@ -2,11 +2,13 @@
 <head>
 <title>WebProxy</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WebProxy</td></tr>
 </thead>
+
 <tbody>
 <!--SCREENSHOTS-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/Wiki.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/Wiki.path
@@ -2,11 +2,13 @@
 <head>
 <title>Wiki</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Wiki</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ADD_PAGE_FORMAT_DROPDOWN</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiConfiguration.path
@@ -2,11 +2,13 @@
 <head>
 <title>WikiConfiguration</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WikiConfiguration</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ALLOW_USERS_TO_ADD_WIKI_TO_ANY_WEBSITE_CHECKBOX</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiEntry.path
@@ -2,11 +2,13 @@
 <head>
 <title>WikiEntry</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WikiEntry</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ATTACHMENTS_LABEL</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiTable.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiTable.path
@@ -2,11 +2,13 @@
 <head>
 <title>WikiTable</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">WikiTable</td></tr>
 </thead>
+
 <tbody>
 <!--ALL_PAGES-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/xsl/XSLContentPortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/xsl/XSLContentPortlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>XSLContentPortlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">XSLContentPortlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Gmail.path
@@ -2,11 +2,13 @@
 <head>
 <title>Gmail</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Gmail</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PAGE_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Google.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Google.path
@@ -2,11 +2,13 @@
 <head>
 <title>Google</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Google</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>PAGE_TITLE</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/GoogleDrive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/GoogleDrive.path
@@ -2,11 +2,13 @@
 <head>
 <title>GoogleDrive</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">GoogleDrive</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>HEADER</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
@@ -2,11 +2,13 @@
 <head>
 <title>Home</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Home</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>API_AXIS_URL</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/JavaDocs.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/JavaDocs.path
@@ -2,11 +2,13 @@
 <head>
 <title>JavaDocs</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">JavaDocs</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>JAVA_CLASS_NAME</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/MobileDevice.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/MobileDevice.path
@@ -2,11 +2,13 @@
 <head>
 <title>MobileDevice</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">MobileDevice</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DEVICE_FAMILY_TABLE_NAME_LINK</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/OS.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/OS.path
@@ -2,11 +2,13 @@
 <head>
 <title>OS</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">OS</td></tr>
 </thead>
+
 <tbody>
 <!--FILE_DIALOG_BOX-->
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Permissions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Permissions.path
@@ -2,11 +2,13 @@
 <head>
 <title>Permissions</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Permissions</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>ASSET_TITLE</td>


### PR DESCRIPTION
Hey Hugo,
Issue: https://github.com/brianchandotcom/liferay-portal/commit/17b869417e8d9b370614af7e244cc99c763913e6
I can easily add `*.path` in `HTMLSourceProcessor`, but there will be a lot of violations.

And there will be anoher issue, it can be resolved by `JSPIndentationCheck`.
Line 541 in portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path:
https://github.com/hhuijser/liferay-portal/pull/5249/files#diff-8a417128a5d32a02562634f5dd75398f4ba190b4b06e46328bbc53b232d921bcR541

`JSPIndentationCheck` will fix indentationa in a bunch of `*.path`, because 99% *.path have bad indentations.

no indentation before tr:
```
<table>
<tr>
```
