### PR TITLE
LPS-105380_JavaTestMethodAnnotationsCheck_20210302_master

### DIFF
--- a/modules/apps/journal/source-formatter-suppressions.xml
+++ b/modules/apps/journal/source-formatter-suppressions.xml
@@ -4,7 +4,4 @@
 	<checkstyle>
 		<suppress checks="StaticVariableNameCheck" files="journal-api/src/main/java/com/liferay/journal/configuration/JournalServiceConfigurationValues\.java" />
 	</checkstyle>
-	<source-check>
-		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeJournalArticleLocalizedValues\.java" />
-	</source-check>
 </suppressions>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaTestMethodAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaTestMethodAnnotationsCheck.java
@@ -73,6 +73,17 @@ public class JavaTestMethodAnnotationsCheck extends BaseJavaTermCheck {
 
 		String methodName = javaTerm.getName();
 
+		if (fileName.endsWith("ResourceTest.java") &&
+			!javaTerm.hasAnnotation("Override") &&
+			methodName.startsWith("test")) {
+
+			addMessage(
+				fileName,
+				"Public test method in '*ResourceTest.java' should contain " +
+					"annotation @Override",
+				javaTerm.getLineNumber());
+		}
+
 		Pattern pattern = Pattern.compile(requiredMethodNameRegex);
 
 		Matcher matcher = pattern.matcher(methodName);


### PR DESCRIPTION
Hey Hugo,

_Issue:_
https://github.com/brianchandotcom/liferay-portal/pull/99325#issuecomment-787561586

We have a few violations on master(see ci:test:sf failures), and now I don't understand why we have to enforce this rule for test classes. Do you know any details on test classes?