### PR TITLE
LPS-105380 PoshiEmptyLinesCheck

### DIFF
--- a/modules/apps/commerce/commerce-media-test/src/testIntegration/java/com/liferay/commerce/media/test/CommerceMediaResolverTest.java
+++ b/modules/apps/commerce/commerce-media-test/src/testIntegration/java/com/liferay/commerce/media/test/CommerceMediaResolverTest.java
@@ -202,6 +202,9 @@ public class CommerceMediaResolverTest {
 	@Rule
 	public FrutillaRule frutillaRule = new FrutillaRule();
 
+	private static Company _company;
+	private static User _user;
+
 	@DeleteAfterTestRun
 	private CommerceAccount _commerceAccount;
 
@@ -213,15 +216,11 @@ public class CommerceMediaResolverTest {
 	@Inject
 	private CommerceMediaResolver _commerceMediaResolver;
 
-	private static Company _company;
-
 	@Inject
 	private CPAttachmentFileEntryLocalService
 		_cpAttachmentFileEntryLocalService;
 
 	private Group _group;
 	private ServiceContext _serviceContext;
-
-	private static User _user;
 
 }

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/util/CPMediaImpl.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/util/CPMediaImpl.java
@@ -35,11 +35,11 @@ public class CPMediaImpl implements CPMedia {
 			fileEntry, fileEntry.getFileVersion(), themeDisplay,
 			StringPool.BLANK);
 
-		_downloadUrl = defaultUrl;
+		_downloadURL = defaultUrl;
 
 		_id = fileEntry.getFileEntryId();
 		_url = defaultUrl;
-		_thumbnailUrl = defaultUrl;
+		_thumbnailURL = defaultUrl;
 		_mimeType = fileEntry.getMimeType();
 		_title = fileEntry.getTitle();
 	}
@@ -47,11 +47,11 @@ public class CPMediaImpl implements CPMedia {
 	public CPMediaImpl(long groupId) throws PortalException {
 		String defaultUrl = CommerceMediaResolverUtil.getDefaultUrl(groupId);
 
-		_downloadUrl = defaultUrl;
+		_downloadURL = defaultUrl;
 
 		_id = 0;
 		_mimeType = null;
-		_thumbnailUrl = defaultUrl;
+		_thumbnailURL = defaultUrl;
 		_title = null;
 		_url = defaultUrl;
 	}
@@ -61,7 +61,7 @@ public class CPMediaImpl implements CPMedia {
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		_downloadUrl = CommerceMediaResolverUtil.getDownloadURL(
+		_downloadURL = CommerceMediaResolverUtil.getDownloadURL(
 			commerceAccountId,
 			cpAttachmentFileEntry.getCPAttachmentFileEntryId());
 		_id = cpAttachmentFileEntry.getCPAttachmentFileEntryId();
@@ -75,7 +75,7 @@ public class CPMediaImpl implements CPMedia {
 			_mimeType = fileEntry.getMimeType();
 		}
 
-		_thumbnailUrl = CommerceMediaResolverUtil.getThumbnailURL(
+		_thumbnailURL = CommerceMediaResolverUtil.getThumbnailURL(
 			commerceAccountId,
 			cpAttachmentFileEntry.getCPAttachmentFileEntryId());
 		_title = cpAttachmentFileEntry.getTitle(themeDisplay.getLanguageId());
@@ -86,7 +86,7 @@ public class CPMediaImpl implements CPMedia {
 
 	@Override
 	public String getDownloadUrl() {
-		return _downloadUrl;
+		return _downloadURL;
 	}
 
 	@Override
@@ -96,7 +96,7 @@ public class CPMediaImpl implements CPMedia {
 
 	@Override
 	public String getThumbnailUrl() {
-		return _thumbnailUrl;
+		return _thumbnailURL;
 	}
 
 	@Override
@@ -114,10 +114,10 @@ public class CPMediaImpl implements CPMedia {
 		return _mimeType;
 	}
 
-	private final String _downloadUrl;
+	private final String _downloadURL;
 	private final long _id;
 	private final String _mimeType;
-	private final String _thumbnailUrl;
+	private final String _thumbnailURL;
 	private final String _title;
 	private final String _url;
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceChannels.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceChannels.testcase
@@ -420,6 +420,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6123 AddTaxRateSettingsFixedTaxRateTaxCalculation
+
 	}
 
 	@description = "This is a test for COMMERCE-6195. CreateCategoryDisplayPage"
@@ -429,6 +430,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6195 CreateCategoryDisplayPage
+
 	}
 
 	test CreateNewChannel {
@@ -622,6 +624,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6197 CreateProductDisplayPage
+
 	}
 
 	@description = "This is a test for COMMERCE-6109. EditAuthorizePaymentMethod"
@@ -689,6 +692,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6119 EditAvalaraTaxCalculation
+
 	}
 
 	@description = "This is a test for COMMERCE-6275. EditCategoryDisplayPage"
@@ -815,6 +819,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6122 EditConfigurationRemoteTaxCalculation
+
 	}
 
 	@description = "This is a test for COMMERCE-6107. EditMercanetPaymentMethod"
@@ -916,6 +921,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6276 EditNotificationTemplate
+
 	}
 
 	@description = "This is a test for COMMERCE-6106. EditPaypalPaymentMethod"
@@ -975,6 +981,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6274 EditProductDisplayPage
+
 	}
 
 	@description = "This is a test for COMMERCE-6198. RemoveCategoryDisplayPage"
@@ -984,6 +991,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6198 RemoveCategoryDisplayPage
+
 	}
 
 	@description = "This is a test for COMMERCE-6270. RemoveNotificationQueue"
@@ -993,6 +1001,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6270 RemoveNotificationQueue
+
 	}
 
 	@description = "This is a test for COMMERCE-6271. RemoveNotificationTemplate"
@@ -1002,6 +1011,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6271 RemoveNotificationTemplate
+
 	}
 
 	@description = "This is a test for COMMERCE-6196. RemoveProductDisplayPage"
@@ -1315,6 +1325,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6121 RemoveTaxRateSettingsByAddressTaxCalculation
+
 	}
 
 	@description = "This is a test for COMMERCE-6124. RemoveTaxRateSettingsFixedTaxRateTaxCalculation"
@@ -1393,6 +1404,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6267 UsePunchOut
+
 	}
 
 	@description = "This is a test for COMMERCE-6101. UseSearchBar"
@@ -1445,6 +1457,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6266 VerifyNotificationQueue
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceCurrencies.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceCurrencies.testcase
@@ -44,6 +44,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5843 DeactivateCurrency Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-5842. As a system administrator I want currencies to be sorted by priority"
@@ -53,6 +54,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5842 SortCurrenciesByPriority Pending Implementation
+
 	}
 
 	test ViewInstanceCurrenciesAvailable {

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceDiscounts.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceDiscounts.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6232 AddEditAndRemoveDiscountRule Pending Implementation
+
 	}
 
 	test AssertDiscountIsAppliedToChannel {
@@ -174,6 +175,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6230 LimitCouponCodeUsability Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6229. Discount coupon code validators"
@@ -183,6 +185,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6229 ViewCouponCodeNotAppliedToNotQualifiedAccount Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6233. Discount expiration"
@@ -192,6 +195,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6233 ViewExpiredDiscountEntry Pending Implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceOrders.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceOrders.testcase
@@ -46,6 +46,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6210 CancelShipmentAndCreateNewFromPendingOrder Pending Implementation
+
 	}
 
 	test EditOrder {
@@ -216,6 +217,7 @@ definition {
 
 		// TODO COMMERCE-5980 EditOrderPaymentMethod Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5980. As an order manager, I want to edit the payment method and payment status of a submitted order"
@@ -226,6 +228,7 @@ definition {
 
 		// TODO COMMERCE-5980 EditOrderPaymentStatus Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5997. As an order manager, I want to filter orders by Channel, Account, Order Data Range and Order Status"
@@ -236,6 +239,7 @@ definition {
 
 		// TODO COMMERCE-5997 FilterOrderByAccount Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5997. As an order manager, I want to filter orders by Channel, Account, Order Data Range and Order Status"
@@ -246,6 +250,7 @@ definition {
 
 		// TODO COMMERCE-5997 FilterOrderByChannel Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5997. As an order manager, I want to filter orders by Channel, Account, Order Data Range and Order Status"
@@ -256,6 +261,7 @@ definition {
 
 		// TODO COMMERCE-5997 FilterOrderByOrderDataRange Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5997. As an order manager, I want to filter orders by Channel, Account, Order Data Range and Order Status"
@@ -266,6 +272,7 @@ definition {
 
 		// TODO COMMERCE-5997 FilterOrderByStatus Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-6209. Admin order fulfillment"
@@ -275,6 +282,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6209 FulfillOrder Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6213. Buyer Order Approval Workflow"
@@ -284,6 +292,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6213 FulfillOrderWithBuyerOrderApprovalWorkflowActive Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6214. Seller Order Acceptance Workflow"
@@ -293,6 +302,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6214 FulfillOrderWithSellerOrderAcceptanceWorkflowActive Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6211. Stock management from order"
@@ -302,6 +312,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6211 ManageBackOrdersFromOrder Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6211. Stock management from order"
@@ -311,6 +322,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6211 ManageProductAvailabilityFromOrder Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6217. Order Permission Management"
@@ -320,6 +332,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6217 OrderPermissionManagement Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6216. Search Order from UI"
@@ -329,6 +342,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6216 SearchOrder Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-5982. As an order manager, I want to sort orders by ascending or descending order date"
@@ -339,6 +353,7 @@ definition {
 
 		// TODO COMMERCE-5982 SortOrdersByOrderDate Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 	@description = "This is a test for COMMERCE-5845. As a product specialist I want to see if a SKU is on order"
@@ -349,6 +364,7 @@ definition {
 
 		// TODO COMMERCE-5845 ViewOrderSKU Pending Implementation
 		// NOTE: 1. Delete action is already handled by commerceAdminTearDown
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommercePriceLists.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommercePriceLists.testcase
@@ -521,6 +521,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6227 AddEditAndDeleteTierPriceEntry Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6234. Price List Qualifier Lifecycle"
@@ -670,6 +671,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6235 AddEditAndRemoveProductGroupFromPL Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6069. Price List Qualifier"
@@ -1308,6 +1310,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6220 CheckOnlyPermittedCatalogIsSelectable Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6236. Check info about where a product group is used"
@@ -1317,6 +1320,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6236 CheckPLProductGroupUsageInfo Pending Implementation
+
 	}
 
 	test CreateNewPriceList {
@@ -1450,6 +1454,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6221 ViewExpiredPL Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6222. Price Entry expiration management"
@@ -1459,6 +1464,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6222 ViewExpiredPriceEntry Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6224. Price Modifier expiration management"
@@ -1468,6 +1474,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6224 ViewExpiredPriceModifier Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6223. Tier Price Entry expiration management"
@@ -1477,6 +1484,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6223 ViewExpiredTierPriceEntry Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6228. Check that an expired entity is not considered in the price calculation"
@@ -1486,6 +1494,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6228 ViewPriceNotAffectedByExpiredPriceEntities Pending Implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProductVisibility.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProductVisibility.testcase
@@ -47,6 +47,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6086 AddAChannelFilter
+
 	}
 
 	@description = "This is a test for COMMERCE-6089. RemoveAccountGroupFilter"
@@ -119,6 +120,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6087 RemoveAChannelFilter
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProducts.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceProducts.testcase
@@ -85,6 +85,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6287 AddASpecificationAndVerifyIfIsPresent
+
 	}
 
 	@description = "This is a test for COMMERCE-6302. AddGroupedProduct"
@@ -94,6 +95,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6302 AddGroupedProduct
+
 	}
 
 	@description = "This is a test for COMMERCE-6301. AddVirtualProduct"
@@ -103,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6301 AddVirtualProduct
+
 	}
 
 	@description = "This is a test for COMMERCE-6020. AssertProductBundleCanBeCreatedWithPriceTypeStaticAndDynamic"
@@ -578,6 +581,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6022 EditASKU
+
 	}
 
 	@description = "This is a test for COMMERCE-5807. EditSkuAndDelete"
@@ -742,6 +746,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6304 UseFriendlyURL
+
 	}
 
 	@description = "This is a test for COMMERCE-6303. UseSchedule"
@@ -792,6 +797,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5805 UseSearchBarAndPagination
+
 	}
 
 	@description = "This is a test for COMMERCE-5806. UseSkuSearchBarAndPagination"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceShipments.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceShipments.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6248 AssertAddingNonShippableItemToShipmentNotPossible Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6252. Check that shipment information set at product level are overriden by the shipment info at cpInstance level"
@@ -52,6 +53,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6252 AssertProductShipmentInfoOverrideCPInstanceShipmentInfo Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6253. Shipment dimensions should be correctly calculated"
@@ -61,6 +63,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6253 AssertShipmentDimensionsCorrectlyCalculated Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6249. Shipment items should be taken only from active warehouses"
@@ -70,6 +73,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6249 AssertShipmentItemTakenFromActiveWarehouses Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6254. Shipment weight should be correctly calculated"
@@ -79,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6254 AssertShipmentWeightIsCorrectlyCalculated Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6251. Delete shipment"
@@ -88,6 +93,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6251 AssertStateShippedShipmentNotDeletable Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6247. Multiple shipment for the same order"
@@ -208,6 +214,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6237 CreateOrderShipment Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6250. Delete shipment"
@@ -217,6 +224,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6250 DeleteShipment Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6241. Execute the shipment workflow"
@@ -226,6 +234,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6241 ExecuteShipmentWorkflow Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6255. Filter, Sort shipment from shipment UI"
@@ -235,6 +244,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6255 FilterAndSortShipments Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6240. Remove shipment items from a shipment"
@@ -244,6 +254,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6240 RemoveItemFromShipment Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6256. Search shipment from shipment UI"
@@ -253,6 +264,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6256 SearchShipment Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6242. Update address"
@@ -262,6 +274,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6242 UpdateShipmentAddress Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6239. Update shipment items to a shipment"
@@ -271,6 +284,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6239 UpdateShipmentItems Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6243. Update address"
@@ -280,6 +294,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6243 ValidateShipmentAddress Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6245. Check that shipping amount is correctly calculated in the order"
@@ -289,6 +304,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6245 ViewOrderShipmentAmountIsCorrect Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6246. Check that shipping discount amount is correctly calculated in the order"
@@ -298,6 +314,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6246 ViewOrderShipmentDiscountAmountIsCorrect Pending Implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceSubscriptions.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceSubscriptions.testcase
@@ -44,6 +44,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6257 SubscriptionLifecycle Pending Implementation
+
 	}
 
 	@description = "COMMERCE-5844. As a system admin I want to check subscription notifications are properly created"
@@ -53,6 +54,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5841 SubscriptionNotifications Pending Implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceWarehouses.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CPCommerceWarehouses.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6206 AddIncomeItems Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6200. Consume booked quantities of one item in multiple warehouses"
@@ -52,6 +53,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6200 ConsumeBookedQuantitiesFromMultipleWarehouses Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6201. Consume quantities of one item in multiple warehouses"
@@ -61,6 +63,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6201 ConsumeQuantitiesFromMultipleWarehouses Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-5706. As a system admin i want to be able to create / update and delete a new warehouse"
@@ -270,6 +273,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5707 DeactivateWarehouse Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6199. Get available quantities of one item in multiple warehouses"
@@ -279,6 +283,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6199 GetAvailableQuantityFromMultipleWarehouses Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6204. Get stock quantity of a SKU for specific channel"
@@ -288,6 +293,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6204 GetChannelSKUStockQuantity Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6203. Get stock quantity of a SKU"
@@ -471,6 +477,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6208 ManageInventoryEntityConcurrency Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-5708. As a product specialist i want to update the quantity of a product inside a warehouse"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountManagement.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountManagement.testcase
@@ -96,6 +96,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6347 AssertOrganizationThatIsPartOfTheAccountCannotBeAddedAgain pending implementation
+
 	}
 
 	@description = "COMMERCE-6357. In Members tab, I want to be unable to add a user that is already a member of the account"
@@ -105,6 +106,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6357 AssertUserThatIsPartOfTheAccountCannotBeAddedAgain pending implementation
+
 	}
 
 	@description = "COMMERCE-6378. In Account Details page, I want to be able to edit account by clicking 'Edit Account'(Account Image, Account Name, VAT Number, Email, Default Billing/Shipping address) and I want to be able to see changes I made in Account details page"
@@ -114,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6378 EditAccountDetails pending implementation
+
 	}
 
 	@description = "COMMERCE-6372. In Addresses tab, I want to be able to edit an address added to the account"
@@ -123,6 +126,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6372 EditAddressInAccount pending implementation
+
 	}
 
 	@description = "COMMERCE-6373. In Addresses tab, I want to be able to remove addresses from the account"
@@ -132,6 +136,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6373 RemoveAddressFromAccount pending implementation
+
 	}
 
 	@description = "COMMERCE-6351. In Info tab, I want to be able to remove an organization from the account by clicking 'Delete'"
@@ -141,6 +146,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6351 RemoveOrganizationFromAccount pending implementation
+
 	}
 
 	@description = "COMMERCE-6361. In Members tab, I want to be able to remove users from the account"
@@ -150,6 +156,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6361 RemoveUserFromAccount pending implementation
+
 	}
 
 	@description = "COMMERCE-6376. In Addresses tab, I want to be able to search for an address using the search bar"
@@ -159,6 +166,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6376 SearchAnAccountAddress pending implementation
+
 	}
 
 	@description = "COMMERCE-6365. In Members tab, I want to be able to search for an account member using the search bar"
@@ -168,6 +176,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6365 SearchAnAccountMember pending implementation
+
 	}
 
 	@description = "COMMERCE-6352. In Info tab, I want to be able to search for an organization in the account using the search bar"
@@ -177,6 +186,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6352 SearchAnAccountOrganization pending implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountSelector.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceAccountSelector.testcase
@@ -71,6 +71,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5925 AssertActiveAccountIsVisibleOnAccountSelectorBar pending implementation
+
 	}
 
 	@description = "COMMERCE-5924. As a buyer, I want the account I have currently selected to be highlighted in the account selector dropdown"
@@ -104,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5927 ChangeActiveAccountFromAccountsList pending implementation
+
 	}
 
 	@description = "COMMERCE-5929. As a buyer, I want to be able to select an order from the list (which is not the selected one), and have the selected order change to the newly selected order"
@@ -113,6 +115,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5929 ChangeActiveOrderFromOrdersList pending implementation
+
 	}
 
 	@description = "COMMERCE-5936. As a buyer, I want to be able to create a new order from the account selector dropdown's order list view, The created order should then be the selected order"
@@ -122,6 +125,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5936 CreateNewOrderFromAccountSelectorDropdown pending implementation
+
 	}
 
 	@description = "COMMERCE-5956. As a buyer, I want to search for an account in the accounts list, and select it as active account"
@@ -275,6 +279,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5928 ViewAccountSelectorDropdownOrdersList pending implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceCompare.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceCompare.testcase
@@ -87,6 +87,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5916 EditMaxNumberOfComparisonItemsInMiniCompare pending implementation
+
 	}
 
 	@description = "COMMERCE-5918. As a buyer, I want to deselect a item in Product Compare page"
@@ -96,6 +97,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5918 RemoveComparisonItemFromComparePage pending implementation
+
 	}
 
 	@description = "COMMERCE-5913. As a buyer, I want to deselect items in Catalog for compare in MiniCompare widget"
@@ -183,6 +185,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6662 UseADTInCommerceComparisonBarWidget pending implementation
+
 	}
 
 	@description = "COMMERCE-6661. I want to be able to use ADT to render Commerce Comparison Table widget and I want to be able to select a Display Template and see it applied to the widget"
@@ -192,6 +195,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6661 UseADTInCommerceComparisonTableWidget pending implementation
+
 	}
 
 	@description = "COMMERCE-5919. As a buyer, when comparing items in Compare page, I want to view product options and specifications, if set"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceFacets.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceFacets.testcase
@@ -70,6 +70,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6170 AssertProductsAreFilteredByPriceRangeFacet pending implementation
+
 	}
 
 	@description = "COMMERCE-6166. As a buyer, I want to filter products using Specification Facet widget and the results should be visible on the Search Results widget"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceMiniCart.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceMiniCart.testcase
@@ -524,6 +524,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6331 RemoveSingleCartItemFromMiniCart pending implementation
+
 	}
 
 	@description = "COMMERCE-6348. As a buyer, I want the first selectable quantity of a cart item to be the minimum multiple quantity if Minimum Order Quantity is higher than Multiple Order Quantity"
@@ -659,6 +660,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6334 ViewMiniCartBundledProductDetails pending implementation
+
 	}
 
 	@description = "COMMERCE-6332. As a buyer, I want to view cart item details in the mini-cart(Name, SKU, Quantity, Options(if present), List Price, Image) and I want to be able to view the number of different products I have in my cart"
@@ -789,6 +791,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6339 ViewMiniCartItemWithDiscountLevels pending implementation
+
 	}
 
 	@description = "COMMERCE-6340. As a buyer, I want to be able to view subtotal and it's total price changed in the mini-cart summary when a discount with target 'Subtotal' is set"
@@ -798,6 +801,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6340 ViewMiniCartItemWithDiscountToSubtotal pending implementation
+
 	}
 
 	@description = "COMMERCE-6341. As a buyer, I want to be able to view order discount and it's total price changed in the mini-cart summary when a discount with target 'Total' is set"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommercePayments.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommercePayments.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6218 MoneyOrderCheckout Pending Implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceProductCard.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceProductCard.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5859 AssertDefaultChannelCurrencyIsAppliedToProductCard pending implementation
+
 	}
 
 	@description = "COMMERCE-6657. As a buyer, I want to be unable to add a bundled product(Price Type Dynamic) to cart directly"
@@ -293,6 +294,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6162 AssertOnlyMultipleValuesAreSelectableQuantities pending implementation
+
 	}
 
 	@description = "COMMERCE-6164. As a buyer I want to be able to add a product to the cart regardless of the availability, if back ordererabilty of that product is enabled"
@@ -436,6 +438,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5860 AssertProductCardCurrencyAfterChannelCurrencyChanged pending implementation
+
 	}
 
 	@description = "COMMERCE-5856. As a buyer, I want to view the product image container in the top area and I want to be able to click on the product image to navigate to the product detail page"
@@ -445,6 +448,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5856 AssertProductCardImageRedirectsToProductDetailsPage pending implementation
+
 	}
 
 	@description = "COMMERCE-5858. As a buyer, I want to view the catalog default product image if set"
@@ -454,6 +458,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5858 AssertProductCardShowsCatalogDefaultImage pending implementation
+
 	}
 
 	@description = "COMMERCE-5857. As a buyer, I want to view the product's own image if set"
@@ -495,6 +500,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5872 AssertProductIsAvailable pending implementation
+
 	}
 
 	@description = "COMMERCE-5871. As a buyer, I want to view the availability of the product, if set and configured admin-side(product unavailable)"
@@ -504,6 +510,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5871 AssertProductIsUnavailable pending implementation
+
 	}
 
 	@description = "COMMERCE-5861. As a buyer, I want to view the product name with the correct localization"
@@ -610,6 +617,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6161 AssertSelectableQuantitiesStartFromMinimumQuantitySet pending implementation
+
 	}
 
 	@description = "COMMERCE-6656. As a buyer, I want to be unable to add a bundled product(Price Type Static) to cart directly"
@@ -805,6 +813,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5868 CompareProductFromProductCard pending implementation
+
 	}
 
 	@description = "COMMERCE-5869. As a buyer, I want to be able to remove a product from a product comparison items list, by unchecking the product via checkbox"
@@ -844,6 +853,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5867 RemoveProductFromWishList pending implementation
+
 	}
 
 	@description = "COMMERCE-6193. As a buyer, I want the first selectable quantity of a product to be the minimum multiple quantity if Minimum Order Quantity is higher than Multiple Order Quantity"
@@ -853,6 +863,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6193 ViewFirstSelectableQuantityWhenMinimumOrderQuantityIsHigherThanMultipleOrderQuantity pending implementation
+
 	}
 
 	@description = "COMMERCE-6194. As a buyer, I want the first selectable quantity of a product to be the minimum multiple quantity if Minimum Order Quantity is lower than Multiple Order Quantity"
@@ -909,6 +920,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5864 ViewProductCardPrice pending implementation
+
 	}
 
 	@description = "COMMERCE-6158. As a buyer, I want to see the barred list price and a discount price of a product, if set"
@@ -983,6 +995,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5862 ViewProductCardSKU pending implementation
+
 	}
 
 	@description = "COMMERCE-5865. As a buyer, I want to view starting price on product card when product has different SKUs with different prices"
@@ -992,6 +1005,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-5865 ViewProductCardStartingPrice pending implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceProductDetails.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceProductDetails.testcase
@@ -190,6 +190,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6369 AssertProductCanBeAddedToCartFromProductDetailsIfBackOrderIsEnabled pending implementation
+
 	}
 
 	@description = "COMMERCE-6367. As a buyer, I don't want to be able to add a product to the cart in Product Details if the product is not purchasable"
@@ -358,6 +359,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6355 RemoveProductFromWishListFromProductDetails pending implementation
+
 	}
 
 	@description = "COMMERCE-6370. As a buyer, I want to be able to select an option value, and add the product to cart in Product Details"
@@ -367,6 +369,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6370 SelectOptionValueAndAddProductToCart pending implementation
+
 	}
 
 	@description = "COMMERCE-6658. As a buyer, I want to be able to select an option value(Bundled Product) and I want to see product details updating(Price, SKU and Availability)"
@@ -376,6 +379,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6658 SelectOptionValueAndAssertBundledProductDetailsAreUpdated pending implementation
+
 	}
 
 	@description = "COMMERCE-6371. As a buyer, I want to be able to select an option value(SKU contributor) and I want to see product details updating(Price, SKU and Availability)"
@@ -385,6 +389,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6371 SelectOptionValueAndAssertProductDetailsAreUpdated pending implementation
+
 	}
 
 	@description = "COMMERCE-6659. I want to be able to use ADT to render Product Details widget and I want to be able to select a Display Template and see it applied to the widget"
@@ -394,6 +399,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6659 UseADTInProductDetailsWidget pending implementation
+
 	}
 
 	@description = "COMMERCE-6660. I want to be able to set a custom renderer for product type different than the default one(Simple/Grouped/Virtual)"
@@ -403,6 +409,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6660 UseCustomRenderersInProductDetails pending implementation
+
 	}
 
 	@description = "COMMERCE-6364. As a buyer, I want the first selectable quantity of a product in Product Details to be the minimum multiple quantity if Minimum Order Quantity is higher than Multiple Order Quantity"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSearch.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSearch.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6323 GlobalSearchSearchEntryInAccounts pending implementation
+
 	}
 
 	@description = "COMMERCE-6326. As a buyer, I want to be able to search an entry in All Content using Global Search and the results should be visible on Search page"
@@ -124,6 +125,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6325 GlobalSearchSearchEntryInOrders pending implementation
+
 	}
 
 	@description = "COMMERCE-6329. As a buyer, I want to search for products in Catalog by typing different Categories in Global Search and I want to see the products with that categories in the suggestions(single category, multiple categories)"
@@ -271,6 +273,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6320 GlobalSearchSuggestedAccountsEntry pending implementation
+
 	}
 
 	@description = "COMMERCE-6319. As a buyer, I want to be able to search a Catalog entry using Global Search(Product Name, Product Name with single quotes, Product Name with double quotes) and I want to be able to click on a suggested entry and get redirected to that product Details page"
@@ -280,6 +283,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6319 GlobalSearchSuggestedCatalogEntries pending implementation
+
 	}
 
 	@description = "COMMERCE-6321. As a buyer, I want to be able to search an Orders entry using Global Search and I want to be able to click on a suggested entry and get redirected to that order details page"
@@ -379,6 +383,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6148 SearchBarWidgetSearchProductByName pending implementation
+
 	}
 
 	@description = "COMMERCE-6149.As a buyer, I want to search a product by its name using double quotes in the Search Bar widget and that product should be visible on the Search Results widget"
@@ -753,6 +758,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6663 UseADTInSearchResultsWidget pending implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSort.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSort.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6174 AssertProductsAreSortedByNameDescending pending implementation
+
 	}
 
 	@description = "COMMERCE-6176. As a buyer, I want to sort products by New Items using Sort widget and the results should be visible on the Search Results widget"
@@ -52,6 +53,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6176 AssertProductsAreSortedByNewItems pending implementation
+
 	}
 
 	@description = "COMMERCE-6171. As a buyer, I want to sort products by Price High to Low using Sort widget and the results should be visible on the Search Results widget"
@@ -61,6 +63,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6171 AssertProductsAreSortedByPriceHighToLow pending implementation
+
 	}
 
 	@description = "COMMERCE-6172. As a buyer, I want to sort products by Price Low to High using Sort widget and the results should be visible on the Search Results widget"
@@ -70,6 +73,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6172 AssertProductsAreSortedByPriceLowToHigh pending implementation
+
 	}
 
 	@description = "COMMERCE-6175. As a buyer, I want to sort products by Relevance using Sort widget and the results should be visible on the Search Results widget"
@@ -79,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6175 AssertProductsAreSortedByRelevance pending implementation
+
 	}
 
 }

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceTaxEngine.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceTaxEngine.testcase
@@ -223,6 +223,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6259 AddTaxRateToFixedTaxEngine Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6262. Test address restriction on tax calculation"
@@ -232,6 +233,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6262 AssertAddressRestrictiedTaxIsCorrectlyCalculated Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6260. Test tax calculation"
@@ -241,6 +243,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6260 AssertProductTaxCategoryIsCorrectlyCalculated Pending Implementation
+
 	}
 
 	@description = "This is a test for COMMERCE-6263. Configure tax properties at channel level"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/SFCommerceOrders.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/SFCommerceOrders.testcase
@@ -43,6 +43,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6380 DeleteOrderFromPendingOrderDetailsPage pending implementation
+
 	}
 
 	@description = "COMMERCE-6379. As a buyer, I want to be able to edit the order in Pending Order details page and I want to view the changes I made applied to order"
@@ -52,6 +53,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6379 EditOrderFromPendingOrderDetailsPage pending implementation
+
 	}
 
 	@description = "COMMERCE-6383. As a buyer, I want to be able to Reorder the Placed Order by clicking on 'Reorder' button"
@@ -61,6 +63,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6383 ReorderFromPlacedOrdersDetailsPage pending implementation
+
 	}
 
 	@description = "COMMERCE-6375. As a buyer, I want to be able to search for one pending order using the search bar"
@@ -70,6 +73,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6375 SearchOrderInPendingOrdersPage pending implementation
+
 	}
 
 	@description = "COMMERCE-6381. As a buyer, I want to be able to search for one placed order using the search bar"
@@ -79,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6381 SearchOrderInPlacedOrdersPage pending implementation
+
 	}
 
 	@description = "COMMERCE-6665. I want to be able to select a Display Template in Pending Orders widget and see it applied to the widget"
@@ -88,6 +93,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6665 UseADTInPendingOrdersWidget pending implementation
+
 	}
 
 	@description = "COMMERCE-6666. I want to be able to select a Display Template in Placed Orders widget and see it applied to the widget"
@@ -97,6 +103,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6666 UseADTInPlacedOrdersWidget pending implementation
+
 	}
 
 	@description = "COMMERCE-6382. As a buyer, I want to be able to see the list of shipments for an order item by clicking on 'Shipments'"
@@ -106,6 +113,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO COMMERCE-6382 ViewListOfShipmentsInPlacedOrdersDetailsPage pending implementation
+
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/documentsadministration/fields/DMSeparatorField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/documentsadministration/fields/DMSeparatorField.testcase
@@ -52,6 +52,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-98081 DeleteSeparatorOnBuilder pending implementation
+
 	}
 
 	@description = "This is a test for LPS-98081. As a Developer, I want to use separators"
@@ -61,6 +62,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-98081 DuplicateSeparatorOnBuilder pending implementation
+
 	}
 
 	@description = "This is a test for LPS-98081. As a Developer, I want to use separators"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-98081 EditHelpTextOfSeparator pending implementation
+
 	}
 
 	@description = "This is a test for LPS-98081. As a Developer, I want to use separators"
@@ -79,6 +82,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-98081 EditLabelOfSeparator pending implementation
+
 	}
 
 	@description = "This is a test for LPS-98081. As a Developer, I want to use separators"
@@ -156,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-98081 RepeatSeparatorOnUpload pending implementation
+
 	}
 
 	@description = "This is a test for LPS-98081. As a Developer, I want to use separators"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -79,7 +79,6 @@ import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 import java.io.Serializable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;

--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -22,3 +22,5 @@
 
     source.check.NewFileCheck.forbiddenDirNames=\
         modules/util/source-formatter/documentation/
+
+    source.check.PoshiEmptyLinesCheck.enabled=true

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PoshiEmptyLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PoshiEmptyLinesCheck.java
@@ -30,7 +30,7 @@ public class PoshiEmptyLinesCheck extends BaseFileCheck {
 		String fileName, String absolutePath, String content) {
 
 		content = content.replaceAll("(\\{\n)\n+(?!\t*/[/\\*])", "$1");
-		content = content.replaceAll("\n(\n\t+\\})", "$1");
+		content = content.replaceAll("(\n\t+[^/\\t])\n(\n\t+\\})", "$1$2");
 		content = content.replaceAll(
 			"(?<!\n)(\n\t(?!else|if)\\w+ \\{)", "\n$1");
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PoshiEmptyLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PoshiEmptyLinesCheck.java
@@ -30,7 +30,7 @@ public class PoshiEmptyLinesCheck extends BaseFileCheck {
 		String fileName, String absolutePath, String content) {
 
 		content = content.replaceAll("(\\{\n)\n+(?!\t*/[/\\*])", "$1");
-		content = content.replaceAll("(\n\t+[^/\\t])\n(\n\t+\\})", "$1$2");
+		content = content.replaceAll("(\n\t+[^/\\t].*)\n(\n\t+\\})", "$1$2");
 		content = content.replaceAll(
 			"(?<!\n)(\n\t(?!else|if)\\w+ \\{)", "\n$1");
 

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -1186,6 +1186,7 @@
 		<check name="PoshiEmptyLinesCheck">
 			<category name="Styling" />
 			<description name="Finds missing and unnecessary empty lines." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="PoshiIndentationCheck">
 			<category name="Styling" />

--- a/portal-impl/src/portal-liferay-online.properties
+++ b/portal-impl/src/portal-liferay-online.properties
@@ -3,7 +3,6 @@ session.timeout.auto.extend=true
 session.timeout.auto.extend.offset=300
 layout.user.private.layouts.enabled=false
 layout.user.public.layouts.enabled=false
-redirect.url.security.mode=domain
 field.editable.user.types=
 field.editable.domains[birthday]=*
 field.editable.domains[emailAddress]=

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/controlpanel/apps/appmanager/AppManagement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/controlpanel/apps/appmanager/AppManagement.testcase
@@ -98,6 +98,7 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test AppsCanBeActivatedAfterUninstalling {
+
 		// TODO LPS-102506 Unable to activate an app (lpkg) after uninstalling it via the app manager, waiting for fix
 
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
@@ -1092,6 +1092,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130330 AddNewExperienceSessionDeviceModelSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130331."
@@ -1101,6 +1102,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130331 AddNewExperienceSessionDeviceScreenResolutionHeightSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130332."
@@ -1110,6 +1112,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130332 AddNewExperienceSessionDeviceScreenResolutionWidthSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130333."
@@ -1430,6 +1433,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130337 AddNewExperienceSessionReferrerURLSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130338."
@@ -1439,6 +1443,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130338 AddNewExperienceSessionRequestParametersSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130339."
@@ -1590,6 +1595,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130341 AddNewExperienceSessionUserAgentSegment pending implementation
+
 	}
 
 	@description = "This is a test for LPS-130293."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -731,6 +731,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130996 CanBeCreatedWithMultiplePages pending implementation
+
 	}
 
 	@description = "Verify that a Form can be deleted"
@@ -2342,6 +2343,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131744 MultipleFormsCanBeDeleted pending implementation
+
 	}
 
 	@description = "This is a use case for LPS-59331"
@@ -2443,6 +2445,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130999 PagesCanBeReordered pending implementation
+
 	}
 
 	@description = "Verify that Form Pages can be reset"
@@ -2453,6 +2456,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131000 PagesCanBeReset pending implementation
+
 	}
 
 	@description = "This is a use case for LPS-61740"
@@ -5733,6 +5737,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-130510 WillAutosaveAfterOneMinute pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsEntries.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsEntries.testcase
@@ -50,6 +50,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131075 CanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a user can navigate to the correct metric by using the list on the right"
@@ -60,6 +61,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131084 CanBeNavigatedUsingNavigationList pending implementation
+
 	}
 
 	@description = "Verify that Entries can be viewed"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131074 CanBeViewed pending implementation
+
 	}
 
 	@description = "Verify that Entries Previews display the correct information"
@@ -80,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131077 DisplayCorrectInfoInPreviews pending implementation
+
 	}
 
 	@description = "Verify that the correct number of Entries are displayed"
@@ -90,6 +94,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131083 DisplayCorrectNumberOfEntries pending implementation
+
 	}
 
 	@description = "Verify that Entries for the Color, Date and Text Fields display a Field List in the Summary Tab"
@@ -100,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131078 DisplayFieldListInSummaryTab pending implementation
+
 	}
 
 	@description = "Verify that Entries for the Paragraph, Rich Text, Separator, Image, and Upload Fields do not display any metrics in the Summary Tab"
@@ -110,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131082 DisplayNoMetricsInSummaryTab pending implementation
+
 	}
 
 	@description = "Verify that Entries for the Numeric Field display a Field List, Average, Maximum Value, Minimum Value, and Sum in the Summary Tab"
@@ -120,6 +127,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131079 DisplayStatisticsInSummaryTab pending implementation
+
 	}
 
 	@description = "Verify that with Single Approver Workflow enabled and after the form entry was approved, the entry will have an approved label"
@@ -130,6 +138,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131203 WorkflowApprovalChangesLabelToApproved pending implementation
+
 	}
 
 	@description = "Verify that with Single Approver Workflow enabled, the Submit button now reads "Submit for Publication""
@@ -140,6 +149,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131085 WorkflowChangesSubmitButtonToSubmitForPublication pending implementation
+
 	}
 
 	@description = "Verify that with Single Approver Workflow enabled and after the user Submit for Publication, the form entry will have a pending label"
@@ -150,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131202 WorkflowSubmissionChangesLabelToPending pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsSubmissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsSubmissions.testcase
@@ -50,6 +50,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131018 CanBeSubmitted pending implementation
+
 	}
 
 	@description = "Verify that a Form can be submitted from the Forms Widget"
@@ -60,6 +61,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131019 CanBeSubmittedFromWidget pending implementation
+
 	}
 
 	@description = "Verify that a Form that is partially filled out can be submitted"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131020 CanBeSubmittedWhilePartiallyFilled pending implementation
+
 	}
 
 	@description = "Verify that a Form with multiple pages can be submitted"
@@ -80,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131151 CanBeSubmittedWithMultiplePages pending implementation
+
 	}
 
 	@description = "Verify that a Form can redirect a user after being submitted"
@@ -90,6 +94,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131026 CanRedirectUserAfterFormSubmission pending implementation
+
 	}
 
 	@description = "Verify that a Form can require user authentication before being accessed"
@@ -100,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131024 CanRequireUserAuthentication pending implementation
+
 	}
 
 	@description = "Verify that a Form's Success Page can be restored"
@@ -110,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131035 DefaultSuccessPageCanBeRestored pending implementation
+
 	}
 
 	@description = "Verify that the Submit button's default value is restored if the Submit Button Label is left blank"
@@ -120,6 +127,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131032 SubmitButtonRestoredToDefaultIfLeftBlank pending implementation
+
 	}
 
 	@description = "Verify that a Form's Submit button's text can be customized"
@@ -130,6 +138,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131028 SubmitButtonTextCanBeCustomized pending implementation
+
 	}
 
 	@description = "Verify that a Form's Submit button's text can be customized multiple times"
@@ -140,6 +149,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131031 SubmitButtonTextCanBeCustomizedMultipleTimes pending implementation
+
 	}
 
 	@description = "Verify that a Form's Submit button's text can be customized with numbers"
@@ -150,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131030 SubmitButtonTextCanBeCustomizedWithNumbers pending implementation
+
 	}
 
 	@description = "Verify that a Form's Submit button's text can be customized with special characters"
@@ -160,6 +171,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131029 SubmitButtonTextCanBeCustomizedWithSpecialCharacters pending implementation
+
 	}
 
 	@description = "Verify that a Form's Success Page can be deleted"
@@ -170,6 +182,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131034 SuccessPageCanBeDeleted pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsGridField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsGridField.testcase
@@ -50,6 +50,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132453 CanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that a Grid can be duplicated"
@@ -60,6 +61,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132455 CanBeDuplicated pending implementation
+
 	}
 
 	@description = "Verify that a Grid can be edited"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132452 CanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a Grid can be required"
@@ -80,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132454 CanBeRequired pending implementation
+
 	}
 
 	@description = "Verify that a Form can be submitted with the Grid Field"
@@ -90,6 +94,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132463 CanBeSubmitted pending implementation
+
 	}
 
 	@description = "Verify that edits to the Field can be canceled"
@@ -100,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132458 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that an option's Field References can be edited"
@@ -110,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132467 FieldReferencesOfOptionsCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a help text can be added"
@@ -120,6 +127,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132461 HelpTextCanBeAdded pending implementation
+
 	}
 
 	@description = "Veriy that the Field Label can be edited"
@@ -130,6 +138,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132456 LabelCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Label can be hidden"
@@ -140,6 +149,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132459 LabelCanBeHidden pending implementation
+
 	}
 
 	@description = "Verify that options can be added"
@@ -150,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132464 OptionsCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that option can be deleted"
@@ -160,6 +171,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132465 OptionsCanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that options can be rearranged"
@@ -170,6 +182,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132466 OptionsCanBeRearranged pending implementation
+
 	}
 
 	@description = "Verify that the Field Reference can be edited"
@@ -180,6 +193,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132462 ReferenceCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Type can be changed"
@@ -190,6 +204,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132457 TypeCanBeChanged pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
@@ -50,6 +50,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132262 CanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that a Multiple Selection Field can be duplicated"
@@ -60,6 +61,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132264 CanBeDuplicated pending implementation
+
 	}
 
 	@description = "Verify that a Multiple Selection Field can be edited"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132261 CanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a Multiple Selection Field can be required"
@@ -80,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132263 CanBeRequired pending implementation
+
 	}
 
 	@description = "Verify that a Multiple Selection Field can be set to repeatable"
@@ -90,6 +94,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132265 CanBeSetToRepeatable pending implementation
+
 	}
 
 	@description = "Verify that a Form can be submitted with the Multiple Selection Field"
@@ -100,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132271 CanBeSubmitted pending implementation
+
 	}
 
 	@description = "Verify that edits to the Field can be canceled"
@@ -110,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132268 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that an option's Field References can be edited"
@@ -120,6 +127,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132276 FieldReferencesOfOptionsCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a help text can be added"
@@ -130,6 +138,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132269 HelpTextCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that the Field Label can be edited"
@@ -140,6 +149,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132266 LabelCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that options can be added"
@@ -150,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132272 OptionsCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that option can be deleted"
@@ -160,6 +171,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132273 OptionsCanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that options can be displayed both inline and as a list"
@@ -170,6 +182,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132275 OptionsCanBeDisplayedInlineAndAsList pending implementation
+
 	}
 
 	@description = "Verify that options can be rearranged"
@@ -180,6 +193,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132274 OptionsCanBeRearranged pending implementation
+
 	}
 
 	@description = "Verify that an option can be selected as a Predefined Value"
@@ -190,6 +204,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132277 PredefinedValueCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that after deleting an option that had been selected as the Predefined Value, the Predefined Value is reset to "Choose Options""
@@ -200,6 +215,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132278 PredefinedValueIsResetWhenSelectedOptionIsDeleted pending implementation
+
 	}
 
 	@description = "Verify that the Field Reference can be edited"
@@ -210,6 +226,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132270 ReferenceCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Type can be changed"
@@ -220,6 +237,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132267 TypeCanBeChanged pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsParagraphField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsParagraphField.testcase
@@ -425,6 +425,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131241 CanSupportALinkToAnAnchor pending implementation
+
 	}
 
 	@description = "Verify that a link to an Email can be added to the Body Text"
@@ -434,6 +435,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131242 CanSupportALinkToAnEmail pending implementation
+
 	}
 
 	@description = "Verify that a link to a Phone Number can be added to the Body Text"
@@ -443,6 +445,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131243 CanSupportALinkToAPhoneNumber pending implementation
+
 	}
 
 	@description = "Verify that a link to a URL can be added to the Body Text"
@@ -550,6 +553,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131247 CanSupportHTML pending implementation
+
 	}
 
 	@description = "Verify that an Image can be uploaded to the Body Text"
@@ -559,6 +563,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131233 CanSupportImages pending implementation
+
 	}
 
 	@description = "Verify that Numbered Lists can be added to the Body Text"
@@ -568,6 +573,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131238 CanSupportNumberedLists pending implementation
+
 	}
 
 	@description = "Verify that a Table can be created in the Body Text"
@@ -714,6 +720,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131244 CanUnlinkALink pending implementation
+
 	}
 
 	@description = "Verify that changes to a Field can be canceled"
@@ -723,6 +730,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131225 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that the Field Reference can be Edited"
@@ -867,6 +875,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131232 TypeCanBeChanged pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
@@ -50,6 +50,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131359 CanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that a Select From List Field can be duplicated"
@@ -60,6 +61,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131361 CanBeDuplicated pending implementation
+
 	}
 
 	@description = "Verify that a Select From List Field can be edited"
@@ -70,6 +72,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131358 CanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a Select From List Field can be required"
@@ -80,6 +83,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131360 CanBeRequired pending implementation
+
 	}
 
 	@description = "Verify that a Select From List Field can be set to repeatable"
@@ -90,6 +94,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131362 CanBeSetAsRepeatable pending implementation
+
 	}
 
 	@description = "Verify that a Form can be submitted with the Select From List Field"
@@ -100,6 +105,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131369 CanBeSubmitted pending implementation
+
 	}
 
 	@description = "Verify that a list can be created using Autofill"
@@ -110,6 +116,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131376 CanCreateListUsingAutofill pending implementation
+
 	}
 
 	@description = "Verify that changes to a Field can be canceled"
@@ -120,6 +127,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131364 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that the Field References for the options can be edited"
@@ -130,6 +138,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131375 FieldReferenceOfOptionsCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that a Help Text can be added"
@@ -140,6 +149,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131367 HelpTextCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that the Field Label can be edited"
@@ -150,6 +160,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131365 LabelCanBeEdited pending implementation
+
 	}
 
 	@description = "Veriy that the Field Label can be hidden"
@@ -160,6 +171,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131366 LabelCanBeHidden pending implementation
+
 	}
 
 	@description = "Verify that options can be added"
@@ -170,6 +182,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131373 OptionsCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that options can be rearranged"
@@ -180,6 +193,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131374 OptionsCanBeRearranged pending implementation
+
 	}
 
 	@description = "Verify that options can be sorted alphabetically"
@@ -190,6 +204,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131372 OptionsCanBeSortedAlphabetically pending implementation
+
 	}
 
 	@description = "Verify that an option can be selected as a Predefined Value"
@@ -200,6 +215,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131370 PredefinedValueCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that after deleting an option that had been selected as the Predefined Value, the Predefined Value is reset to "Choose Options""
@@ -210,6 +226,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131371 PredefinedValueIsResetWhenSelectedOptionIsDeleted pending implementation
+
 	}
 
 	@description = "Verify that the Field Reference can be Edited"
@@ -220,6 +237,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131368 ReferenceCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Type can be changed"
@@ -230,6 +248,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131363 TypeCanBeChanged pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSingleSelectionField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSingleSelectionField.testcase
@@ -342,6 +342,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132196 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that the Field References for the options can be edited"
@@ -568,6 +569,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132206 OptionsCanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that options can be displayed both Inline and as a list"
@@ -578,6 +580,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132204 OptionsCanBeDisplayedInlineAndAsList pending implementation
+
 	}
 
 	@description = "Verify that options can be rearranged"
@@ -724,6 +727,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132200 ReferenceCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Type can be changed"
@@ -734,6 +738,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-132195 TypeCanBeChanged pending implementation
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
@@ -77,6 +77,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131332 CanBeDeleted pending implementation
+
 	}
 
 	@description = "Verify that a Text Field can be duplicated"
@@ -87,6 +88,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131333 CanBeDuplicated pending implementation
+
 	}
 
 	@description = "Verify that the "Contains" option can be used to validate a Text Field"
@@ -97,6 +99,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131344 CanBeValidatedUsingTheContainsOption pending implementation
+
 	}
 
 	@description = "Verify that the "Does Not Match" option can be used to validate a Text Field"
@@ -107,6 +110,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131348 CanBeValidatedUsingTheDoesNotMatchOption pending implementation
+
 	}
 
 	@description = "Verify that the "Is Not Email" option can be used to validate a Text Field"
@@ -117,6 +121,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131347 CanBeValidatedUsingTheIsNotEmailOption pending implementation
+
 	}
 
 	@description = "Verify that the "Is Not URL" option can be used to validate a Text Field"
@@ -127,6 +132,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131346 CanBeValidatedUsingTheIsNotURLOption pending implementation
+
 	}
 
 	@description = "Verify that changes to a Field can be canceled"
@@ -137,6 +143,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131335 ChangesCanBeCanceled pending implementation
+
 	}
 
 	@description = "Verify that a Help Text can be added to a Text Field"
@@ -147,6 +154,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131338 HelpTextCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that the Field Label can be edited"
@@ -157,6 +165,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131336 LabelCanBeEdited pending implementation
+
 	}
 
 	@description = "Veriy that the Field Label can be hidden"
@@ -167,6 +176,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131337 LabelCanBeHidden pending implementation
+
 	}
 
 	@description = "Verify that Placeholder Text can be set"
@@ -177,6 +187,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131342 PlaceholderTextCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that a Predefined Value can be set"
@@ -187,6 +198,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131341 PredefinedValueCanBeAdded pending implementation
+
 	}
 
 	@description = "Verify that the Field Reference can be Edited"
@@ -197,6 +209,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131339 ReferenceCanBeEdited pending implementation
+
 	}
 
 	@description = "Verify that the Field Type can be changed"
@@ -207,6 +220,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131334 TypeCanBeChanged pending implementation
+
 	}
 
 	@description = "Verify that Validation options are reset after changing the Field Type from Text Field to Numeric Field"
@@ -217,6 +231,7 @@ definition {
 		property portal.acceptance = "false";
 
 		// TODO LPS-131352 ValidationIsResetAfterChangingFieldType pending implementation
+
 	}
 
 }

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -505,6 +505,8 @@
 
     source.check.JSPMethodCallsCheck.enabled=true
 
+    source.check.PoshiEmptyLinesCheck.enabled=true
+
     source.check.PropertiesBuildIncludeDirsCheck.buildIncludeCategoryNames=\
         apps,\
         core,\


### PR DESCRIPTION
Hi Hugo,

Issue: https://liferay.slack.com/archives/C1SJ64S9X/p1621876408010700?thread_ts=1621547483.007600&cid=C1SJ64S9X

I fixed logic to remove the empty line before "}", but keep it when the previous line is a comment line.
we also did the same rule for java, I mean skip empty line before and after the comment line.